### PR TITLE
orchestration: RunPod backend (MI300X/B200, persistent volume + S3 drain)

### DIFF
--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -32,6 +32,7 @@ REPO_URL="${HOTAISLE_REPO_URL:?set HOTAISLE_REPO_URL in config.env}"
 BRANCH="${HOTAISLE_BRANCH:-main}"
 STATE="${HOTAISLE_STATE:-$HOME/.config/hotaisle/campaign_vm}"
 OUT="${HOTAISLE_OUT:-$HOME/campaign_out}"
+DEPOT_CACHE="${DEPOT_CACHE:-}"; DEPOT_CACHE_KEY="${DEPOT_CACHE_KEY:-$HOME/.config/runpod/depot_key}"   # shared cache (see depot_cache.sh)
 CM="$HOME/.ssh/cm-hotaisle.sock"
 SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600"
 
@@ -51,19 +52,30 @@ provision() {
 }
 wait_ssh() { log "waiting for ssh…"; local i; for i in $(seq 1 40); do ssh_vm true 2>/dev/null && return 0; sleep 15; done; return 1; }
 warm() {
-    log "warm: julia + clone $BRANCH + instantiate (registry from GitHub)"
-    ssh_vm "REPO_URL='$REPO_URL' BRANCH='$BRANCH' bash -s" <<'WARM'
+    log "warm: julia + clone $BRANCH + instantiate (depot cache: ${DEPOT_CACHE:-none})"
+    if [ -n "$DEPOT_CACHE" ]; then
+        if [ -f "$DEPOT_CACHE_KEY" ]; then   # jailed key — the VM can ONLY rsync inside the archive store
+            ssh_vm 'mkdir -p ~/.ssh && cat > ~/.ssh/depot_key && chmod 600 ~/.ssh/depot_key' < "$DEPOT_CACHE_KEY"
+        else
+            log "[warn] DEPOT_CACHE set but $DEPOT_CACHE_KEY missing — building the depot fresh"
+            DEPOT_CACHE=""
+        fi
+    fi
+    ssh_vm "REPO_URL='$REPO_URL' BRANCH='$BRANCH' DEPOT_CACHE='$DEPOT_CACHE' bash -s" <<'WARM'
 set -e
 [ -x "$HOME/.juliaup/bin/julia" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes
-export PATH="$HOME/.juliaup/bin:$PATH" JULIA_PKG_SERVER=""
+export PATH="$HOME/.juliaup/bin:$PATH"   # no JULIA_PKG_SERVER: the VM uses Julia's public default (registries also ride the depot cache)
 rm -rf EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" EDM
 # VM-local config.env (gitignored ⇒ not cloned): rocm local backend, no ntfy on the VM, and
 # REDUCE_OVERLAP=1 so each cell's reduction overlaps the next cell's GPU compute (paid-time win).
 printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\nREDUCE_OVERLAP=1\n' > EDM/orchestration/config.env
+BK=rocm REPO_DIR="$HOME/EDM"; . EDM/orchestration/depot_cache.sh   # julia-actions/cache semantics (default ~/.julia depot)
+depot_cache_restore   # → DC_RESTORED = exact | prefix (instantiate tops it up) | miss (fresh build)
 ok=0; for i in 1 2 3; do
   if julia --startup=no --project=EDM/scripts -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'; then ok=1; break; fi
   echo "instantiate retry $i"; sleep 20
 done; [ "$ok" = 1 ] || { echo "instantiate failed"; exit 1; }
+[ "$DC_RESTORED" = exact ] || depot_cache_push   # exact hit ⇒ the store already has this depot
 WARM
 }
 

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -126,7 +126,7 @@ warm() {
 set -e
 export JULIA_DEPOT_PATH="/workspace/julia-depot-$BK"          # persists on the network volume
 [ -x "$HOME/.juliaup/bin/julia" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes
-export PATH="$HOME/.juliaup/bin:$PATH" JULIA_PKG_SERVER=""
+export PATH="$HOME/.juliaup/bin:$PATH"   # no JULIA_PKG_SERVER: fresh pod uses Julia's public default (don't leak the driver's internal one)
 rm -rf ~/EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" ~/EDM   # fresh clone = always current
 mkdir -p /workspace/runs && ln -sfn /workspace/runs ~/EDM/runs           # cubes+products on the volume
 printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=/workspace/julia-depot-%s\nREDUCE_OVERLAP=1\n' \
@@ -171,14 +171,15 @@ run_campaign() {
     push_orchestration
     notify hourglass_flowing_sand default "EDM runpod started" "$CAMPAIGN on $POD ($BACKEND @$DC)"
     log "launching $CAMPAIGN on the pod via the local backend ($BACKEND), detached…"
-    ssh_vm "cd EDM && mkdir -p runs && nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid"
+    ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && rm -f runs/${CAMPAIGN}.out runs/${CAMPAIGN}.pid && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
     log "polling for completion (DONE marker, or driver-death = crash)…"
-    until ssh_vm "grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null"; do
-        if ! ssh_vm "kill -0 \$(cat runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
+    until ssh_vm "cd EDM && grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null"; do
+        if ! ssh_vm "cd EDM && kill -0 \$(cat runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
+            ssh_vm "cd EDM && grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null" && break   # finished fast — DONE is present, not a crash
             notify rotating_light urgent "EDM runpod CRASH" "$CAMPAIGN driver died with no DONE on $POD — pod KEPT; teardown when done."
-            log "[ERROR] driver gone, no DONE — pod $POD KEPT. tail:"; ssh_vm "tail -n 20 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'; return 1
+            log "[ERROR] driver gone, no DONE — pod $POD KEPT. tail:"; ssh_vm "cd EDM && tail -n 20 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'; return 1
         fi
-        sleep 60; ssh_vm "tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'
+        sleep 60; ssh_vm "cd EDM && tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'
     done
     if [ "${RUNPOD_RSYNC_DOWNLOAD:-1}" = 1 ]; then
         log "campaign done; downloading reduced products via rsync (cubes excluded)…"

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# RUNPOD backend — run a campaign on a RunPod cloud GPU (MI300X in EU-RO-1 by default), using a
+# PERSISTENT network volume that outlives the pod: it caches the Julia depot (precompile paid once)
+# and stages cubes/products on S3-drainable storage. Mirrors hotaisle.sh's lifecycle; cell execution,
+# tagging, logging and cube policy all come from the SAME run_cell.sh the pod clones.
+#
+#   bash orchestration/backends/runpod.sh run orchestration/campaigns/<campaign>.sh
+#   bash orchestration/backends/runpod.sh teardown
+#
+# RunPod specifics (validated 2026-07-01 — see memory runpod-mi300x-backend):
+#   • MI300X is Secure-Cloud/EU-RO-1/intermittent → grab_pod POLLS create-pod until it schedules
+#   • raw rocm/pytorch crash-loops without a start CMD → we inject a dockerStartCmd sshd bootstrap
+#   • Secure Cloud assigns the public IP only once the container is stable → wait_ready polls for it
+#   • depot + outputs live on the network volume (/workspace) → precompile paid once, cubes persist
+#
+# config.env: RUNPOD_DC, RUNPOD_ROCM_IMAGE/RUNPOD_CUDA_IMAGE, RUNPOD_VOLUME_NAME/GB, RUNPOD_REPO_URL/BRANCH.
+# Secrets external: API token ~/.config/runpod/token; ntfy via NTFY_ENV. The pod authorizes
+# $RUNPOD_SSH_PUBKEY (a key you can auth as — e.g. your YubiKey pubkey; ControlMaster ⇒ one touch/run).
+set -Eeuo pipefail
+ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."; ORCH="$(cd "$ORCH" && pwd)"
+. "$ORCH/run_cell.sh"        # config.env + notify() (notifications fire from THIS driving machine)
+
+MODE="${1:?usage: runpod.sh run <campaign.sh> | teardown}"
+TOK=$(cat "${RUNPOD_TOKEN_FILE:-$HOME/.config/runpod/token}")
+API="https://rest.runpod.io/v1"
+DC="${RUNPOD_DC:-EU-RO-1}"
+ROCM_IMAGE="${RUNPOD_ROCM_IMAGE:-rocm/pytorch@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e}"
+CUDA_IMAGE="${RUNPOD_CUDA_IMAGE:-runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404}"
+DISK="${RUNPOD_DISK_GB:-120}"
+VOLNAME="${RUNPOD_VOLUME_NAME:-edm-vol}"; VOLGB="${RUNPOD_VOLUME_GB:-200}"
+REPO_URL="${RUNPOD_REPO_URL:?set RUNPOD_REPO_URL in config.env}"; BRANCH="${RUNPOD_BRANCH:-main}"
+STATE="${RUNPOD_STATE:-$HOME/.config/runpod/campaign_pod}"; OUT="${RUNPOD_OUT:-$HOME/campaign_out}"
+POLL="${RUNPOD_POLL_SEC:-120}"; MAXTRIES="${RUNPOD_MAX_TRIES:-240}"
+PUBKEY="$(cat "${RUNPOD_SSH_PUBKEY:-$HOME/.config/runpod/ssh_pubkey}" 2>/dev/null || ssh-add -L 2>/dev/null | head -1)"
+CM="$HOME/.ssh/cm-runpod.sock"
+SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600"
+
+rp()      { curl -fsS -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" "$@"; }
+ssh_vm()  { /usr/bin/ssh $SSHOPTS -p "$PORT" root@"$IP" "$@"; }
+log()     { echo "[$(date -u +%FT%TZ)] $*"; }
+
+# sshd bootstrap: sshd in the foreground IS the keep-alive; also authorize the injected key.
+# Needed on any image or the container crash-loops (rocm/pytorch's default CMD just exits).
+read -r -d '' START_CMD <<'EOF' || true
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq openssh-server
+mkdir -p /root/.ssh /run/sshd
+printf '%s\n' "$PUBLIC_KEY" > /root/.ssh/authorized_keys
+chmod 700 /root/.ssh; chmod 600 /root/.ssh/authorized_keys
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+exec /usr/sbin/sshd -D -e
+EOF
+
+# gpuTypeId → "backend image": keeps the acquisition policy backend-agnostic. A CUDA fallback needs
+# a CUDA image + cuda backend + its own depot (warm() namespaces JULIA_DEPOT_PATH by $BACKEND).
+gpu_profile() {
+    case "$1" in
+        "AMD Instinct MI300X OAM")   echo "rocm $ROCM_IMAGE" ;;
+        NVIDIA*)                     echo "cuda $CUDA_IMAGE" ;;
+        *)                           echo "" ;;
+    esac
+}
+
+# ── GPU acquisition policy ───────────────────────────────────────────────────
+# Echo the gpuTypeIds to attempt, ONE PER LINE, in priority order. grab_pod tries each in turn every
+# poll round; the first that schedules in EU-RO-1 wins (and its gpu_profile sets image+backend+depot).
+# This encodes your "use whatever's available in EU-RO-1" strategy.
+gpu_candidates() {
+    echo "AMD Instinct MI300X OAM"   # primary
+    echo "NVIDIA B200"               # in-region fallback
+}
+
+ensure_volume() {
+    VOLID="$(rp "$API/networkvolumes" | jq -r --arg n "$VOLNAME" '.[]|select(.name==$n)|.id' | head -1)"
+    if [ -n "$VOLID" ] && [ "$VOLID" != null ]; then log "reusing volume $VOLNAME ($VOLID) in $DC"; return 0; fi
+    log "creating network volume $VOLNAME ${VOLGB}GB in $DC"
+    VOLID="$(rp -X POST "$API/networkvolumes" \
+        -d "$(jq -n --arg n "$VOLNAME" --argjson s "$VOLGB" --arg dc "$DC" '{name:$n,size:$s,dataCenterId:$dc}')" | jq -r .id)"
+    [ -n "$VOLID" ] && [ "$VOLID" != null ] || { log "[ERROR] volume create failed"; return 1; }
+}
+
+grab_pod() {
+    [ -n "$PUBKEY" ] || { log "[ERROR] no SSH pubkey — set RUNPOD_SSH_PUBKEY"; return 1; }
+    ensure_volume
+    local -a cands; mapfile -t cands < <(gpu_candidates)
+    [ "${#cands[@]}" -gt 0 ] || { log "[ERROR] gpu_candidates returned nothing"; return 1; }
+    log "grabbing (poll ${POLL}s ≤$MAXTRIES tries): ${cands[*]}"
+    local try gpu prof resp pid
+    for ((try=1; try<=MAXTRIES; try++)); do
+        for gpu in "${cands[@]}"; do
+            prof="$(gpu_profile "$gpu")"; [ -n "$prof" ] || { log "no profile for '$gpu'"; continue; }
+            BACKEND="${prof%% *}"; IMAGE="${prof#* }"
+            resp="$(curl -fsS -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" -X POST "$API/pods" \
+                -d "$(jq -n --arg gpu "$gpu" --arg img "$IMAGE" --arg pub "$PUBKEY" --arg vol "$VOLID" \
+                        --arg dc "$DC" --arg start "$START_CMD" --argjson disk "$DISK" \
+                    '{name:"edm-runpod",imageName:$img,gpuTypeIds:[$gpu],cloudType:"SECURE",gpuCount:1,
+                      containerDiskInGb:$disk,dataCenterIds:[$dc],networkVolumeId:$vol,volumeMountPath:"/workspace",
+                      ports:["22/tcp"],supportPublicIp:true,env:{PUBLIC_KEY:$pub},
+                      dockerEntrypoint:["/bin/bash","-c"],dockerStartCmd:[$start]}')" 2>/dev/null)" || resp=""
+            pid="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null)"
+            [ -n "$pid" ] && { POD="$pid"; log "grabbed $gpu → pod $POD ($BACKEND / $IMAGE)"; return 0; }
+        done
+        [ $(( (try-1) % 10 )) -eq 0 ] && log "  no capacity yet (try $try/$MAXTRIES)…"
+        sleep "$POLL"
+    done
+    log "[ERROR] gave up after $MAXTRIES tries"; return 1
+}
+
+wait_ready() {   # public IP + 22 mapping appear only once the container is stable; then sshd is up
+    log "waiting for public IP + sshd…"; local i j
+    for i in $(seq 1 60); do
+        j="$(rp "$API/pods/$POD?includeMachine=true" 2>/dev/null || true)"
+        IP="$(echo "$j" | jq -r '.publicIp // empty' 2>/dev/null)"
+        PORT="$(echo "$j" | jq -r '.portMappings["22"] // empty' 2>/dev/null)"
+        [ -n "$IP" ] && [ -n "$PORT" ] && { log "endpoint root@$IP:$PORT"; break; }
+        sleep 15
+    done
+    [ -n "${IP:-}" ] && [ -n "${PORT:-}" ] || { log "[ERROR] no endpoint after wait"; return 1; }
+    for i in $(seq 1 40); do ssh_vm true 2>/dev/null && return 0; sleep 10; done
+    log "[ERROR] sshd never came up"; return 1
+}
+
+warm() {
+    log "warm: clone $BRANCH + instantiate ($BACKEND depot on the volume ⇒ precompile paid once)"
+    ssh_vm "REPO_URL='$REPO_URL' BRANCH='$BRANCH' BK='$BACKEND' bash -s" <<'WARM'
+set -e
+export JULIA_DEPOT_PATH="/workspace/julia-depot-$BK"          # persists on the network volume
+[ -x "$HOME/.juliaup/bin/julia" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes
+export PATH="$HOME/.juliaup/bin:$PATH" JULIA_PKG_SERVER=""
+rm -rf ~/EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" ~/EDM   # fresh clone = always current
+mkdir -p /workspace/runs && ln -sfn /workspace/runs ~/EDM/runs           # cubes+products on the volume
+printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=/workspace/julia-depot-%s\nREDUCE_OVERLAP=1\n' \
+    "$BK" "$BK" > ~/EDM/orchestration/config.env
+ok=0; for i in 1 2 3; do
+  if julia --startup=no --project=EDM/scripts -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'; then ok=1; break; fi
+  echo "instantiate retry $i"; sleep 20
+done; [ "$ok" = 1 ] || { echo "instantiate failed"; exit 1; }
+WARM
+}
+
+# Is a kept pod still reachable? (lets smoke→real / several campaigns share ONE paid pod.)
+pod_reachable() { [ -f "$STATE" ] && read -r POD IP PORT VOLID BACKEND < "$STATE" && [ -n "${IP:-}" ] && ssh_vm true 2>/dev/null; }
+
+push_orchestration() {   # overlay the driver's orchestration/ (keeping the pod's config.env)
+    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='config.env' "$ORCH/" root@"$IP":EDM/orchestration/
+}
+
+download_verify() {   # md5 each non-cube product pod-vs-local; alert on mismatch/missing
+    local dst=$1 bad=0 vsum fn lsum
+    while read -r vsum fn; do
+        [ -n "$vsum" ] || continue; fn=$(basename "$fn")
+        if [ ! -f "$dst/$fn" ]; then log "[verify] MISSING locally: $fn"; bad=1; continue; fi
+        lsum=$(md5sum "$dst/$fn" | awk '{print $1}')
+        [ "$lsum" = "$vsum" ] || { log "[verify] MD5 MISMATCH: $fn"; bad=1; }
+    done < <(ssh_vm "cd EDM/runs/$CAMPAIGN && md5sum * 2>/dev/null | grep -vE 'field_.*\\.jls'")
+    [ "$bad" -eq 0 ] && { log "[verify] $CAMPAIGN OK (cubes excluded)"; return 0; }
+    notify rotating_light high "EDM download CHECK FAILED" "$CAMPAIGN: md5 mismatch/missing → $dst"; return 1
+}
+
+run_campaign() {
+    local cf="${1:?usage: runpod.sh run <campaign.sh>}" cname; cname=$(basename "$cf")
+    . "$cf"   # CAMPAIGN (product paths); re-read on the pod
+    if pod_reachable; then
+        log "reusing kept pod $POD ($IP:$PORT) from $STATE (no grab/warm)"
+    else
+        trap 'rc=$?; log "FAILED (rc=$rc) before pod handoff"; notify rotating_light urgent "EDM runpod FAILED" "$CAMPAIGN setup errored (rc=$rc); tearing down"; teardown; exit $rc' ERR
+        grab_pod; wait_ready; warm
+        echo "$POD $IP $PORT $VOLID $BACKEND" > "$STATE"
+        trap - ERR    # pod up + warm; a campaign hiccup below must NOT auto-destroy it
+    fi
+    push_orchestration
+    notify hourglass_flowing_sand default "EDM runpod started" "$CAMPAIGN on $POD ($BACKEND @$DC)"
+    log "launching $CAMPAIGN on the pod via the local backend ($BACKEND), detached…"
+    ssh_vm "cd EDM && mkdir -p runs && nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid"
+    log "polling for completion (DONE marker, or driver-death = crash)…"
+    until ssh_vm "grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null"; do
+        if ! ssh_vm "kill -0 \$(cat runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
+            notify rotating_light urgent "EDM runpod CRASH" "$CAMPAIGN driver died with no DONE on $POD — pod KEPT; teardown when done."
+            log "[ERROR] driver gone, no DONE — pod $POD KEPT. tail:"; ssh_vm "tail -n 20 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'; return 1
+        fi
+        sleep 60; ssh_vm "tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'
+    done
+    log "campaign done; downloading reduced products (cubes excluded)…"
+    mkdir -p "$OUT/$CAMPAIGN"
+    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='field_*.jls' root@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
+    download_verify "$OUT/$CAMPAIGN" || log "[verify] issues — products also on the volume at /workspace/runs/$CAMPAIGN"
+    notify white_check_mark default "EDM runpod done" "$CAMPAIGN → $OUT/$CAMPAIGN ; pod $POD KEPT — run teardown."
+    log "products → $OUT/$CAMPAIGN ; pod $POD KEPT (state $STATE). More: $0 run <campaign>. Finish: $0 teardown"
+}
+
+teardown() {   # delete the pod (stops GPU billing); KEEP the volume (depot+cubes persist, ~\$0.07/GB-mo)
+    [ -f "$STATE" ] || { echo "no kept pod recorded in $STATE"; exit 0; }
+    read -r POD IP PORT VOLID BACKEND < "$STATE"
+    /usr/bin/ssh -O exit -o ControlPath="$CM" root@"$IP" 2>/dev/null || true
+    if rp -X DELETE "$API/pods/$POD" >/dev/null 2>&1; then
+        rm -f "$STATE"; log "deleted pod $POD; volume $VOLID KEPT (drain via S3, or delete to stop storage \$)."
+        notify checkered_flag default "EDM runpod torn down" "pod $POD deleted; volume $VOLID kept."
+    else
+        notify rotating_light urgent "EDM teardown FAILED" "DELETE of pod $POD errored — likely STILL billing. Delete in console."
+        log "[ERROR] DELETE of $POD FAILED — likely STILL billing. Delete in console. state kept at $STATE."; exit 1
+    fi
+}
+
+case "$MODE" in
+    run)      shift; run_campaign "${1:-}" ;;
+    teardown) teardown ;;
+    *) echo "usage: $0 run <campaign.sh> | teardown" >&2; exit 64 ;;
+esac

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -180,10 +180,14 @@ run_campaign() {
         fi
         sleep 60; ssh_vm "tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'
     done
-    log "campaign done; downloading reduced products (cubes excluded)…"
-    mkdir -p "$OUT/$CAMPAIGN"
-    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='field_*.jls' root@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
-    download_verify "$OUT/$CAMPAIGN" || log "[verify] issues — products also on the volume at /workspace/runs/$CAMPAIGN"
+    if [ "${RUNPOD_RSYNC_DOWNLOAD:-1}" = 1 ]; then
+        log "campaign done; downloading reduced products via rsync (cubes excluded)…"
+        mkdir -p "$OUT/$CAMPAIGN"
+        /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='field_*.jls' root@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
+        download_verify "$OUT/$CAMPAIGN" || log "[verify] issues — products also on the volume at /workspace/runs/$CAMPAIGN"
+    else
+        log "campaign done; rsync skipped (RUNPOD_RSYNC_DOWNLOAD=0) — drain from the volume later: orchestration/drain.sh $CAMPAIGN"
+    fi
     notify white_check_mark default "EDM runpod done" "$CAMPAIGN → $OUT/$CAMPAIGN ; pod $POD KEPT — run teardown."
     log "products → $OUT/$CAMPAIGN ; pod $POD KEPT (state $STATE). More: $0 run <campaign>. Finish: $0 teardown"
 }

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -1,34 +1,43 @@
 #!/usr/bin/env bash
