### PR TITLE
Add ENV overridable polarization option

### DIFF
--- a/orchestration/campaigns/linpol_maps.sh
+++ b/orchestration/campaigns/linpol_maps.sh
@@ -1,0 +1,23 @@
+# campaigns/linpol_maps.sh — linear-polarization radiated-field harmonic maps (Nx=200, N=400).
+# PURE DATA: no infra, no backend, no run-tags (the core mints UUIDs). Runs on any backend:
+#   bash orchestration/backends/local.sh   orchestration/campaigns/linpol_maps.sh
+#   bash orchestration/backends/hotaisle.sh orchestration/campaigns/linpol_maps.sh
+#   sbatch orchestration/backends/slurm.sbatch orchestration/campaigns/linpol_maps.sh
+#
+# Same harmonic-map recipe as lowa0_maps (uniform EDM_INTERP_SAVEAT=16 floor fix, φ0=-π/2 published
+# convention) but with EDM_POL=linear instead of the default circular_minus, so it is directly
+# comparable to the circular runs at matched a0. a0 spans 1e-5 (deep-linear ∝a0) to 0.1.
+CAMPAIGN=linpol_maps
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=200 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=400 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
+  EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
+  EDM_POL=linear                       # linear polarization (ξ = (1,0)); default is circular_minus
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+)
+CELLS=(
+  "a1em5|EDM_A0=1e-5"
+  "a1em3|EDM_A0=1e-3"
+  "a1e1|EDM_A0=0.1"
+)

--- a/orchestration/campaigns/linpol_maps.sh
+++ b/orchestration/campaigns/linpol_maps.sh
@@ -1,12 +1,5 @@
-# campaigns/linpol_maps.sh — linear-polarization radiated-field harmonic maps (Nx=200, N=400).
-# PURE DATA: no infra, no backend, no run-tags (the core mints UUIDs). Runs on any backend:
-#   bash orchestration/backends/local.sh   orchestration/campaigns/linpol_maps.sh
-#   bash orchestration/backends/hotaisle.sh orchestration/campaigns/linpol_maps.sh
-#   sbatch orchestration/backends/slurm.sbatch orchestration/campaigns/linpol_maps.sh
-#
-# Same harmonic-map recipe as lowa0_maps (uniform EDM_INTERP_SAVEAT=16 floor fix, φ0=-π/2 published
-# convention) but with EDM_POL=linear instead of the default circular_minus, so it is directly
-# comparable to the circular runs at matched a0. a0 spans 1e-5 (deep-linear ∝a0) to 0.1.
+# campaigns/linpol_maps.sh — linear-pol radiated-field harmonic maps (Nx=200, N=400, a0 1e-5…0.1).
+# EDM_POL=linear (vs default circular_minus): directly comparable to the circular runs at matched a0.
 CAMPAIGN=linpol_maps
 SCRIPT=scripts/thomson_scattering.jl
 BASE=(

--- a/orchestration/campaigns/linpol_maps_N5k.sh
+++ b/orchestration/campaigns/linpol_maps_N5k.sh
@@ -1,0 +1,16 @@
+# campaigns/linpol_maps_N5k.sh — linear-pol harmonic maps at N_electrons=5000 (vs 400 in
+# linpol_maps.sh): ~√(5000/400) ≈ 3.5× lower shot-noise floor for the ∝a0 2ω at a0=1e-5. N is VRAM-free.
+CAMPAIGN=linpol_maps_N5k
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=200 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=5000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
+  EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
+  EDM_POL=linear                       # linear polarization (ξ = (1,0)); default is circular_minus
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+)
+CELLS=(
+  "a1em5|EDM_A0=1e-5"
+  "a1em3|EDM_A0=1e-3"
+  "a1e1|EDM_A0=0.1"
+)

--- a/orchestration/campaigns/lowa0_maps.sh
+++ b/orchestration/campaigns/lowa0_maps.sh
@@ -1,11 +1,5 @@
 # campaigns/lowa0_maps.sh — low-a0 radiated-field harmonic maps.
