### PR TITLE
Record GPU telemetry in a manifest [gpu] section

### DIFF
--- a/scripts/gpu_telemetry.jl
+++ b/scripts/gpu_telemetry.jl
@@ -1,0 +1,70 @@
+# GPU telemetry for the solver manifests' [gpu] section — shared by thomson_scattering.jl + lpwa.jl.
+# A static device snapshot (name, SMs, capacity, VRAM, thread-fill occupancy) plus a sampler that
+# records power / compute-util / mem-util / VRAM over the accumulate_field window on a spawned
+# thread. Uses the vendor-agnostic gpu_api (CUDA=NVML, AMD=sysfs), which the scripts already
+# `using`. Everything is wrapped so a telemetry hiccup NEVER breaks a run — it just omits the section.
+
+# Run `f()` while a background task samples the CURRENT device every `dt` seconds. Returns
+# (result_of_f, samples::Vector{NTuple{4,Float64}} = (power_W, compute_util, mem_util, vram_used_B)).
+# `f` is FIRST so the do-block form works: `with_gpu_sampler(backend, dt) do … end` (Julia prepends
+# the closure). The sampler is the sole writer and the caller reads `samples` only after wait() ⇒ no
+# data race. Needs ≥2 Julia threads or the sampler starves behind the field kernel (caller should warn).
+function with_gpu_sampler(f, backend, dt::Real)
+    running = Threads.Atomic{Bool}(true)
+    samples = NTuple{4, Float64}[]
+    sampler = Threads.@spawn begin
+        while running[]
+            try
+                u = gpu_utilization(backend)
+                m = gpu_memory_info(backend)
+                push!(samples, (gpu_power(backend), Float64(u.compute), Float64(u.memory), Float64(m.used)))
+            catch
+                # transient telemetry read failure — drop this sample, keep sampling
+            end
+            sleep(dt)
+        end
+    end
+    result = f()
+    running[] = false
+    wait(sampler)
+    return result, samples
+end
+
+# Static device snapshot + reduced sampler stats → the manifest's [gpu] table (a plain Dict that
+# RunManifests writes verbatim as a top-level section). `n_threads` = the pixel-parallel launch size
+# (Nx·Ny) for thread-fill occupancy. In a sharded (device_count>1) run the sampler sees only its own
+# current device; the static props are per-device (identical hardware) and device_count records the fan-out.
+# Returns `nothing` if telemetry is unavailable (e.g. no vendor extension) so the caller just omits [gpu].
+function gpu_manifest_section(backend, backend_name::AbstractString, n_threads::Integer,
+        device_count::Integer, samples::Vector{NTuple{4, Float64}})
+    try
+        gpu = Dict{String, Any}(
+            "backend" => String(backend_name),
+            "device" => gpu_name(backend),
+            "device_count" => Int(device_count),
+            "sm_count" => Int(gpu_sm_count(backend)),
+            "max_threads_per_sm" => Int(gpu_max_threads_per_sm(backend)),
+            "memory_total" => Int(gpu_memory_info(backend).total),
+            "thread_fill_occupancy" => Float64(thread_fill_occupancy(backend, n_threads)),
+        )
+        if !isempty(samples)
+            _mean(v) = sum(v) / length(v)
+            pw = Float64[s[1] for s in samples]
+            cu = Float64[s[2] for s in samples]
+            mu = Float64[s[3] for s in samples]
+            vr = Float64[s[4] for s in samples]
+            gpu["samples"] = length(samples)
+            gpu["power_mean"] = _mean(pw);          gpu["power_peak"] = maximum(pw)
+            gpu["compute_util_mean"] = _mean(cu);   gpu["compute_util_peak"] = maximum(cu)
+            gpu["memory_util_mean"] = _mean(mu);    gpu["memory_util_peak"] = maximum(mu)
+            gpu["vram_used_peak"] = maximum(vr)
+        end
+        return gpu
+    catch err
+        @warn "GPU telemetry unavailable — omitting [gpu] from the manifest" exception = err
+        return nothing
+    end
+end
+
+# Sampler cadence (s); coarse is fine — field runs are seconds→hours. Override with EDM_GPU_SAMPLE_DT.
+const GPU_SAMPLE_DT = parse(Float64, get(ENV, "EDM_GPU_SAMPLE_DT", "1.0"))