-# RUNPOD backend — run a campaign on a RunPod cloud GPU (MI300X in EU-RO-1 by default), using a
-# PERSISTENT network volume that outlives the pod: it caches the Julia depot (precompile paid once)
-# and stages cubes/products on S3-drainable storage. Mirrors hotaisle.sh's lifecycle; cell execution,
-# tagging, logging and cube policy all come from the SAME run_cell.sh the pod clones.
+# RUNPOD backend — run a campaign on a RunPod cloud GPU (MI300X in EU-RO-1 by default). Mirrors
+# hotaisle.sh's lifecycle; cell execution, tagging, logging and cube policy all come from the SAME
+# run_cell.sh the pod clones.
 #
-#   bash orchestration/backends/runpod.sh run orchestration/campaigns/<campaign>.sh
-#   bash orchestration/backends/runpod.sh teardown
+#   bash orchestration/backends/runpod.sh run <campaign.sh>      grab pod → warm → run → download
+#   bash orchestration/backends/runpod.sh attach <campaign.sh>   re-attach to a kept pod's campaign
+#                                                                (monitor + download, NO relaunch)
+#   bash orchestration/backends/runpod.sh teardown               delete the kept pod (stops billing)
+#
+# Storage layout (reworked 2026-07-02 — the FUSE network volume is pathological for depots):
+#   • Julia depot → pod-LOCAL disk (/root/julia-depot-$BACKEND), restored from / pushed to a
+#     zstd archive on the VPS (RUNPOD_DEPOT_CACHE, rrsync-jailed) ⇒ warm in minutes, not ~30
+#   • outputs → pod-local EDM/runs by default, rsync'd down when the campaign finishes
+#   • the network volume is OPT-IN (RUNPOD_VOLUME_GB>0): only for campaigns that must persist
+#     cubes past the pod (S3 drain via orchestration/drain.sh); never put a depot on it
 #
 # RunPod specifics (validated 2026-07-01 — see memory runpod-mi300x-backend):
 #   • MI300X is Secure-Cloud/EU-RO-1/intermittent → grab_pod POLLS create-pod until it schedules
 #   • raw rocm/pytorch crash-loops without a start CMD → we inject a dockerStartCmd sshd bootstrap
 #   • Secure Cloud assigns the public IP only once the container is stable → wait_ready polls for it