-# PURE DATA: no infra, no backend, no run-tags (the core mints UUIDs). Runs on any backend:
-#   bash orchestration/backends/local.sh   orchestration/campaigns/lowa0_maps.sh
-#   bash orchestration/backends/hotaisle.sh orchestration/campaigns/lowa0_maps.sh
-#   sbatch orchestration/backends/slurm.sbatch orchestration/campaigns/lowa0_maps.sh
-#
-# Uses uniform EDM_INTERP_SAVEAT=16 — the floor fix: adaptive Vern9 output injects a spurious 2ω
-# in the radiation field; uniform output recovers the physical ∝a0 2ω (see the floor investigation).
+# Uniform EDM_INTERP_SAVEAT=16 (the floor fix): recovers the physical ∝a0 2ω vs adaptive-Vern9's spurious 2ω.
 CAMPAIGN=lowa0_maps
 SCRIPT=scripts/thomson_scattering.jl
 BASE=(

--- a/orchestration/campaigns/smalla0_floor.sh
+++ b/orchestration/campaigns/smalla0_floor.sh
@@ -1,8 +1,5 @@
-# campaigns/smalla0_floor.sh — small-a0 2ω floor investigation (OAT / star design).
-# PURE DATA. One baseline + independent 1-D arms (a0, interp_saveat, N, reltol, n_substeps). The
-# dashboard renders this as a hub-and-arms star (see the OAT family/hub support in the builder).
-# Run on any backend, e.g.:  bash orchestration/backends/local.sh orchestration/campaigns/smalla0_floor.sh
-# (cuda vs rocm is a BACKEND choice — the old "baseWS" rocm cross-check is just this baseline on rocm.)
+# campaigns/smalla0_floor.sh — small-a0 2ω floor investigation (OAT/star: one baseline + 1-D arms).
+# Arms over a0, interp_saveat, N, reltol, n_substeps; renders as a hub-and-arms star in the dashboard.
 CAMPAIGN=smalla0_floor
 SCRIPT=scripts/thomson_scattering.jl
 BASE=(

--- a/orchestration/campaigns/smoke.sh
+++ b/orchestration/campaigns/smoke.sh
@@ -1,11 +1,5 @@
-# campaigns/smoke.sh — tiny end-to-end validation cell, runnable on ANY backend.
-# PURE DATA. Proves the whole toolchain (ODE solve → field accumulation → reduction →
-# products) on a trivially small grid before committing to a costly campaign. Use it as the
-# first thing on a fresh machine / a freshly-provisioned cloud VM:
-#   bash   orchestration/backends/local.sh    orchestration/campaigns/smoke.sh
-#   sbatch orchestration/backends/slurm.sbatch orchestration/campaigns/smoke.sh
-#   bash   orchestration/backends/hotaisle.sh run orchestration/campaigns/smoke.sh
-# A clean exit + a run_<uuid>.toml with its PNG/derived sidecars beside it == the box is good.
+# campaigns/smoke.sh — tiny end-to-end validation cell (ANY backend): ODE solve → field accumulation →
+# reduction → products on a trivial grid. Run first on a fresh machine/VM; clean exit + sidecars == good.
 CAMPAIGN=smoke
 SCRIPT=scripts/thomson_scattering.jl
 BASE=(

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -6,6 +6,7 @@
 #
 # ENV knobs (defaults = full production): EDM_GPU_BACKEND (rocm|cuda), EDM_A0,
 # EDM_INITIAL_PHASE, EDM_NX, EDM_N, EDM_NSAMPLES, EDM_SPP, EDM_NSUBSTEPS,
+# EDM_POL (linear|circular[_plus]|circular_minus),
 # EDM_SYNC_PER_ELECTRON, EDM_OUTDIR. Writes the field .jls + per-harmonic PNGs +
 # run_<uuid>.toml manifest.
 
@@ -77,7 +78,7 @@ a₀ = A0
 
 p_radial = 2
 m_azimuthal = -2
-pol = :circular_minus   # opposite circular handedness — matches the LPWA analytic trajectory's spin; recorded in [laser].pol
+pol = Symbol(get(ENV, "EDM_POL", "circular_minus"))   # EDM_POL: :linear | :circular[_plus] | :circular_minus (default matches the LPWA analytic trajectory's spin); recorded in [laser].pol
 profile = :gaussian
 z_focus = 0.0
 


### PR DESCRIPTION
Make the beam polarization in thomson_scattering.jl ENV-overridable via EDM_POL (linear|circular[_plus]|circular_minus), defaulting to the previous hardcoded :circular_minus so existing runs are unchanged. :linear was already supported in external_fields.jl but unreachable from a pure-data campaign.

Add campaigns/linpol_maps.sh: linear-polarization radiated-field harmonic maps at Nx=200, N=400, a0 in {1e-5, 1e-3, 0.1}. Same recipe as lowa0_maps (uniform INTERP_SAVEAT=16 floor fix, φ0=-π/2) so it is directly comparable to the circular runs at matched a0.