### PR TITLE
Portable campaign orchestration framework (core + local/slurm/hotaisle backends)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,15 @@
 /docs/build/
 # Local run outputs (GPU dry runs, campaign data) — never committed.
 /runs/
-# Local ops orchestration
+# Orchestration framework is COMMITTED (portable across machines); only the machine-specific
+# infra config is ignored. Secrets never live here — they stay in ~/.config (referenced by path).
+/orchestration/config.env
+/orchestration/**/config.env
+# Legacy campaign kits (infra-laden: hostnames, branch-pin git-guards, machine paths, run notes) —
+# local only, superseded by orchestration/{run_cell.sh,backends/,campaigns/}; recipes migrated to campaigns/.
+/orchestration/smalla0_floor/
+/orchestration/floor_probe/
+# Legacy infra-specific ops scripts (superseded by orchestration/backends/*; kept local until migrated)
 /scripts/hotaisle_campaign.sh
 /scripts/balance_monitor.sh
 /scripts/*.sbatch

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# HOTAISLE backend — run a campaign on a Hot Aisle cloud MI300X.
+# Cloud lifecycle only: provision → warm (clone repo + instantiate + write a VM-local config.env) →
+# run the campaign ON THE VM via the shared local backend (rocm) → download reduced products → KEEP
+# the VM warm. Then `teardown` (cost-safe). Cell execution, tagging, logging, cube policy all come
+# from the SAME run_cell.sh the VM clones — so this file holds only the cloud wrapper, no run logic.
+#
+#   bash orchestration/backends/hotaisle.sh run orchestration/campaigns/<campaign>.sh
+#   bash orchestration/backends/hotaisle.sh teardown
+#
+# config.env: HOTAISLE_TEAM, HOTAISLE_GPUS, HOTAISLE_REPO_URL, HOTAISLE_BRANCH (, HOTAISLE_API).
+# Secrets stay external: API token at ~/.config/hotaisle/token; ntfy creds (driving-side) via NTFY_ENV.
+# BILLING: 1 GPU = per-minute (1-min minimum); 2/4 carry 60/120-min minimums. Teardown waits out the
+# minimum, then a non-force DELETE — ALWAYS verify the VM is gone in the TUI (ssh admin.hotaisle.app);
+# the API DELETE is best-effort and billing only truly stops on TUI destroy.
+set -Eeuo pipefail
+ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."; ORCH="$(cd "$ORCH" && pwd)"
+. "$ORCH/run_cell.sh"        # config.env + notify() (notifications fire from THIS driving machine)
+
+MODE="${1:?usage: hotaisle.sh run <campaign.sh> | teardown}"
+TOK=$(cat "${HOTAISLE_TOKEN_FILE:-$HOME/.config/hotaisle/token}")
+TEAM="${HOTAISLE_TEAM:?set HOTAISLE_TEAM in config.env}"
+API="${HOTAISLE_API:-https://admin.hotaisle.app/api/teams}/$TEAM"
+GPUS="${HOTAISLE_GPUS:-1}"
+REPO_URL="${HOTAISLE_REPO_URL:?set HOTAISLE_REPO_URL in config.env}"
+BRANCH="${HOTAISLE_BRANCH:-main}"
+STATE="${HOTAISLE_STATE:-$HOME/.config/hotaisle/campaign_vm}"
+OUT="${HOTAISLE_OUT:-$HOME/campaign_out}"
+CM="$HOME/.ssh/cm-hotaisle.sock"
+SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600"
+
+api()       { curl -fsS -X "$1" -H "Authorization: Token $TOK" "${@:3}" "$API$2"; }
+ssh_vm()    { /usr/bin/ssh $SSHOPTS hotaisle@"$IP" "$@"; }
+log()       { echo "[$(date -u +%FT%TZ)] $*"; }
+balance()   { api GET /balance/ | jq -r '.available_balance/100'; }
+min_resv()  { api GET /virtual_machines/available/ | jq -r --argjson g "$GPUS" \
+              '[.[]|select(.Specs.gpus[0].model=="MI300X" and .Specs.gpus[0].count==$g)|.MinimumReservationMinutes][0]//1'; }
+
+provision() {
+    log "provisioning ${GPUS}×MI300X (balance \$$(balance))…"
+    local vm; vm=$(api POST /virtual_machines/ -H "Content-Type: application/json" \
+        --data-binary "{\"gpus\":[{\"model\":\"MI300X\",\"count\":$GPUS}]}")
+    NAME=$(echo "$vm"|jq -r .name); IP=$(echo "$vm"|jq -r .ssh_access.ip_address); PROV_TS=$(date +%s)
+    log "provisioned $NAME ($IP)"
+}
+wait_ssh() { log "waiting for ssh…"; local i; for i in $(seq 1 40); do ssh_vm true 2>/dev/null && return 0; sleep 15; done; return 1; }
+warm() {
+    log "warm: julia + clone $BRANCH + instantiate (registry from GitHub)"
+    ssh_vm "REPO_URL='$REPO_URL' BRANCH='$BRANCH' bash -s" <<'WARM'
+set -e
+[ -x "$HOME/.juliaup/bin/julia" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes
+export PATH="$HOME/.juliaup/bin:$PATH" JULIA_PKG_SERVER=""
+rm -rf EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" EDM
+# VM-local config.env (gitignored ⇒ not cloned): rocm local backend, no ntfy on the VM.
+printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\n' > EDM/orchestration/config.env
+ok=0; for i in 1 2 3; do
+  if julia --startup=no --project=EDM/scripts -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'; then ok=1; break; fi
+  echo "instantiate retry $i"; sleep 20
+done; [ "$ok" = 1 ] || { echo "instantiate failed"; exit 1; }
+WARM
+}
+
+run_campaign() {
+    local cf="${1:?usage: hotaisle.sh run <campaign.sh>}" cname; cname=$(basename "$cf")
+    . "$cf"   # CAMPAIGN (for product paths); the same file is read again on the VM
+    trap 'rc=$?; log "FAILED (rc=$rc) before VM was handed off"; notify rotating_light urgent "EDM hotaisle FAILED" "$CAMPAIGN setup errored (rc=$rc); tearing down"; teardown; exit $rc' ERR
+    provision; wait_ssh; warm
+    echo "$NAME $IP $PROV_TS $(min_resv)" > "$STATE"
+    trap - ERR    # VM is up + warm; a campaign/download hiccup below must NOT auto-destroy it
+    notify hourglass_flowing_sand default "EDM hotaisle started" "$CAMPAIGN on $NAME (${GPUS}×MI300X)"
+    log "launching $CAMPAIGN on the VM via the local backend (rocm), detached…"
+    ssh_vm "cd EDM && setsid nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo launched"
+    log "polling for completion…"
+    until ssh_vm "grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null"; do
+        sleep 60; ssh_vm "tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[vm] /'
+    done
+    log "campaign done; downloading reduced products (cubes excluded)…"
+    mkdir -p "$OUT/$CAMPAIGN"
+    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS" --exclude='field_*.jls' \
+        hotaisle@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
+    notify white_check_mark default "EDM hotaisle done" "$CAMPAIGN → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM — run teardown."
+    log "products → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM (state $STATE). Finish: $0 teardown"
+}
+
+teardown() {
+    [ -f "$STATE" ] || { echo "no kept VM recorded in $STATE"; exit 0; }
+    read -r NAME IP PROV_TS MIN_MIN < "$STATE"
+    local min_s=$(( ${MIN_MIN:-1} * 60 )) el=$(( $(date +%s) - ${PROV_TS:-$(date +%s)} ))
+    if [ "$el" -lt "$min_s" ]; then
+        log "waiting $(( (min_s - el + 59) / 60 )) min to reach the ${MIN_MIN}-min reservation minimum (billed either way; Ctrl-C to delete now)"
+        sleep $(( min_s - el ))
+    fi
+    /usr/bin/ssh -O exit -o ControlPath="$CM" hotaisle@"$IP" 2>/dev/null || true
+    if api DELETE "/virtual_machines/$NAME/" >/dev/null 2>&1; then
+        rm -f "$STATE"
+        log "API delete of $NAME accepted; balance \$$(balance). VERIFY it's gone in the TUI (ssh admin.hotaisle.app) — billing stops on TUI destroy."
+        notify checkered_flag default "EDM hotaisle torn down" "$NAME deleted; balance \$$(balance). Verify in TUI."
+    else
+        notify rotating_light urgent "EDM teardown FAILED" "API DELETE of $NAME errored — VM likely STILL UP + billing. Destroy it in the TUI now (ssh admin.hotaisle.app)."
+        log "[ERROR] API DELETE of $NAME FAILED — VM likely STILL UP + billing. DESTROY IN THE TUI. state kept at $STATE."
+        exit 1
+    fi
+}
+
+case "$MODE" in
+    run)      shift; run_campaign "${1:-}" ;;
+    teardown) teardown ;;
+    *) echo "usage: $0 run <campaign.sh> | teardown" >&2; exit 64 ;;
+esac

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -8,6 +8,12 @@
 #   bash orchestration/backends/hotaisle.sh run orchestration/campaigns/<campaign>.sh
 #   bash orchestration/backends/hotaisle.sh teardown
 #
+# `run` REUSES a kept-warm, reachable VM if one is recorded (else provisions + warms a new one), so
+# the proven smoke→real flow shares ONE paid VM:
+#   hotaisle.sh run campaigns/smoke.sh   # provision+warm+smoke, KEEP warm — eyeball products
+#   hotaisle.sh run campaigns/lowa0_maps.sh   # reuses the SAME warm VM (no re-provision/warm)
+#   hotaisle.sh teardown                 # cost-safe delete (waits the reservation minimum)
+#
 # config.env: HOTAISLE_TEAM, HOTAISLE_GPUS, HOTAISLE_REPO_URL, HOTAISLE_BRANCH (, HOTAISLE_API).
 # Secrets stay external: API token at ~/.config/hotaisle/token; ntfy creds (driving-side) via NTFY_ENV.
 # BILLING: 1 GPU = per-minute (1-min minimum); 2/4 carry 60/120-min minimums. Teardown waits out the
@@ -51,8 +57,9 @@ set -e
 [ -x "$HOME/.juliaup/bin/julia" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes
 export PATH="$HOME/.juliaup/bin:$PATH" JULIA_PKG_SERVER=""
 rm -rf EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" EDM
-# VM-local config.env (gitignored ⇒ not cloned): rocm local backend, no ntfy on the VM.
-printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\n' > EDM/orchestration/config.env
+# VM-local config.env (gitignored ⇒ not cloned): rocm local backend, no ntfy on the VM, and
+# REDUCE_OVERLAP=1 so each cell's reduction overlaps the next cell's GPU compute (paid-time win).
+printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\nREDUCE_OVERLAP=1\n' > EDM/orchestration/config.env
 ok=0; for i in 1 2 3; do
   if julia --startup=no --project=EDM/scripts -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'; then ok=1; break; fi
   echo "instantiate retry $i"; sleep 20
@@ -60,26 +67,64 @@ done; [ "$ok" = 1 ] || { echo "instantiate failed"; exit 1; }
 WARM
 }
 
+# Is there a kept-warm VM we can reuse? (lets smoke→real, or several campaigns, share ONE paid VM
+# instead of re-provisioning + re-warming — ~8 min of paid clone/instantiate — every time.)
+vm_reachable() { [ -f "$STATE" ] && read -r NAME IP PROV_TS MIN_MIN < "$STATE" && [ -n "${IP:-}" ] && ssh_vm true 2>/dev/null; }
+
+# Overlay the driver's current orchestration/ onto the VM clone (keeping the VM's own config.env),
+# so the VM runs THIS machine's framework + campaign files — even ones not yet pushed to BRANCH.
+push_orchestration() {
+    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS" --exclude='config.env' "$ORCH/" hotaisle@"$IP":EDM/orchestration/
+}
+
+# Integrity-check the downloaded reduced products: md5 each non-cube file VM-vs-local; alert on any
+# mismatch/missing. Cheap insurance against a truncated rsync silently corrupting the physics.
+download_verify() {
+    local dst=$1 bad=0 vsum fn lsum
+    while read -r vsum fn; do
+        [ -n "$vsum" ] || continue
+        fn=$(basename "$fn")
+        if [ ! -f "$dst/$fn" ]; then log "[verify] MISSING locally: $fn"; bad=1; continue; fi
+        lsum=$(md5sum "$dst/$fn" | awk '{print $1}')
+        [ "$lsum" = "$vsum" ] || { log "[verify] MD5 MISMATCH: $fn (vm=$vsum local=$lsum)"; bad=1; }
+    done < <(ssh_vm "cd EDM/runs/$CAMPAIGN && md5sum * 2>/dev/null | grep -vE 'field_.*\\.jls'")
+    [ "$bad" -eq 0 ] && { log "[verify] $CAMPAIGN OK (md5 match; cubes excluded)"; return 0; }
+    notify rotating_light high "EDM download CHECK FAILED" "$CAMPAIGN: md5 mismatch/missing on download to $dst"
+    return 1
+}
+
 run_campaign() {
     local cf="${1:?usage: hotaisle.sh run <campaign.sh>}" cname; cname=$(basename "$cf")
-    . "$cf"   # CAMPAIGN (for product paths); the same file is read again on the VM
-    trap 'rc=$?; log "FAILED (rc=$rc) before VM was handed off"; notify rotating_light urgent "EDM hotaisle FAILED" "$CAMPAIGN setup errored (rc=$rc); tearing down"; teardown; exit $rc' ERR
-    provision; wait_ssh; warm
-    echo "$NAME $IP $PROV_TS $(min_resv)" > "$STATE"
-    trap - ERR    # VM is up + warm; a campaign/download hiccup below must NOT auto-destroy it
+    . "$cf"   # CAMPAIGN (for product paths); the same file is re-read on the VM
+    if vm_reachable; then
+        log "reusing kept-warm VM $NAME ($IP) from $STATE (no provision/warm)"
+    else
+        trap 'rc=$?; log "FAILED (rc=$rc) before VM was handed off"; notify rotating_light urgent "EDM hotaisle FAILED" "$CAMPAIGN setup errored (rc=$rc); tearing down"; teardown; exit $rc' ERR
+        provision; wait_ssh; warm
+        echo "$NAME $IP $PROV_TS $(min_resv)" > "$STATE"
+        trap - ERR    # VM is up + warm; a campaign/download hiccup below must NOT auto-destroy it
+    fi
+    push_orchestration   # VM runs the driver's framework + this campaign file (works pre-merge too)
     notify hourglass_flowing_sand default "EDM hotaisle started" "$CAMPAIGN on $NAME (${GPUS}×MI300X)"
     log "launching $CAMPAIGN on the VM via the local backend (rocm), detached…"
-    ssh_vm "cd EDM && setsid nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo launched"
-    log "polling for completion…"
+    # nohup + a pidfile (not setsid): keeps the driver's PID so we can tell "still running" from "crashed".
+    ssh_vm "cd EDM && mkdir -p runs && nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid"
+    log "polling for completion (DONE marker, or driver-death = crash so we don't poll forever while billing)…"
     until ssh_vm "grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null"; do
+        if ! ssh_vm "kill -0 \$(cat runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
+            notify rotating_light urgent "EDM hotaisle CRASH" "$CAMPAIGN driver died with no DONE on $NAME — VM KEPT for inspection; teardown when done (verify in TUI)."
+            log "[ERROR] driver process gone, no DONE marker — likely crashed. VM $NAME KEPT. tail:"; ssh_vm "tail -n 20 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[vm] /'
+            return 1
+        fi
         sleep 60; ssh_vm "tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[vm] /'
     done
     log "campaign done; downloading reduced products (cubes excluded)…"
     mkdir -p "$OUT/$CAMPAIGN"
     /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS" --exclude='field_*.jls' \
         hotaisle@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
+    download_verify "$OUT/$CAMPAIGN" || log "[verify] integrity problems — products also remain on VM:EDM/runs/$CAMPAIGN"
     notify white_check_mark default "EDM hotaisle done" "$CAMPAIGN → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM — run teardown."
-    log "products → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM (state $STATE). Finish: $0 teardown"
+    log "products → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM (state $STATE). Add more: $0 run <campaign>. Finish: $0 teardown"
 }
 
 teardown() {

--- a/orchestration/backends/local.sh
+++ b/orchestration/backends/local.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# LOCAL backend — run a campaign's cells on THIS machine's GPU.
+#   bash orchestration/backends/local.sh orchestration/campaigns/<campaign>.sh
+# Detached (survives logout):
+#   setsid nohup bash orchestration/backends/local.sh orchestration/campaigns/<c>.sh \
+#       > /tmp/<c>.out 2>&1 < /dev/null & echo "pid $!"
+# Reads orchestration/config.env: LOCAL_BACKEND, LOCAL_PREENV, LOCAL_JL_THREADS, JULIA_CHANNEL, EDM_REPO.
+set -uo pipefail
+ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ORCH/run_cell.sh"                                   # sources config.env + defines run_cell/run_cells
+CAMPAIGN_FILE="${1:?usage: local.sh <campaign.sh>}"
+. "$CAMPAIGN_FILE"                                      # sets CAMPAIGN, SCRIPT, BASE, CELLS
+
+BACKEND="${LOCAL_BACKEND:-cuda}"
+JL=(julia +"${JULIA_CHANNEL:-release}" --startup=no -t "${LOCAL_JL_THREADS:-auto}")
+PREENV=(); [ -n "${LOCAL_PREENV:-}" ] && read -r -a PREENV <<< "$LOCAL_PREENV"
+CAMP="$REPO/runs/$CAMPAIGN"
+mkdir -p "$CAMP"
+echo "[local] campaign=$CAMPAIGN backend=$BACKEND cells=${#CELLS[@]} threads=${LOCAL_JL_THREADS:-auto} -> $CAMP"
+run_cells
+echo "[local] $CAMPAIGN DONE ($(date -u +%FT%TZ))"

--- a/orchestration/backends/slurm.sbatch
+++ b/orchestration/backends/slurm.sbatch
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=edm-campaign
+#SBATCH --output=%x-%A_%a.out
+#SBATCH --error=%x-%A_%a.err
+# Node-side: run ONE campaign cell — the array task's index into CELLS — via the shared core.
+# All #SBATCH resource directives (partition/gres/cpus/mem/time/array) are supplied by
+# slurm_submit.sh from config.env (CLI flags override the placeholders above). The repo (with
+# orchestration/ + a machine-local config.env) must be present on the cluster.
+set -uo pipefail
+ORCH="$(cd "$(dirname "$(realpath "$0")")/.." && pwd)"
+. "$ORCH/run_cell.sh"                        # sources config.env + defines run_cell/notify
+: "${CAMPAIGN_FILE:?CAMPAIGN_FILE must be exported by slurm_submit.sh}"
+. "$CAMPAIGN_FILE"                            # sets CAMPAIGN, SCRIPT, BASE, CELLS
+
+BACKEND="${SLURM_BACKEND:-cuda}"             # cluster GPUs are NVIDIA
+JL=(julia +"${JULIA_CHANNEL:-release}" --startup=no -t "${SLURM_CPUS_PER_TASK:-auto}")
+CAMP="${SLURM_OUTROOT:-$REPO/runs}/${CAMPAIGN}_${SLURM_ARRAY_JOB_ID:-$SLURM_JOB_ID}"
+mkdir -p "$CAMP"
+NTFY_DISABLE=1   # compute nodes have no outbound internet — completion ntfy comes from the external
+                 # squeue poller (e.g. ~/.local/bin/edm-campaign-notify on a box with egress), not from here
+
+idx="${SLURM_ARRAY_TASK_ID:?not an array job — submit via slurm_submit.sh}"
+entry="${CELLS[$idx]}"; label=${entry%%|*}; overrides=${entry#*|}
+[ "$overrides" = "$entry" ] && overrides=""
+echo "[slurm] task $idx/$((${#CELLS[@]} - 1)): $CAMPAIGN/$label on $(hostname) cuda=${CUDA_VISIBLE_DEVICES:-?} -> $CAMP"
+# shellcheck disable=SC2086
+run_cell "$label" $overrides

--- a/orchestration/backends/slurm_submit.sh
+++ b/orchestration/backends/slurm_submit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SLURM backend (submit side) — run a campaign as a job array on the cluster.
+#   bash orchestration/backends/slurm_submit.sh orchestration/campaigns/<campaign>.sh
+# Sizes the array from the campaign's CELLS and pulls all SLURM directives from config.env
+# (SLURM_PARTITION/GRES/CPUS/MEM/TIME/CONCURRENCY/OUTROOT). The node-side work is slurm.sbatch.
+set -uo pipefail
+ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ORCH/run_cell.sh"                       # sources config.env (SLURM_* + EDM_REPO)
+CAMPAIGN_FILE="${1:?usage: slurm_submit.sh <campaign.sh>}"
+. "$CAMPAIGN_FILE"                           # sets CAMPAIGN, CELLS, ...
+n=${#CELLS[@]}; last=$((n - 1))
+echo "[slurm] submit $CAMPAIGN: $n cells, array 0-${last}%${SLURM_CONCURRENCY:-2}, partition=${SLURM_PARTITION:-?} gres=${SLURM_GRES:-?}"
+jobid=$(sbatch --parsable \
+  --job-name="edm-$CAMPAIGN" \
+  --partition="${SLURM_PARTITION:?set SLURM_PARTITION in config.env}" \
+  --gres="${SLURM_GRES:-gpu:1}" \
+  --cpus-per-task="${SLURM_CPUS:-32}" \
+  --mem="${SLURM_MEM:-192G}" \
+  --time="${SLURM_TIME:-12:00:00}" \
+  --array="0-${last}%${SLURM_CONCURRENCY:-2}" \
+  --output="%x-%A_%a.out" --error="%x-%A_%a.err" \
+  --export="ALL,CAMPAIGN_FILE=$(realpath "$CAMPAIGN_FILE")" \
+  "$ORCH/backends/slurm.sbatch")
+echo "[slurm] submitted $CAMPAIGN as job $jobid ($n tasks)"
+# Login-side ping (works only where the login node has egress; harmless no-op/warn otherwise).
+# COMPLETION notifications come from the external squeue poller, not the cluster.
+notify hourglass_flowing_sand default "EDM SLURM submitted" "$CAMPAIGN: $n cells, job $jobid on $(hostname). Completion via the squeue poller."

--- a/orchestration/campaigns/lowa0_maps.sh
+++ b/orchestration/campaigns/lowa0_maps.sh
@@ -1,0 +1,21 @@
+# campaigns/lowa0_maps.sh — low-a0 radiated-field harmonic maps.
+# PURE DATA: no infra, no backend, no run-tags (the core mints UUIDs). Runs on any backend:
+#   bash orchestration/backends/local.sh   orchestration/campaigns/lowa0_maps.sh
+#   bash orchestration/backends/hotaisle.sh orchestration/campaigns/lowa0_maps.sh
+#   sbatch orchestration/backends/slurm.sbatch orchestration/campaigns/lowa0_maps.sh
+#
+# Uses uniform EDM_INTERP_SAVEAT=16 — the floor fix: adaptive Vern9 output injects a spurious 2ω
+# in the radiation field; uniform output recovers the physical ∝a0 2ω (see the floor investigation).
+CAMPAIGN=lowa0_maps
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=400 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=10000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
+  EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+)
+CELLS=(
+  "a1em5|EDM_A0=1e-5"
+  "a1em6|EDM_A0=1e-6"
+  "a1em7|EDM_A0=1e-7"
+)

--- a/orchestration/campaigns/smalla0_floor.sh
+++ b/orchestration/campaigns/smalla0_floor.sh
@@ -1,0 +1,21 @@
+# campaigns/smalla0_floor.sh — small-a0 2ω floor investigation (OAT / star design).
+# PURE DATA. One baseline + independent 1-D arms (a0, interp_saveat, N, reltol, n_substeps). The
+# dashboard renders this as a hub-and-arms star (see the OAT family/hub support in the builder).
+# Run on any backend, e.g.:  bash orchestration/backends/local.sh orchestration/campaigns/smalla0_floor.sh
+# (cuda vs rocm is a BACKEND choice — the old "baseWS" rocm cross-check is just this baseline on rocm.)
+CAMPAIGN=smalla0_floor
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=200 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_A0=1e-5 EDM_N=400 EDM_RELTOL=1e-12 EDM_NSUBSTEPS=1
+  EDM_INITIAL_PHASE=-1.5707963267948966
+)
+CELLS=(
+  "base|"                              # the hub
+  "a1e4|EDM_A0=1e-4"  "a1e3|EDM_A0=1e-3"  "a1e2|EDM_A0=1e-2"  "a1e1|EDM_A0=0.1"      # a0 arm
+  "sa16|EDM_INTERP_SAVEAT=16" "sa32|EDM_INTERP_SAVEAT=32"                            # saveat arm (the key test)
+  "sa64|EDM_INTERP_SAVEAT=64" "sa128|EDM_INTERP_SAVEAT=128"
+  "N1600|EDM_N=1600" "N3200|EDM_N=3200" "N6400|EDM_N=6400" "N12800|EDM_N=12800"      # N arm (shot-noise)
+  "rt14|EDM_RELTOL=1e-14"                                                            # solve-accuracy recheck
+  "ns8|EDM_NSUBSTEPS=8"                                                              # march recheck
+)

--- a/orchestration/campaigns/smoke.sh
+++ b/orchestration/campaigns/smoke.sh
@@ -1,0 +1,17 @@
+# campaigns/smoke.sh — tiny end-to-end validation cell, runnable on ANY backend.
+# PURE DATA. Proves the whole toolchain (ODE solve → field accumulation → reduction →
+# products) on a trivially small grid before committing to a costly campaign. Use it as the
+# first thing on a fresh machine / a freshly-provisioned cloud VM:
+#   bash   orchestration/backends/local.sh    orchestration/campaigns/smoke.sh
+#   sbatch orchestration/backends/slurm.sbatch orchestration/campaigns/smoke.sh
+#   bash   orchestration/backends/hotaisle.sh run orchestration/campaigns/smoke.sh
+# A clean exit + a run_<uuid>.toml with its PNG/derived sidecars beside it == the box is good.
+CAMPAIGN=smoke
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=48 EDM_N=64 EDM_NSAMPLES=512 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_A0=0.1 EDM_NSUBSTEPS=1 EDM_INITIAL_PHASE=-1.5707963267948966
+)
+CELLS=(
+  "smoke|"
+)

--- a/orchestration/config.env.example
+++ b/orchestration/config.env.example
@@ -7,7 +7,7 @@
 # partition, host handles) — the stuff that differs per machine and that we keep out of git.
 
 # ── repo + julia ─────────────────────────────────────────────────────────────
-EDM_REPO="${HOME}/.julia/dev/ElectronDynamicsModels"   # EDM checkout on this machine
+EDM_REPO="${HOME}/.julia/dev/ElectronDynamicsModels"   # EDM checkout (optional — defaults to the repo containing orchestration/)
 JULIA_CHANNEL=release                                   # juliaup channel (matches the pinned Manifest)
 
 # ── local backend (this machine's GPU) ───────────────────────────────────────

--- a/orchestration/config.env.example
+++ b/orchestration/config.env.example
@@ -1,0 +1,39 @@
+# orchestration/config.env — machine-specific infra for the EDM run framework.
+# COPY this to orchestration/config.env (gitignored) and fill in your values.
+#
+# SECRETS DO NOT GO HERE. Tokens / mTLS certs / keys stay in ~/.config and are referenced
+# below by PATH only, so this file (and the whole orchestration/ dir) is safe in a public repo.
+# This file holds only non-secret, machine-specific infra (repo path, GPU vendor, cluster
+# partition, host handles) — the stuff that differs per machine and that we keep out of git.
+
+# ── repo + julia ─────────────────────────────────────────────────────────────
+EDM_REPO="${HOME}/.julia/dev/ElectronDynamicsModels"   # EDM checkout on this machine
+JULIA_CHANNEL=release                                   # juliaup channel (matches the pinned Manifest)
+
+# ── local backend (this machine's GPU) ───────────────────────────────────────
+LOCAL_BACKEND=cuda                 # cuda | rocm
+LOCAL_PREENV=                      # extra leading env for the local GPU, e.g. "HIP_VISIBLE_DEVICES=0" on rocm
+LOCAL_JL_THREADS=auto              # julia -t value (auto | N)
+
+# ── SLURM backend (cluster login node) ───────────────────────────────────────
+SLURM_PARTITION=GPU
+SLURM_GRES=gpu:h200:1              # gpu:<type>:<count> (count>1 ⇒ the solver auto-shards)
+SLURM_CPUS=32
+SLURM_MEM=192G
+SLURM_TIME=12:00:00
+SLURM_CONCURRENCY=2                # %N cap on the job array
+SLURM_OUTROOT="${HOME}/data/thomson_runs"   # campaign output dirs live here on the cluster
+
+# ── Hot Aisle backend (cloud MI300X) ─────────────────────────────────────────
+HOTAISLE_TEAM=                     # your team handle (also in ~/.config/hotaisle/team)
+HOTAISLE_GPUS=1                    # 1 ⇒ per-minute billing (1-min minimum); 2/4 carry 60/120-min minimums
+HOTAISLE_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git   # PUBLIC clone URL
+HOTAISLE_BRANCH=main
+# token lives at ~/.config/hotaisle/token  (NOT here)
+
+# ── notifications (optional; secrets external) ───────────────────────────────
+# Sourced for NTFY_URL / NTFY_TOKEN / NTFY_CERT / NTFY_KEY (mTLS-gated, so the URL alone is inert).
+NTFY_ENV="${HOME}/.config/ntfy/edm-campaigns.env"
+
+# ── publish (optional) ───────────────────────────────────────────────────────
+RESEARCH_PUBLISH_CONFIG="${HOME}/.config/research-publish.env"

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Shared run core for EDM campaigns — used by EVERY backend (local / SLURM / Hot Aisle).
+# COMMITTED + generic: no infra, no secrets. Machine specifics come from orchestration/config.env
+# (gitignored); secrets stay in ~/.config (referenced by path). Because this file ships in the repo,
+# it's present on any machine the repo is cloned to (your box, a cluster node, a cloud VM).
+#
+# THE CONTRACT every backend honours, identically:
+#   • mint a UUID run-tag (never readable tags — they collide in the 8-char derived-sidecar key)
+#   • set EDM_RUN_TAG + EDM_OUTDIR, run the solver, tee/redirect to run_<uuid>.log beside the manifest
+#   • record a canonical cells.tsv trail (label ⇆ uuid ⇆ script ⇆ backend ⇆ overrides)
+#   • apply the cube-retention policy (KEEP_CUBE)
+#   • optionally run a post-process hook (a reducer), given the uuid
+#
+# A CAMPAIGN is pure data — it sets BASE (baseline EDM_* env) + SCRIPT and lists CELLS; a BACKEND
+# sets JL/PREENV/CAMP/BACKEND and decides where/how cells run. The split keeps campaigns and the
+# core infra-free and portable.
+#
+# Caller sets before using run_cell:
+#   REPO      EDM checkout (cd target; scripts env at $REPO/scripts)
+#   CAMP      output dir for this campaign's runs (holds run_<uuid>.{toml,log,jls}, cells.tsv)
+#   BACKEND   cuda | rocm                          (→ EDM_GPU_BACKEND)
+#   JL        julia launcher+flags array           e.g. JL=(julia +release --startup=no -t auto)
+#   SCRIPT    solver, default scripts/thomson_scattering.jl (scripts/lpwa.jl for the analytic path)
+#   BASE      array of baseline EDM_* assignments  e.g. BASE=(EDM_NX=200 EDM_NSAMPLES=6000 ...)
+#   PREENV    optional leading env array           e.g. PREENV=(HIP_VISIBLE_DEVICES=0)
+#   KEEP_CUBE 1 keeps the field_*.jls cube (default 0 = delete after a successful post-process)
+#   POST_HOOK optional command run after a successful cell; receives the uuid as $1
+# Usage: run_cell <label> [EDM_VAR=val ...]   (per-cell overrides win — env is last-wins)
+: "${SCRIPT:=scripts/thomson_scattering.jl}"
+
+# Load machine infra (gitignored). orchestration/ is this file's dir.
+_ORCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$_ORCH_DIR/config.env" ] && . "$_ORCH_DIR/config.env"
+: "${REPO:=${EDM_REPO:-$HOME/.julia/dev/ElectronDynamicsModels}}"
+
+# ── notifications (optional, ALL backends) ───────────────────────────────────
+# Creds come from $NTFY_ENV (set in config.env → e.g. ~/.config/ntfy/edm-campaigns.env); secrets stay
+# external. No-op if unconfigured, so campaigns run fine without ntfy. mTLS cert/key are optional
+# (the topic is mTLS-gated, so the URL alone is inert — safe even if it ever leaked).
+[ -n "${NTFY_ENV:-}" ] && [ -f "${NTFY_ENV:-/nonexistent}" ] && . "$NTFY_ENV"
+notify() {   # notify <tags> <priority> <title> <message>  — no-op unless NTFY_URL is set
+    # NTFY_DISABLE=1 hard-disables (e.g. SLURM compute nodes have no outbound internet — pushing from
+    # there would just hang the curl; cluster completion is handled by an external squeue poller instead).
+    [ "${NTFY_DISABLE:-0}" = 1 ] && return 0
+    [ -n "${NTFY_URL:-}" ] || return 0
+    curl -sS --max-time 10 ${NTFY_CERT:+--cert "$NTFY_CERT"} ${NTFY_KEY:+--key "$NTFY_KEY"} \
+        ${NTFY_TOKEN:+-H "Authorization: Bearer $NTFY_TOKEN"} \
+        -H "Tags: $1" -H "Priority: $2" -H "Title: $3" -d "$4" "$NTFY_URL" >/dev/null 2>&1 \
+        || echo "[warn] ntfy post failed: $3" >&2
+}
+
+run_cell() {
+    local label=$1; shift
+    local uuid; uuid=$(uuidgen)
+    mkdir -p "$CAMP"
+    [ -f "$CAMP/cells.tsv" ] || printf 'label\tuuid\tscript\tbackend\toverrides\n' > "$CAMP/cells.tsv"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$label" "$uuid" "$(basename "$SCRIPT")" "${BACKEND:-?}" "$*" >> "$CAMP/cells.tsv"
+    local log="$CAMP/run_${uuid}.log"
+    echo "[$(date -u +%FT%TZ)] cell $label  [$(basename "$SCRIPT") ${BACKEND:-?}]  keep=${KEEP_CUBE:-0}  $uuid :: ${*:-<baseline>}"
+    ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} ${BASE[@]+"${BASE[@]}"} \
+          EDM_GPU_BACKEND="$BACKEND" EDM_OUTDIR="$CAMP" EDM_RUN_TAG="$uuid" "$@" \
+          "${JL[@]}" --project=scripts "$SCRIPT" ) > "$log" 2>&1
+    local rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "  done $label ($uuid)"
+        CELLS_OK=$(( ${CELLS_OK:-0} + 1 ))
+        [ "${NOTIFY_EACH:-0}" = 1 ] && notify white_check_mark default "EDM cell done" "${CAMPAIGN:-?}/$label ($(hostname))"
+        [ -n "${POST_HOOK:-}" ] && eval "$POST_HOOK \"$uuid\""
+        [ "${KEEP_CUBE:-0}" = 1 ] || rm -f "$CAMP"/field_*_"$uuid".jls
+    else
+        echo "  FAILED $label rc=$rc — cube kept, see $log"
+        CELLS_FAIL=$(( ${CELLS_FAIL:-0} + 1 ))
+        notify rotating_light high "EDM cell FAILED" "${CAMPAIGN:-?}/$label rc=$rc on $(hostname) — see run_${uuid}.log"
+    fi
+    return 0   # one bad cell never aborts the sweep
+}
+
+# Iterate a CELLS array of "label|EDM_VAR=val EDM_VAR2=val2" entries (the campaign's data).
+# Used by the local + hotaisle backends; SLURM indexes CELLS by $SLURM_ARRAY_TASK_ID instead.
+# ntfy: a campaign-start ping, per-cell-failure pings (always), and a pass/fail summary at the end.
+run_cells() {
+    CELLS_OK=0; CELLS_FAIL=0
+    notify hourglass_flowing_sand default "EDM campaign started" "${CAMPAIGN:-?}: ${#CELLS[@]} cells, ${BACKEND:-?}@$(hostname)"
+    local entry label overrides
+    for entry in "${CELLS[@]}"; do
+        label=${entry%%|*}; overrides=${entry#*|}
+        [ "$overrides" = "$entry" ] && overrides=""   # no '|' ⇒ baseline cell
+        # shellcheck disable=SC2086
+        run_cell "$label" $overrides
+    done
+    local tag=white_check_mark pri=default
+    [ "${CELLS_FAIL:-0}" -gt 0 ] && { tag=warning; pri=high; }
+    notify "$tag" "$pri" "EDM campaign done" "${CAMPAIGN:-?}: ${CELLS_OK:-0}/${#CELLS[@]} ok, ${CELLS_FAIL:-0} failed (${BACKEND:-?}@$(hostname))"
+}

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -24,14 +24,21 @@
 #   BASE      array of baseline EDM_* assignments  e.g. BASE=(EDM_NX=200 EDM_NSAMPLES=6000 ...)
 #   PREENV    optional leading env array           e.g. PREENV=(HIP_VISIBLE_DEVICES=0)
 #   KEEP_CUBE 1 keeps the field_*.jls cube (default 0 = delete after a successful post-process)
-#   POST_HOOK optional command run after a successful cell; receives the uuid as $1
+#   POST_HOOK optional command run synchronously after a successful cell; receives the uuid as $1
+#   REDUCE_OVERLAP 1 runs the solver field-only (EDM_SKIP_POSTPROCESS=1) and reduces it in the
+#             BACKGROUND, so this cell's reduction overlaps the NEXT cell's GPU compute (the paid
+#             multi-cell win). Reaped (+ cube policy) by reap_reduces ⇒ requires the run_cells path.
+#   REDUCE_HOOK optional command (receives the uuid as $1) replacing the default cube→products
+#             reducer used in overlap mode (default: harmonic_products.jl + plot_screen_observables.jl)
 # Usage: run_cell <label> [EDM_VAR=val ...]   (per-cell overrides win — env is last-wins)
 : "${SCRIPT:=scripts/thomson_scattering.jl}"
 
 # Load machine infra (gitignored). orchestration/ is this file's dir.
 _ORCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [ -f "$_ORCH_DIR/config.env" ] && . "$_ORCH_DIR/config.env"
-: "${REPO:=${EDM_REPO:-$HOME/.julia/dev/ElectronDynamicsModels}}"
+# REPO defaults to the repo that CONTAINS this orchestration/ dir (so it's right on any clone —
+# your dev checkout, a cluster node, a cloud VM at $HOME/EDM). config.env's EDM_REPO overrides it.
+: "${REPO:=${EDM_REPO:-$(cd "$_ORCH_DIR/.." && pwd)}}"
 
 # ── notifications (optional, ALL backends) ───────────────────────────────────
 # Creds come from $NTFY_ENV (set in config.env → e.g. ~/.config/ntfy/edm-campaigns.env); secrets stay
@@ -49,6 +56,24 @@ notify() {   # notify <tags> <priority> <title> <message>  — no-op unless NTFY
         || echo "[warn] ntfy post failed: $3" >&2
 }
 
+# Default reducer for overlap mode: turn a finished field cube into its products (the step the
+# solver does inline when EDM_SKIP_POSTPROCESS is unset). Runs BACKGROUNDED; appends to the cell's
+# run_<uuid>.log (so the reduce output travels with the run) and drops a <uuid>.reduced /
+# <uuid>.reduce_failed marker that reap_reduces waits on. Override with REDUCE_HOOK for a custom reducer.
+_reduce_cell() {
+    local uuid=$1 manifest="$CAMP/run_${uuid}.toml" cube rc=0
+    ( cd "$REPO" && "${JL[@]}" --project=scripts scripts/harmonic_products.jl "$manifest" ) \
+        >> "$CAMP/run_${uuid}.log" 2>&1 || rc=1
+    if [ "$rc" -eq 0 ]; then
+        for cube in "$CAMP"/field_*_"$uuid".jls; do
+            [ -e "$cube" ] || continue
+            ( cd "$REPO" && "${JL[@]}" --project=scripts scripts/plot_screen_observables.jl "$cube" ) \
+                >> "$CAMP/run_${uuid}.log" 2>&1 || rc=1
+        done
+    fi
+    [ "$rc" -eq 0 ] && touch "$CAMP/${uuid}.reduced" || touch "$CAMP/${uuid}.reduce_failed"
+}
+
 run_cell() {
     local label=$1; shift
     local uuid; uuid=$(uuidgen)
@@ -56,17 +81,27 @@ run_cell() {
     [ -f "$CAMP/cells.tsv" ] || printf 'label\tuuid\tscript\tbackend\toverrides\n' > "$CAMP/cells.tsv"
     printf '%s\t%s\t%s\t%s\t%s\n' "$label" "$uuid" "$(basename "$SCRIPT")" "${BACKEND:-?}" "$*" >> "$CAMP/cells.tsv"
     local log="$CAMP/run_${uuid}.log"
-    echo "[$(date -u +%FT%TZ)] cell $label  [$(basename "$SCRIPT") ${BACKEND:-?}]  keep=${KEEP_CUBE:-0}  $uuid :: ${*:-<baseline>}"
-    ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} ${BASE[@]+"${BASE[@]}"} \
+    # In overlap mode the field runs WITHOUT inline postprocess; _reduce_cell does it backgrounded.
+    local skip=""; [ "${REDUCE_OVERLAP:-0}" = 1 ] && skip="EDM_SKIP_POSTPROCESS=1"
+    echo "[$(date -u +%FT%TZ)] cell $label  [$(basename "$SCRIPT") ${BACKEND:-?}]  keep=${KEEP_CUBE:-0} overlap=${REDUCE_OVERLAP:-0}  $uuid :: ${*:-<baseline>}"
+    # shellcheck disable=SC2086
+    ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} ${BASE[@]+"${BASE[@]}"} $skip \
           EDM_GPU_BACKEND="$BACKEND" EDM_OUTDIR="$CAMP" EDM_RUN_TAG="$uuid" "$@" \
           "${JL[@]}" --project=scripts "$SCRIPT" ) > "$log" 2>&1
     local rc=$?
     if [ "$rc" -eq 0 ]; then
-        echo "  done $label ($uuid)"
         CELLS_OK=$(( ${CELLS_OK:-0} + 1 ))
         [ "${NOTIFY_EACH:-0}" = 1 ] && notify white_check_mark default "EDM cell done" "${CAMPAIGN:-?}/$label ($(hostname))"
-        [ -n "${POST_HOOK:-}" ] && eval "$POST_HOOK \"$uuid\""
-        [ "${KEEP_CUBE:-0}" = 1 ] || rm -f "$CAMP"/field_*_"$uuid".jls
+        if [ "${REDUCE_OVERLAP:-0}" = 1 ]; then
+            echo "  field done $label ($uuid) — reduce backgrounded (overlaps next cell)"
+            rm -f "$CAMP/${uuid}.reduced" "$CAMP/${uuid}.reduce_failed"
+            ( eval "${REDUCE_HOOK:-_reduce_cell \"$uuid\"}" ) &
+            REDUCE_PIDS+=("$!"); PENDING_REDUCE+=("$uuid|$label")
+        else
+            echo "  done $label ($uuid)"
+            [ -n "${POST_HOOK:-}" ] && eval "$POST_HOOK \"$uuid\""
+            [ "${KEEP_CUBE:-0}" = 1 ] || rm -f "$CAMP"/field_*_"$uuid".jls
+        fi
     else
         echo "  FAILED $label rc=$rc — cube kept, see $log"
         CELLS_FAIL=$(( ${CELLS_FAIL:-0} + 1 ))
@@ -75,11 +110,35 @@ run_cell() {
     return 0   # one bad cell never aborts the sweep
 }
 
+# In overlap mode, join the backgrounded reductions launched by run_cell: wait them out, then for
+# each apply the cube-retention policy. A field that ran but whose reduction failed is the awkward
+# case — the GPU work (the expensive part) is done, and the cube is the only way to recover the
+# products without re-running it, so the policy trades disk for compute.
+reap_reduces() {
+    [ "${REDUCE_OVERLAP:-0}" = 1 ] || return 0
+    [ "${#PENDING_REDUCE[@]}" -gt 0 ] || return 0
+    echo "[reduce] waiting on ${#PENDING_REDUCE[@]} backgrounded reduction(s)…"
+    wait "${REDUCE_PIDS[@]}" 2>/dev/null
+    local entry uuid label
+    for entry in "${PENDING_REDUCE[@]}"; do
+        uuid=${entry%%|*}; label=${entry#*|}
+        if [ -f "$CAMP/${uuid}.reduced" ]; then
+            echo "  reduce ok: $label ($uuid)"
+            [ "${KEEP_CUBE:-0}" = 1 ] || rm -f "$CAMP"/field_*_"$uuid".jls
+        else
+            # Field ok but reduction failed: keep the cube (recoverable), alert, count the cell failed.
+            CELLS_OK=$(( ${CELLS_OK:-0} - 1 )); CELLS_FAIL=$(( ${CELLS_FAIL:-0} + 1 ))
+            echo "  REDUCE FAILED: $label ($uuid) — cube KEPT for recovery, see run_${uuid}.log"
+            notify rotating_light high "EDM reduce FAILED" "${CAMPAIGN:-?}/$label ($uuid): field ok, reduce failed on $(hostname) — cube kept; re-reduce from run_${uuid}.toml"
+        fi
+    done
+}
+
 # Iterate a CELLS array of "label|EDM_VAR=val EDM_VAR2=val2" entries (the campaign's data).
 # Used by the local + hotaisle backends; SLURM indexes CELLS by $SLURM_ARRAY_TASK_ID instead.
 # ntfy: a campaign-start ping, per-cell-failure pings (always), and a pass/fail summary at the end.
 run_cells() {
-    CELLS_OK=0; CELLS_FAIL=0
+    CELLS_OK=0; CELLS_FAIL=0; PENDING_REDUCE=(); REDUCE_PIDS=()
     notify hourglass_flowing_sand default "EDM campaign started" "${CAMPAIGN:-?}: ${#CELLS[@]} cells, ${BACKEND:-?}@$(hostname)"
     local entry label overrides
     for entry in "${CELLS[@]}"; do
@@ -88,6 +147,7 @@ run_cells() {
         # shellcheck disable=SC2086
         run_cell "$label" $overrides
     done
+    reap_reduces
     local tag=white_check_mark pri=default
     [ "${CELLS_FAIL:-0}" -gt 0 ] && { tag=warning; pri=high; }
     notify "$tag" "$pri" "EDM campaign done" "${CAMPAIGN:-?}: ${CELLS_OK:-0}/${#CELLS[@]} ok, ${CELLS_FAIL:-0} failed (${BACKEND:-?}@$(hostname))"


### PR DESCRIPTION
Unifies the ad-hoc per-machine run scripts into one portable orchestration framework under `orchestration/`, split as **data + universal core + thin backend adapters**.

## Structure
- **`run_cell.sh`** — universal core, sourced by every backend: mints a UUID `EDM_RUN_TAG` (readable tags collide in the 8-char derived-sidecar key), records `cells.tsv`, tees each cell to `run_<uuid>.log`, applies the cube-retention policy, carries an optional ntfy `notify()`. Also `REDUCE_OVERLAP` (opt-in field-only solve + backgrounded reduce so a cell's reduction overlaps the next cell's GPU compute) and `REPO` defaulting to the repo containing `orchestration/` (works on any clone, incl. a cloud VM).
- **`campaigns/`** — pure data (`BASE` + `SCRIPT` + `CELLS`), no infra: `smoke`, `lowa0_maps`, `smalla0_floor`.
- **`backends/`** — `local.sh`, `slurm_submit.sh` + `slurm.sbatch` (data-driven job array), `hotaisle.sh` (cloud MI300X lifecycle with warm-VM reuse, crash-aware poll, md5 download-verify).

## Infra boundary (public repo)
Machine specifics live in `orchestration/config.env` (gitignored; `config.env.example` committed); secrets stay in `~/.config`, referenced by path. ntfy is mTLS-gated and disabled on SLURM compute nodes (no egress).

Supersedes the local-only `scripts/{run_logged.sh,hotaisle_campaign.sh,balance_monitor.sh,*.sbatch}` (kept gitignored as fallbacks).

## Validation
`bash -n` clean on all scripts; stubbed-julia dry-runs of the core (UUID/cells.tsv/BASE-override/KEEP_CUBE) and the overlap path (success deletes cube, reduce-fail keeps it, default inline path unregressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