-#   • depot + outputs live on the network volume (/workspace) → precompile paid once, cubes persist
 #
-# config.env: RUNPOD_DC, RUNPOD_ROCM_IMAGE/RUNPOD_CUDA_IMAGE, RUNPOD_VOLUME_NAME/GB, RUNPOD_REPO_URL/BRANCH.
-# Secrets external: API token ~/.config/runpod/token; ntfy via NTFY_ENV. The pod authorizes
-# $RUNPOD_SSH_PUBKEY (a key you can auth as — e.g. your YubiKey pubkey; ControlMaster ⇒ one touch/run).
+# config.env: RUNPOD_DC, RUNPOD_ROCM_IMAGE/RUNPOD_CUDA_IMAGE, RUNPOD_VOLUME_NAME/GB,
+# RUNPOD_REPO_URL/BRANCH, RUNPOD_DEPOT_CACHE/RUNPOD_DEPOT_KEY. Secrets external: API token at
+# ~/.config/runpod/token; ntfy via NTFY_ENV. The pod authorizes $RUNPOD_SSH_PUBKEY (a key you can
+# auth as — e.g. your YubiKey pubkey; ControlMaster ⇒ one touch/run).
 set -Eeuo pipefail
 ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."; ORCH="$(cd "$ORCH" && pwd)"
 . "$ORCH/run_cell.sh"        # config.env + notify() (notifications fire from THIS driving machine)
 