--- a/scripts/lpwa.jl
+++ b/scripts/lpwa.jl
@@ -9,6 +9,7 @@ using Serialization
 
 using RunManifests
 include(joinpath(@__DIR__, "harmonic_products.jl"))   # write_harmonic_products (shared with thomson + recovery)
+include(joinpath(@__DIR__, "gpu_telemetry.jl"))   # with_gpu_sampler + gpu_manifest_section → the manifest [gpu] section
 
 const T_START = time()   # wall-clock anchor for the [timing] section (mirrors thomson_scattering.jl)
 
@@ -189,17 +190,24 @@ screen = ObserverScreen(
 # Multi-GPU: when >1 device is visible (e.g. SLURM --gres=gpu:h200:2) shard the electrons across
 # them — linear superposition ⇒ the summed partials are exact; one device ⇒ the plain path.
 ndev = gpu_device_count(gpu_backend)
-t_field = @elapsed fld = if ndev > 1
-    @info "sharding electrons across $ndev devices"
-    accumulate_field_sharded(
-        trajs, screen, GPUKernelRK4(), gpu_backend;
-        mode = Val(FIELD_MODE), n_substeps = NSUBSTEPS, sync_per_electron = SYNC
-    )
-else
-    accumulate_field(
-        trajs, screen, GPUKernelRK4(), gpu_backend;
-        mode = Val(FIELD_MODE), n_substeps = NSUBSTEPS, sync_per_electron = SYNC
-    )
+Threads.nthreads() >= 2 ||
+    @warn "only $(Threads.nthreads()) Julia thread — the GPU telemetry sampler starves behind the kernel; [gpu] sample stats may be empty (run with -t≥2)"
+# Sample GPU power/util/VRAM on a spawned thread across the accumulate_field window (→ manifest [gpu]).
+t_field = @elapsed begin
+    fld, gpu_samples = with_gpu_sampler(gpu_backend, GPU_SAMPLE_DT) do
+        if ndev > 1
+            @info "sharding electrons across $ndev devices"
+            accumulate_field_sharded(
+                trajs, screen, GPUKernelRK4(), gpu_backend;
+                mode = Val(FIELD_MODE), n_substeps = NSUBSTEPS, sync_per_electron = SYNC
+            )
+        else
+            accumulate_field(
+                trajs, screen, GPUKernelRK4(), gpu_backend;
+                mode = Val(FIELD_MODE), n_substeps = NSUBSTEPS, sync_per_electron = SYNC
+            )
+        end
+    end
 end
 @info "field accumulated" t_field ndev
 
@@ -296,8 +304,12 @@ timing = Dict{String, Any}(
 # Sharding → [sharding] (axis → partition count). Flat + generic so future axes (e.g. a Z-split
 # 3D screen) slot in with no schema change. NOT in [timing] — a device count is not a duration.
 sharding = Dict{String, Any}("electrons" => ndev)
+# GPU telemetry → [gpu] (static device snapshot + power/util/VRAM stats over the field window).
+# `nothing` (no vendor extension / telemetry error) ⇒ the section is simply omitted.
+gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_samples)
+extra = Dict{String, Any}("model" => model_params, "timing" => timing, "sharding" => sharding)
+gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(
-    OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs,
-    extra = Dict("model" => model_params, "timing" => timing, "sharding" => sharding),
+    OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs, extra,
 )
 println("manifest → $manifestfile")

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -26,6 +26,7 @@ using UUIDs
 
 include(joinpath(@__DIR__, "manifest.jl"))   # RunManifests: run_provenance, write_solver_manifest
 include(joinpath(@__DIR__, "harmonic_products.jl"))   # write_harmonic_products (shared with the recovery path)
+include(joinpath(@__DIR__, "gpu_telemetry.jl"))   # with_gpu_sampler + gpu_manifest_section → the manifest [gpu] section
 
 # GPU backend selected via ENV: "rocm" (workstation default) or "cuda" (issaf H200).
 const GPU_BACKEND = lowercase(get(ENV, "EDM_GPU_BACKEND", "rocm"))
@@ -198,17 +199,24 @@ screen = ObserverScreen(
 # Multi-GPU: when >1 device is visible (e.g. SLURM --gres=gpu:h200:2) shard the electrons across
 # them — linear superposition ⇒ the summed partials are exact; one device ⇒ the plain path.
 ndev = gpu_device_count(gpu_backend)
-t_field = @elapsed fld = if ndev > 1
-    @info "sharding electrons across $ndev devices"
-    accumulate_field_sharded(
-        trajs, screen, GPUKernelRK4(), gpu_backend;
-        n_substeps = NSUBSTEPS, mode = Val(FIELD_MODE), sync_per_electron = SYNC
-    )
-else
-    accumulate_field(
-        trajs, screen, GPUKernelRK4(), gpu_backend;
-        n_substeps = NSUBSTEPS, mode = Val(FIELD_MODE), sync_per_electron = SYNC
-    )
+Threads.nthreads() >= 2 ||
+    @warn "only $(Threads.nthreads()) Julia thread — the GPU telemetry sampler starves behind the kernel; [gpu] sample stats may be empty (run with -t≥2)"
+# Sample GPU power/util/VRAM on a spawned thread across the accumulate_field window (→ manifest [gpu]).
+t_field = @elapsed begin
+    fld, gpu_samples = with_gpu_sampler(gpu_backend, GPU_SAMPLE_DT) do
+        if ndev > 1
+            @info "sharding electrons across $ndev devices"
+            accumulate_field_sharded(
+                trajs, screen, GPUKernelRK4(), gpu_backend;
+                n_substeps = NSUBSTEPS, mode = Val(FIELD_MODE), sync_per_electron = SYNC
+            )
+        else
+            accumulate_field(
+                trajs, screen, GPUKernelRK4(), gpu_backend;
+                n_substeps = NSUBSTEPS, mode = Val(FIELD_MODE), sync_per_electron = SYNC
+            )
+        end
+    end
 end
 @info "field accumulated" t_field ndev
 
@@ -300,8 +308,12 @@ timing = Dict{String, Any}(
 # Sharding → [sharding] (axis → partition count). Flat + generic so future axes (e.g. a Z-split
 # 3D screen) slot in with no schema change. NOT in [timing] — a device count is not a duration.
 sharding = Dict{String, Any}("electrons" => ndev)
+# GPU telemetry → [gpu] (static device snapshot + power/util/VRAM stats over the field window).
+# `nothing` (no vendor extension / telemetry error) ⇒ the section is simply omitted.
+gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_samples)
+extra = Dict{String, Any}("timing" => timing, "sharding" => sharding)
+gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(
-    OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs,
-    extra = Dict("timing" => timing, "sharding" => sharding),
+    OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs, extra,
 )
 println("manifest → $manifestfile")


### PR DESCRIPTION
Both field solvers now capture per-run GPU telemetry into a top-level `[gpu]` manifest section — **no RunManifests schema change** (it rides the same `extra`-dict path as `[timing]`/`[sharding]`).

## What's added
New **`scripts/gpu_telemetry.jl`** (included by both `thomson_scattering.jl` and `lpwa.jl`):
- `with_gpu_sampler(f, backend, dt)` — runs the field accumulation while a spawned thread samples power / compute-util / mem-util / VRAM off the vendor-agnostic `src/gpu_api.jl` (CUDA=NVML, AMD=sysfs); returns `(result, samples)`. `f` is first so the do-block form works.
- `gpu_manifest_section(...)` — static device snapshot (name, `sm_count`, `max_threads_per_sm`, total VRAM, `thread_fill_occupancy` at `Nx·Ny`) + mean/peak of the samples → a TOML-serializable `Dict`, or `nothing` if telemetry is unavailable (no vendor extension / read error) so the section is simply omitted. **Never breaks a run.**

## Notes
- Log-visibility (the paired half of the original task) is handled separately by the dashboard diagnostics branch — this PR is solver-side `[gpu]` only.
- Sharded runs sample the sampler's current device; static props are per-device (identical hardware) and `device_count` records the fan-out.

## Validation
Stubbed-GPU functional test (sampler window + `[gpu]` TOML round-trip + failure path) and parse-checks of both edited solvers. The test caught a do-block arg-order bug (closure is prepended) before any real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