-MODE="${1:?usage: runpod.sh run <campaign.sh> | teardown}"
+MODE="${1:?usage: runpod.sh run <campaign.sh> | attach <campaign.sh> | teardown}"
 TOK=$(cat "${RUNPOD_TOKEN_FILE:-$HOME/.config/runpod/token}")
 API="https://rest.runpod.io/v1"
 DC="${RUNPOD_DC:-EU-RO-1}"
 ROCM_IMAGE="${RUNPOD_ROCM_IMAGE:-rocm/pytorch@sha256:4449f856653602317e4101a76fce599c7fcd58ccec2e539951fce5f73083179e}"
 CUDA_IMAGE="${RUNPOD_CUDA_IMAGE:-runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404}"
 DISK="${RUNPOD_DISK_GB:-120}"
-VOLNAME="${RUNPOD_VOLUME_NAME:-edm-vol}"; VOLGB="${RUNPOD_VOLUME_GB:-200}"
+VOLNAME="${RUNPOD_VOLUME_NAME:-edm-vol}"; VOLGB="${RUNPOD_VOLUME_GB:-0}"
 REPO_URL="${RUNPOD_REPO_URL:?set RUNPOD_REPO_URL in config.env}"; BRANCH="${RUNPOD_BRANCH:-main}"
+DEPOT_CACHE="${DEPOT_CACHE:-}"; DEPOT_CACHE_KEY="${DEPOT_CACHE_KEY:-$HOME/.config/runpod/depot_key}"   # shared cache (see depot_cache.sh)
 STATE="${RUNPOD_STATE:-$HOME/.config/runpod/campaign_pod}"; OUT="${RUNPOD_OUT:-$HOME/campaign_out}"
 POLL="${RUNPOD_POLL_SEC:-120}"; MAXTRIES="${RUNPOD_MAX_TRIES:-240}"
 PUBKEY="$(cat "${RUNPOD_SSH_PUBKEY:-$HOME/.config/runpod/ssh_pubkey}" 2>/dev/null || ssh-add -L 2>/dev/null | head -1)"
@@ -41,9 +50,10 @@ log()     { echo "[$(date -u +%FT%TZ)] $*"; }
 
 # sshd bootstrap: sshd in the foreground IS the keep-alive; also authorize the injected key.
 # Needed on any image or the container crash-loops (rocm/pytorch's default CMD just exits).
+# rsync + zstd serve the depot cache restore/push and the product download, on ANY base image.
 read -r -d '' START_CMD <<'EOF' || true
 apt-get update -qq
-DEBIAN_FRONTEND=noninteractive apt-get install -y -qq openssh-server
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq openssh-server rsync zstd
 mkdir -p /root/.ssh /run/sshd
 printf '%s\n' "$PUBLIC_KEY" > /root/.ssh/authorized_keys
 chmod 700 /root/.ssh; chmod 600 /root/.ssh/authorized_keys
@@ -52,7 +62,7 @@ exec /usr/sbin/sshd -D -e
 EOF
 
 # gpuTypeId → "backend image": keeps the acquisition policy backend-agnostic. A CUDA fallback needs
-# a CUDA image + cuda backend + its own depot (warm() namespaces JULIA_DEPOT_PATH by $BACKEND).
+# a CUDA image + cuda backend + its own depot archive (warm() keys the cache by $BACKEND).
 gpu_profile() {
     case "$1" in
         "AMD Instinct MI300X OAM")   echo "rocm $ROCM_IMAGE" ;;
@@ -70,8 +80,9 @@ gpu_candidates() {
     echo "NVIDIA B200"               # in-region fallback
 }
 
-ensure_volume() {
-    VOLID="$(rp "$API/networkvolumes" | jq -r --arg n "$VOLNAME" '.[]|select(.name==$n)|.id' | head -1)"
+ensure_volume() {   # opt-in: only called when RUNPOD_VOLUME_GB > 0; must match OUR datacenter
+    VOLID="$(rp "$API/networkvolumes" | jq -r --arg n "$VOLNAME" --arg dc "$DC" \
+        '.[]|select(.name==$n and .dataCenterId==$dc)|.id' | head -1)"
     if [ -n "$VOLID" ] && [ "$VOLID" != null ]; then log "reusing volume $VOLNAME ($VOLID) in $DC"; return 0; fi
     log "creating network volume $VOLNAME ${VOLGB}GB in $DC"
     VOLID="$(rp -X POST "$API/networkvolumes" \
@@ -81,7 +92,11 @@ ensure_volume() {
 
 grab_pod() {
     [ -n "$PUBKEY" ] || { log "[ERROR] no SSH pubkey — set RUNPOD_SSH_PUBKEY"; return 1; }
-    ensure_volume
+    if [ "$VOLGB" -gt 0 ] 2>/dev/null; then
+        ensure_volume
+    else
+        VOLID=""; log "network volume: none (RUNPOD_VOLUME_GB=0) — outputs pod-local, downloaded before teardown"
+    fi
     local -a cands; mapfile -t cands < <(gpu_candidates)
     [ "${#cands[@]}" -gt 0 ] || { log "[ERROR] gpu_candidates returned nothing"; return 1; }
     log "grabbing (poll ${POLL}s ≤$MAXTRIES tries): ${cands[*]}"
@@ -91,12 +106,13 @@ grab_pod() {
             prof="$(gpu_profile "$gpu")"; [ -n "$prof" ] || { log "no profile for '$gpu'"; continue; }
             BACKEND="${prof%% *}"; IMAGE="${prof#* }"
             resp="$(curl -fsS -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" -X POST "$API/pods" \
-                -d "$(jq -n --arg gpu "$gpu" --arg img "$IMAGE" --arg pub "$PUBKEY" --arg vol "$VOLID" \
+                -d "$(jq -n --arg gpu "$gpu" --arg img "$IMAGE" --arg pub "$PUBKEY" --arg vol "${VOLID:-}" \
                         --arg dc "$DC" --arg start "$START_CMD" --argjson disk "$DISK" \
                     '{name:"edm-runpod",imageName:$img,gpuTypeIds:[$gpu],cloudType:"SECURE",gpuCount:1,
-                      containerDiskInGb:$disk,dataCenterIds:[$dc],networkVolumeId:$vol,volumeMountPath:"/workspace",
+                      containerDiskInGb:$disk,dataCenterIds:[$dc],
                       ports:["22/tcp"],supportPublicIp:true,env:{PUBLIC_KEY:$pub},
-                      dockerEntrypoint:["/bin/bash","-c"],dockerStartCmd:[$start]}')" 2>/dev/null)" || resp=""
+                      dockerEntrypoint:["/bin/bash","-c"],dockerStartCmd:[$start]}
+                     + (if $vol != "" then {networkVolumeId:$vol,volumeMountPath:"/workspace"} else {} end)')" 2>/dev/null)" || resp=""
             pid="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null)"
             [ -n "$pid" ] && { POD="$pid"; log "grabbed $gpu → pod $POD ($BACKEND / $IMAGE)"; return 0; }
         done
@@ -121,71 +137,89 @@ wait_ready() {   # public IP + 22 mapping appear only once the container is stab
 }
 
 warm() {
-    log "warm: clone $BRANCH + instantiate ($BACKEND depot on the volume ⇒ precompile paid once)"
-    ssh_vm "REPO_URL='$REPO_URL' BRANCH='$BRANCH' BK='$BACKEND' bash -s" <<'WARM'
+    log "warm: clone $BRANCH + instantiate ($BACKEND depot on pod-local disk; cache: ${DEPOT_CACHE:-none})"
+    if [ -n "$DEPOT_CACHE" ]; then
+        if [ -f "$DEPOT_CACHE_KEY" ]; then   # jailed key — the pod can ONLY rsync inside the archive store
+            ssh_vm 'mkdir -p /root/.ssh && cat > /root/.ssh/depot_key && chmod 600 /root/.ssh/depot_key' < "$DEPOT_CACHE_KEY"
+        else
+            log "[warn] DEPOT_CACHE set but $DEPOT_CACHE_KEY missing — building the depot fresh"
+            DEPOT_CACHE=""
+        fi
+    fi
+    ssh_vm "REPO_URL='$REPO_URL' BRANCH='$BRANCH' BK='$BACKEND' DEPOT_CACHE='$DEPOT_CACHE' HAS_VOL='${VOLID:+1}' bash -s" <<'WARM'
 set -e
-export JULIA_DEPOT_PATH="/workspace/julia-depot-$BK"          # persists on the network volume
+export JULIA_DEPOT_PATH="/root/julia-depot-$BK"   # pod-local NVMe — NEVER the FUSE volume (100k tiny files)
 [ -x "$HOME/.juliaup/bin/julia" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes
 export PATH="$HOME/.juliaup/bin:$PATH"   # no JULIA_PKG_SERVER: fresh pod uses Julia's public default (don't leak the driver's internal one)
 rm -rf ~/EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" ~/EDM   # fresh clone = always current
-mkdir -p /workspace/runs && ln -sfn /workspace/runs ~/EDM/runs           # cubes+products on the volume
-printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=/workspace/julia-depot-%s\nREDUCE_OVERLAP=1\n' \
-    "$BK" "$BK" > ~/EDM/orchestration/config.env
+if [ -n "$HAS_VOL" ]; then mkdir -p /workspace/runs && ln -sfn /workspace/runs ~/EDM/runs   # cubes persist on the volume
+else mkdir -p ~/EDM/runs; fi
+printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=%s\nREDUCE_OVERLAP=1\n' \
+    "$BK" "$JULIA_DEPOT_PATH" > ~/EDM/orchestration/config.env
+REPO_DIR=~/EDM; . ~/EDM/orchestration/depot_cache.sh   # julia-actions/cache semantics over the rsync store
+depot_cache_restore   # → DC_RESTORED = exact | prefix (instantiate tops it up) | miss (fresh build)
 ok=0; for i in 1 2 3; do
   if julia --startup=no --project=EDM/scripts -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()'; then ok=1; break; fi
   echo "instantiate retry $i"; sleep 20
 done; [ "$ok" = 1 ] || { echo "instantiate failed"; exit 1; }
+[ "$DC_RESTORED" = exact ] || depot_cache_push   # exact hit ⇒ the store already has this depot
 WARM
 }
 
 # Is a kept pod still reachable? (lets smoke→real / several campaigns share ONE paid pod.)
-pod_reachable() { [ -f "$STATE" ] && read -r POD IP PORT VOLID BACKEND < "$STATE" && [ -n "${IP:-}" ] && ssh_vm true 2>/dev/null; }
+pod_reachable() {
+    [ -f "$STATE" ] || return 1
+    read -r POD IP PORT VOLID BACKEND < "$STATE" || return 1
+    [ "$VOLID" = "-" ] && VOLID=""
+    [ -n "${IP:-}" ] && [ "$IP" != PENDING ] && ssh_vm true 2>/dev/null
+}
 
 push_orchestration() {   # overlay the driver's orchestration/ (keeping the pod's config.env)
     /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='config.env' "$ORCH/" root@"$IP":EDM/orchestration/
 }
 
-download_verify() {   # md5 each non-cube product pod-vs-local; alert on mismatch/missing
+download_verify() {   # md5 each non-cube product pod-vs-local (subdirs included); alert on mismatch/missing
     local dst=$1 bad=0 vsum fn lsum
     while read -r vsum fn; do
-        [ -n "$vsum" ] || continue; fn=$(basename "$fn")
+        [ -n "$vsum" ] || continue; fn=${fn#./}
         if [ ! -f "$dst/$fn" ]; then log "[verify] MISSING locally: $fn"; bad=1; continue; fi
         lsum=$(md5sum "$dst/$fn" | awk '{print $1}')
         [ "$lsum" = "$vsum" ] || { log "[verify] MD5 MISMATCH: $fn"; bad=1; }
-    done < <(ssh_vm "cd EDM/runs/$CAMPAIGN && md5sum * 2>/dev/null | grep -vE 'field_.*\\.jls'")
+    done < <(ssh_vm "cd EDM/runs/$CAMPAIGN && find . -type f ! -name 'field_*.jls' -exec md5sum {} +")
     [ "$bad" -eq 0 ] && { log "[verify] $CAMPAIGN OK (cubes excluded)"; return 0; }
     notify rotating_light high "EDM download CHECK FAILED" "$CAMPAIGN: md5 mismatch/missing → $dst"; return 1
 }
 
-run_campaign() {
-    local cf="${1:?usage: runpod.sh run <campaign.sh>}" cname; cname=$(basename "$cf")
-    . "$cf"   # CAMPAIGN (product paths); re-read on the pod
-    if pod_reachable; then
-        log "reusing kept pod $POD ($IP:$PORT) from $STATE (no grab/warm)"
-    else
-        trap 'rc=$?; log "FAILED (rc=$rc) before pod handoff"; notify rotating_light urgent "EDM runpod FAILED" "$CAMPAIGN setup errored (rc=$rc); tearing down"; teardown; exit $rc' ERR
-        grab_pod; wait_ready; warm
-        echo "$POD $IP $PORT $VOLID $BACKEND" > "$STATE"
-        trap - ERR    # pod up + warm; a campaign hiccup below must NOT auto-destroy it
-    fi
-    push_orchestration
-    notify hourglass_flowing_sand default "EDM runpod started" "$CAMPAIGN on $POD ($BACKEND @$DC)"
-    log "launching $CAMPAIGN on the pod via the local backend ($BACKEND), detached…"
-    ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && rm -f runs/${CAMPAIGN}.out runs/${CAMPAIGN}.pid && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
-    log "polling for completion (DONE marker, or driver-death = crash)…"
+monitor_and_download() {   # poll for DONE (crash = 3 consecutive dead liveness checks), then download+verify
+    log "polling for completion (DONE marker; crash = 3 consecutive failed liveness checks)…"
+    local misses=0
     until ssh_vm "cd EDM && grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null"; do
-        if ! ssh_vm "cd EDM && kill -0 \$(cat runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
-            ssh_vm "cd EDM && grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null" && break   # finished fast — DONE is present, not a crash
-            notify rotating_light urgent "EDM runpod CRASH" "$CAMPAIGN driver died with no DONE on $POD — pod KEPT; teardown when done."
-            log "[ERROR] driver gone, no DONE — pod $POD KEPT. tail:"; ssh_vm "cd EDM && tail -n 20 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'; return 1
+        if ssh_vm "cd EDM && kill -0 \$(cat runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
+            misses=0
+        else
+            misses=$((misses+1))
+            if [ "$misses" -ge 3 ]; then
+                ssh_vm "cd EDM && grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null" && break   # finished between checks
+                notify rotating_light urgent "EDM runpod CRASH" "$CAMPAIGN driver died with no DONE on $POD — pod KEPT; '$0 attach' to retry or teardown."
+                log "[ERROR] driver gone, no DONE — pod $POD KEPT. tail:"; ssh_vm "cd EDM && tail -n 20 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'; return 1
+            fi
+            log "  liveness check failed ($misses/3) — transient ssh blip or a real crash, retrying…"
         fi
-        sleep 60; ssh_vm "cd EDM && tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'
+        sleep 60; ssh_vm "cd EDM && tail -n1 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /' || true
     done
-    if [ "${RUNPOD_RSYNC_DOWNLOAD:-1}" = 1 ]; then
-        log "campaign done; downloading reduced products via rsync (cubes excluded)…"
+    local dl="${RUNPOD_RSYNC_DOWNLOAD:-1}"
+    if [ "$dl" != 1 ] && [ -z "${VOLID:-}" ]; then
+        log "[warn] RUNPOD_RSYNC_DOWNLOAD=0 but no volume attached — downloading anyway (products would die with the pod)"; dl=1
+    fi
+    if [ "$dl" = 1 ]; then
+        log "campaign done; downloading products via rsync…"
         mkdir -p "$OUT/$CAMPAIGN"
-        /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='field_*.jls' root@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
-        download_verify "$OUT/$CAMPAIGN" || log "[verify] issues — products also on the volume at /workspace/runs/$CAMPAIGN"
+        local -a excl=(--exclude='field_*.jls')
+        if [ "${KEEP_CUBE:-0}" = 1 ] && [ -z "${VOLID:-}" ]; then
+            excl=(); log "  KEEP_CUBE=1 with no volume ⇒ cubes included in the download (bulky!)"
+        fi
+        /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" ${excl[@]+"${excl[@]}"} root@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
+        download_verify "$OUT/$CAMPAIGN" || log "[verify] issues — products still on the pod${VOLID:+ and volume /workspace/runs/$CAMPAIGN}"
     else
         log "campaign done; rsync skipped (RUNPOD_RSYNC_DOWNLOAD=0) — drain from the volume later: orchestration/drain.sh $CAMPAIGN"
     fi
@@ -193,13 +227,54 @@ run_campaign() {
     log "products → $OUT/$CAMPAIGN ; pod $POD KEPT (state $STATE). More: $0 run <campaign>. Finish: $0 teardown"
 }
 
-teardown() {   # delete the pod (stops GPU billing); KEEP the volume (depot+cubes persist, ~\$0.07/GB-mo)
+run_campaign() {
+    local cf="${1:?usage: runpod.sh run <campaign.sh>}" cname; cname=$(basename "$cf")
+    . "$cf"   # CAMPAIGN + KEEP_CUBE (names product paths + sets cube download policy); re-read on the pod
+    if pod_reachable; then
+        log "reusing kept pod $POD ($IP:$PORT) from $STATE (no grab/warm)"
+    else
+        if [ -f "$STATE" ]; then   # unreachable but maybe still billing — never silently orphan it
+            read -r POD _ < "$STATE"
+            if rp "$API/pods/$POD" >/dev/null 2>&1; then
+                log "[ERROR] kept pod $POD ($STATE) still EXISTS but is unreachable — investigate or '$0 teardown' first."; exit 1
+            fi
+            log "stale state: pod $POD is gone — clearing $STATE"; rm -f "$STATE"
+        fi
+        trap 'rc=$?; log "FAILED (rc=$rc) before campaign launch"; notify rotating_light urgent "EDM runpod FAILED" "$CAMPAIGN setup errored (rc=$rc); tearing down"; teardown; exit $rc' ERR
+        grab_pod
+        echo "$POD PENDING 0 ${VOLID:--} $BACKEND" > "$STATE"   # pod bills from NOW — record it before anything can fail
+        wait_ready
+        echo "$POD $IP $PORT ${VOLID:--} $BACKEND" > "$STATE"
+        warm
+        trap - ERR    # pod up + warm; a campaign hiccup below must NOT auto-destroy it
+    fi
+    push_orchestration
+    if ssh_vm "cd EDM && grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null"; then
+        log "$CAMPAIGN already DONE on the pod — skipping launch (rm runs/${CAMPAIGN}.out on the pod to force a rerun)"
+    elif ssh_vm "cd EDM && kill -0 \$(cat runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
+        log "$CAMPAIGN already RUNNING on the pod — monitoring it (no relaunch)"
+    else
+        notify hourglass_flowing_sand default "EDM runpod started" "$CAMPAIGN on $POD ($BACKEND @$DC)"
+        log "launching $CAMPAIGN on the pod via the local backend ($BACKEND), detached…"
+        ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && rm -f runs/${CAMPAIGN}.out runs/${CAMPAIGN}.pid && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
+    fi
+    monitor_and_download
+}
+
+attach_campaign() {   # resume monitoring+download after a driver-side interruption — never relaunches
+    local cf="${1:?usage: runpod.sh attach <campaign.sh>}"; . "$cf"
+    pod_reachable || { log "[ERROR] no reachable kept pod ($STATE)"; exit 1; }
+    log "attached to kept pod $POD ($IP:$PORT) for $CAMPAIGN"
+    monitor_and_download
+}
+
+teardown() {   # delete the pod (stops GPU billing); a volume, if attached, is KEPT (bills ~\$0.07/GB-mo)
     [ -f "$STATE" ] || { echo "no kept pod recorded in $STATE"; exit 0; }
-    read -r POD IP PORT VOLID BACKEND < "$STATE"
+    read -r POD IP PORT VOLID BACKEND < "$STATE"; [ "$VOLID" = "-" ] && VOLID=""
     /usr/bin/ssh -O exit -o ControlPath="$CM" root@"$IP" 2>/dev/null || true
     if rp -X DELETE "$API/pods/$POD" >/dev/null 2>&1; then
-        rm -f "$STATE"; log "deleted pod $POD; volume $VOLID KEPT (drain via S3, or delete to stop storage \$)."
-        notify checkered_flag default "EDM runpod torn down" "pod $POD deleted; volume $VOLID kept."
+        rm -f "$STATE"; log "deleted pod $POD${VOLID:+; volume $VOLID KEPT (drain via S3, then delete to stop storage \$)}"
+        notify checkered_flag default "EDM runpod torn down" "pod $POD deleted${VOLID:+; volume $VOLID kept}."
     else
         notify rotating_light urgent "EDM teardown FAILED" "DELETE of pod $POD errored — likely STILL billing. Delete in console."
         log "[ERROR] DELETE of $POD FAILED — likely STILL billing. Delete in console. state kept at $STATE."; exit 1
@@ -208,6 +283,7 @@ teardown() {   # delete the pod (stops GPU billing); KEEP the volume (depot+cube
 
 case "$MODE" in
     run)      shift; run_campaign "${1:-}" ;;
+    attach)   shift; attach_campaign "${1:-}" ;;
     teardown) teardown ;;
-    *) echo "usage: $0 run <campaign.sh> | teardown" >&2; exit 64 ;;
+    *) echo "usage: $0 run <campaign.sh> | attach <campaign.sh> | teardown" >&2; exit 64 ;;
 esac

--- a/orchestration/campaigns/linpol_maps_N10k_Nx400.sh
+++ b/orchestration/campaigns/linpol_maps_N10k_Nx400.sh
@@ -1,0 +1,18 @@
+# campaigns/linpol_maps_N10k_Nx400.sh — hi-res linear-pol harmonic maps: EDM_NX=400 (vs 200 in
+# linpol_maps_N5k) and N_electrons=10000 (vs 5000). Nx doubles → ~4× the field-accumulation work;
+# N doubles → ~2× → ~8× the per-cell cost of linpol_maps_N5k. Bump EDM_N to 15000 for a ~1.22× lower
+# shot-noise floor (√N) at ~1.5× the cost. Same physics as N5k (linear pol, φ0=-π/2, uniform saveat).
+CAMPAIGN=linpol_maps_N10k_Nx400
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=400 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=10000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
+  EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
+  EDM_POL=linear                       # linear polarization (ξ = (1,0))
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+)
+CELLS=(
+  "a1em5|EDM_A0=1e-5"
+  "a1em3|EDM_A0=1e-3"
+  "a1e1|EDM_A0=0.1"
+)

--- a/orchestration/config.env.example
+++ b/orchestration/config.env.example
@@ -31,18 +31,27 @@ HOTAISLE_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git 
 HOTAISLE_BRANCH=main
 # token lives at ~/.config/hotaisle/token  (NOT here)
 
-# ── RunPod backend (cloud MI300X / CUDA, persistent network volume) ──────────
+# ── RunPod backend (cloud MI300X / CUDA) ─────────────────────────────────────
 RUNPOD_DC=EU-RO-1                   # datacenter (only RO DC; supports network volumes; MI300X lands here)
-RUNPOD_VOLUME_NAME=edm-vol         # network volume (holds the depot cache + cube/product staging)
-RUNPOD_VOLUME_GB=200               # sized for peak cubes in flight (volumes GROW-not-shrink; bill even stopped)
 RUNPOD_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git   # PUBLIC clone URL
 RUNPOD_BRANCH=main
 RUNPOD_SSH_PUBKEY="${HOME}/.config/runpod/ssh_pubkey"
 # RUNPOD_ROCM_IMAGE / RUNPOD_CUDA_IMAGE override the pinned defaults; token lives at ~/.config/runpod/token
+# Network volume — OPT-IN, for cube persistence past the pod (S3 drain). NOT for the depot (FUSE
+# is pathological for many tiny files). Volumes GROW-not-shrink and bill (~$0.07/GB-mo) even idle.
+RUNPOD_VOLUME_GB=0                 # 0 (default) = no volume: outputs pod-local + rsync'd down before teardown
+RUNPOD_VOLUME_NAME=edm-vol         # volume to reuse/create when RUNPOD_VOLUME_GB > 0
 # S3 drain (drain.sh — runs from any box with the [runpod] awscli profile; no API token needed):
 RUNPOD_S3_PROFILE=runpod           # aws profile in ~/.aws/credentials used by drain.sh
 # RUNPOD_VOLUME_ID=                 # drain.sh auto-resolves when exactly one volume exists; set to disambiguate
-RUNPOD_RSYNC_DOWNLOAD=1            # runpod.sh: 1=rsync products off the live pod; 0=defer to drain.sh
+RUNPOD_RSYNC_DOWNLOAD=1            # runpod.sh: 1=rsync products off the live pod; 0=defer to drain.sh (needs a volume)
+
+# ── depot warm-cache (shared by ALL cloud backends; see orchestration/depot_cache.sh) ──────────
+# VMs restore the Julia depot from / push it to an rrsync-jailed rsync-over-ssh archive store with
+# julia-actions/cache semantics (key = backend+julia+CPU+Manifest hash, prefix fallback), instead
+# of rebuilding (~10-30 min) on every fresh VM.
+DEPOT_CACHE=                       # user@host of the jailed store account (empty = build depot fresh each VM)
+DEPOT_CACHE_KEY="${HOME}/.config/runpod/depot_key"   # its private key (scp'd to the VM; can ONLY rsync the jail)
 
 # ── notifications (optional; secrets external) ───────────────────────────────
 # Sourced for NTFY_URL / NTFY_TOKEN / NTFY_CERT / NTFY_KEY (mTLS-gated, so the URL alone is inert).

--- a/orchestration/config.env.example
+++ b/orchestration/config.env.example
@@ -39,7 +39,10 @@ RUNPOD_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git   
 RUNPOD_BRANCH=main
 RUNPOD_SSH_PUBKEY="${HOME}/.config/runpod/ssh_pubkey"
 # RUNPOD_ROCM_IMAGE / RUNPOD_CUDA_IMAGE override the pinned defaults; token lives at ~/.config/runpod/token
-# S3 drain (post-teardown, from the volume): awscli [runpod] profile + https://s3api-eu-ro-1.runpod.io/
+# S3 drain (drain.sh — runs from any box with the [runpod] awscli profile; no API token needed):
+RUNPOD_S3_PROFILE=runpod           # aws profile in ~/.aws/credentials used by drain.sh
+# RUNPOD_VOLUME_ID=                 # drain.sh auto-resolves when exactly one volume exists; set to disambiguate
+RUNPOD_RSYNC_DOWNLOAD=1            # runpod.sh: 1=rsync products off the live pod; 0=defer to drain.sh
 
 # ── notifications (optional; secrets external) ───────────────────────────────
 # Sourced for NTFY_URL / NTFY_TOKEN / NTFY_CERT / NTFY_KEY (mTLS-gated, so the URL alone is inert).

--- a/orchestration/config.env.example
+++ b/orchestration/config.env.example
@@ -31,6 +31,16 @@ HOTAISLE_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git 
 HOTAISLE_BRANCH=main
 # token lives at ~/.config/hotaisle/token  (NOT here)
 
+# ── RunPod backend (cloud MI300X / CUDA, persistent network volume) ──────────
+RUNPOD_DC=EU-RO-1                   # datacenter (only RO DC; supports network volumes; MI300X lands here)
+RUNPOD_VOLUME_NAME=edm-vol         # network volume (holds the depot cache + cube/product staging)
+RUNPOD_VOLUME_GB=200               # sized for peak cubes in flight (volumes GROW-not-shrink; bill even stopped)
+RUNPOD_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git   # PUBLIC clone URL
+RUNPOD_BRANCH=main
+RUNPOD_SSH_PUBKEY="${HOME}/.config/runpod/ssh_pubkey"
+# RUNPOD_ROCM_IMAGE / RUNPOD_CUDA_IMAGE override the pinned defaults; token lives at ~/.config/runpod/token
+# S3 drain (post-teardown, from the volume): awscli [runpod] profile + https://s3api-eu-ro-1.runpod.io/
+
 # ── notifications (optional; secrets external) ───────────────────────────────
 # Sourced for NTFY_URL / NTFY_TOKEN / NTFY_CERT / NTFY_KEY (mTLS-gated, so the URL alone is inert).
 NTFY_ENV="${HOME}/.config/ntfy/edm-campaigns.env"

--- a/orchestration/depot_cache.sh
+++ b/orchestration/depot_cache.sh
@@ -1,0 +1,80 @@
+# depot_cache.sh — warm-start the Julia depot on a cloud VM from an rsync-jailed archive store,
+# with julia-actions/cache semantics (github.com/julia-actions/cache), which we mirror because a
+# VM has no Actions cache service:
+#   • archives hold the depot SUBDIRS worth caching: packages artifacts compiled registries
+#     scratchspaces (never logs/clones/juliaup — same pick as julia-actions/cache)
+#   • the cache key IS the filename: depot-<backend>-<julia version>-<Sys.CPU_NAME>-m<manifest8>.tar.zst
+#     CPU name is in the key because pkgimages compile for the host microarch — Hot Aisle bare-metal
+#     and RunPod SR-IOV pods only share caches when their CPUs actually match.
+#   • restore-keys fallback: exact key → else NEWEST archive on the same prefix (instantiate then
+#     tops it up) → else fresh build. Push back ONLY when the exact key was absent, so a Manifest
+#     or Julia bump uploads once (from the VM that re-precompiled) and steady-state runs upload nothing.
+#
+# Sourced ON THE VM (inside a backend's warm heredoc), after julia is on PATH and the repo is cloned.
+# Env in:  DEPOT_CACHE          user@host of the jailed store (empty ⇒ every call is a no-op/miss)
+#          DEPOT_CACHE_KEYFILE  private key on the VM (default ~/.ssh/depot_key; jailed to the store)
+#          BK                   backend slug (rocm|cuda) — namespaces the archives
+#          REPO_DIR             repo checkout (for the pinned scripts/Manifest*.toml hash)
+#          JULIA_DEPOT_PATH     optional (default ~/.julia)
+# Usage:   depot_cache_restore   → sets DC_RESTORED=exact|prefix|miss (+ DC_EXACT/DC_PREFIX)
+#          depot_cache_push      → archives the depot under $DC_EXACT (call when DC_RESTORED != exact)
+# Degrades gracefully: missing rsync/zstd or an unreachable store ⇒ miss + skipped push (warn only).
+
+_dc_depot() { echo "${JULIA_DEPOT_PATH:-$HOME/.julia}"; }
+_dc_ssh()   { echo "ssh -i ${DEPOT_CACHE_KEYFILE:-$HOME/.ssh/depot_key} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o BatchMode=yes"; }
+_dc_ok()    {
+    [ -n "${DEPOT_CACHE:-}" ] || return 1
+    command -v rsync >/dev/null && command -v zstd >/dev/null && return 0
+    echo "[depot-cache] rsync/zstd missing — cache disabled this run" >&2; return 1
+}
+
+depot_cache_key() {   # sets DC_PREFIX + DC_EXACT from julia version, CPU microarch, Manifest hash
+    local jv cpu mh
+    jv=$(julia --version | awk '{print $3}')
+    cpu=$(julia --startup=no -e 'print(Sys.CPU_NAME)')
+    mh=$(cat "${REPO_DIR:?}"/scripts/Manifest*.toml 2>/dev/null | sha256sum | cut -c1-8)
+    DC_PREFIX="depot-${BK:?}-$jv-$cpu"
+    DC_EXACT="$DC_PREFIX-m$mh"
+}
+
+depot_cache_restore() {
+    DC_RESTORED=miss
+    _dc_ok || return 0
+    depot_cache_key
+    # rsync --list-only columns: perms size date time name; keep "date time name" sortable by mtime
+    local list best t0
+    list=$(rsync --list-only -e "$(_dc_ssh)" "$DEPOT_CACHE:" 2>/dev/null | awk '$1 ~ /^-/ {print $3, $4, $5}') || list=""
+    if echo "$list" | grep -q " $DC_EXACT\.tar\.zst\$"; then
+        best="$DC_EXACT.tar.zst"; DC_RESTORED=exact
+    else
+        best=$(echo "$list" | grep " $DC_PREFIX-m[0-9a-f]*\.tar\.zst\$" | sort | tail -1 | awk '{print $3}')
+        [ -n "$best" ] && DC_RESTORED=prefix
+    fi
+    [ -n "$best" ] || { echo "[depot-cache] MISS ($DC_EXACT)"; return 0; }
+    t0=$SECONDS
+    if rsync --partial -e "$(_dc_ssh)" "$DEPOT_CACHE:$best" /tmp/dc_restore.tar.zst 2>/dev/null; then
+        mkdir -p "$(_dc_depot)"
+        zstd -dc /tmp/dc_restore.tar.zst | tar -x -C "$(_dc_depot)"
+        rm -f /tmp/dc_restore.tar.zst
+        echo "[depot-cache] $DC_RESTORED HIT: $best restored in $((SECONDS-t0))s"
+    else
+        DC_RESTORED=miss; echo "[depot-cache] MISS (download of $best failed)"
+    fi
+}
+
+depot_cache_push() {
+    _dc_ok || return 0
+    [ -n "${DC_EXACT:-}" ] || depot_cache_key
+    local d dirs=() t0=$SECONDS
+    for d in packages artifacts compiled registries scratchspaces; do
+        if [ -d "$(_dc_depot)/$d" ]; then dirs+=("$d"); fi
+    done
+    [ "${#dirs[@]}" -gt 0 ] || { echo "[depot-cache] nothing to push (empty depot?)" >&2; return 0; }
+    tar -C "$(_dc_depot)" -cf - "${dirs[@]}" | zstd -T0 -3 > "/tmp/$DC_EXACT.tar.zst"
+    if rsync --partial -e "$(_dc_ssh)" "/tmp/$DC_EXACT.tar.zst" "$DEPOT_CACHE:"; then
+        echo "[depot-cache] PUSHED $DC_EXACT.tar.zst ($(du -h "/tmp/$DC_EXACT.tar.zst" | cut -f1)) in $((SECONDS-t0))s"
+    else
+        echo "[depot-cache] push failed — run continues (a future VM rebuilds)" >&2
+    fi
+    rm -f "/tmp/$DC_EXACT.tar.zst"
+}

--- a/orchestration/drain.sh
+++ b/orchestration/drain.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# DRAIN — pull a campaign's reduced products (and optionally the big field cubes) from a RunPod
+# network VOLUME to THIS machine over the S3 API. Data-plane only: needs the [runpod] S3 profile in
+# ~/.aws + awscli — NOT the RunPod API token, a pod, or SSH — so it runs from ANY configured box
+# (poincare / workstation / VPS). The volume persists after teardown, so drain any time, repeatedly.
+#
+#   bash orchestration/drain.sh <campaign> [dest] [--cubes]
+#     --cubes   also download field_*.jls cubes (present only if the run used KEEP_CUBE=1)
+#
+# config.env: RUNPOD_DC (→ S3 endpoint), RUNPOD_VOLUME_ID (optional; auto-resolved if exactly one),
+#             RUNPOD_S3_PROFILE (default 'runpod'), RUNPOD_OUT (default dest). Creds: ~/.aws/credentials.
+# NOTE: use s3api get-object, not `aws s3 cp` — the latter's HeadObject precheck 403s on RunPod's S3.
+set -Eeuo pipefail
+ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$ORCH/config.env" ] && . "$ORCH/config.env"
+
+CAMPAIGN="${1:?usage: drain.sh <campaign> [dest] [--cubes]}"; shift
+DEST="${RUNPOD_OUT:-$HOME/campaign_out}"; CUBES=0
+for a in "$@"; do case "$a" in --cubes|--all) CUBES=1 ;; *) DEST="$a" ;; esac; done
+
+DC="${RUNPOD_DC:-EU-RO-1}"
+ENDPOINT="https://s3api-${DC,,}.runpod.io/"
+PROFILE="${RUNPOD_S3_PROFILE:-runpod}"
+AWS="${AWS_BIN:-aws}"; command -v "$AWS" >/dev/null 2>&1 || AWS="$HOME/.venvs/awscli/bin/aws"
+S3() { "$AWS" --profile "$PROFILE" --region "$DC" --endpoint-url "$ENDPOINT" "$@"; }
+
+# Volume id: explicit config wins; else auto-resolve via ListBuckets (bucket name == volume id).
+VOL="${RUNPOD_VOLUME_ID:-}"
+if [ -z "$VOL" ]; then
+    mapfile -t _v < <(S3 s3api list-buckets --query 'Buckets[].Name' --output text 2>/dev/null | tr '\t' '\n' | sed '/^$/d')
+    case "${#_v[@]}" in
+        1) VOL="${_v[0]}"; echo "[drain] auto-resolved volume: $VOL" ;;
+        0) echo "[drain] no volume auto-found (ListBuckets empty/unsupported) — set RUNPOD_VOLUME_ID" >&2; exit 1 ;;
+        *) echo "[drain] ${#_v[@]} volumes — set RUNPOD_VOLUME_ID to pick one: ${_v[*]}" >&2; exit 1 ;;
+    esac
+fi
+
+PREFIX="runs/$CAMPAIGN/"
+echo "[drain] s3://$VOL/$PREFIX → $DEST/$CAMPAIGN  (cubes=$CUBES, $ENDPOINT)"
+mkdir -p "$DEST/$CAMPAIGN"; got=0
+while read -r key; do
+    [ -n "$key" ] || continue
+    rel="${key#"$PREFIX"}"
+    [ "$CUBES" -eq 1 ] || case "$(basename "$rel")" in field_*.jls) continue ;; esac
+    mkdir -p "$DEST/$CAMPAIGN/$(dirname "$rel")"
+    echo "  ← $rel"
+    S3 s3api get-object --bucket "$VOL" --key "$key" "$DEST/$CAMPAIGN/$rel" >/dev/null && got=$((got+1))
+done < <(S3 s3 ls "s3://$VOL/$PREFIX" --recursive | awk '{print $4}')
+echo "[drain] done: $got file(s) → $DEST/$CAMPAIGN"

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -62,12 +62,12 @@ notify() {   # notify <tags> <priority> <title> <message>  — no-op unless NTFY
 # <uuid>.reduce_failed marker that reap_reduces waits on. Override with REDUCE_HOOK for a custom reducer.
 _reduce_cell() {
     local uuid=$1 manifest="$CAMP/run_${uuid}.toml" cube rc=0
-    ( cd "$REPO" && "${JL[@]}" --project=scripts scripts/harmonic_products.jl "$manifest" ) \
+    ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} "${JL[@]}" --project=scripts scripts/harmonic_products.jl "$manifest" ) \
         >> "$CAMP/run_${uuid}.log" 2>&1 || rc=1
     if [ "$rc" -eq 0 ]; then
         for cube in "$CAMP"/field_*_"$uuid".jls; do
             [ -e "$cube" ] || continue
-            ( cd "$REPO" && "${JL[@]}" --project=scripts scripts/plot_screen_observables.jl "$cube" ) \
+            ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} "${JL[@]}" --project=scripts scripts/plot_screen_observables.jl "$cube" ) \
                 >> "$CAMP/run_${uuid}.log" 2>&1 || rc=1
         done
     fi
@@ -76,7 +76,7 @@ _reduce_cell() {
 
 run_cell() {
     local label=$1; shift
-    local uuid; uuid=$(uuidgen)
+    local uuid; uuid=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
     mkdir -p "$CAMP"
     [ -f "$CAMP/cells.tsv" ] || printf 'label\tuuid\tscript\tbackend\toverrides\n' > "$CAMP/cells.tsv"
     printf '%s\t%s\t%s\t%s\t%s\n' "$label" "$uuid" "$(basename "$SCRIPT")" "${BACKEND:-?}" "$*" >> "$CAMP/cells.tsv"


### PR DESCRIPTION
Adds a RunPod cloud backend to the orchestration framework, mirroring the Hot Aisle backend's lifecycle but leveraging RunPod's persistent network storage.

**`orchestration/backends/runpod.sh`** — provision → warm → run (via the shared local backend) → download → teardown for RunPod GPUs:
- poll-to-grab `create-pod` (policy: MI300X → B200, EU-RO-1) — a successful create *is* the grab, since MI300X capacity is intermittent
- `dockerStartCmd` sshd bootstrap (raw `rocm/pytorch` crash-loops without a foreground CMD)
- a persistent **network volume** mounted at `/workspace`, caching a per-backend Julia depot (`julia-depot-$BACKEND`, precompile paid once) and staging cubes/products
- rsync+md5 download, gated by `RUNPOD_RSYNC_DOWNLOAD`

**`orchestration/drain.sh`** — standalone S3 drain from the persistent volume, runnable from any box with the `[runpod]` awscli profile (no API token / pod / SSH). `--cubes` also pulls `field_*.jls` for issaf-style persistence.

`config.env.example` gains the `RUNPOD_*` section.

**Status:** the MI300X path is validated component-by-component (grab, sshd bootstrap, AMDGPU on gfx942 @ ROCm 7.2.4, S3 round-trip). The end-to-end run and the B200/CUDA fallback path have not yet been exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)