### PR TITLE
telemetry: sample GPU power/util in a child process

### DIFF
--- a/ext/EDMAMDGPUExt.jl
+++ b/ext/EDMAMDGPUExt.jl
@@ -49,18 +49,38 @@ function _amd_device_sysfs(dev = AMDGPU.device())
     error("gpu telemetry: no /sys/class/drm card matches PCI $pci")
 end
 
-function EDM.gpu_power(::ROCBackend)
-    dev = _amd_device_sysfs()
+# The hwmon power file under a card's sysfs dir: `power1_average` where the driver provides
+# it (most dGPUs), else the instantaneous `power1_input`. Reports µW.
+function _amd_power_file(card::AbstractString)
     hw = first(filter(d -> startswith(basename(d), "hwmon"),
-        readdir(joinpath(dev, "hwmon"); join = true)))
+        readdir(joinpath(card, "hwmon"); join = true)))
     f = isfile(joinpath(hw, "power1_average")) ? "power1_average" : "power1_input"
-    return parse(Int, strip(read(joinpath(hw, f), String))) / 1.0e6   # µW → W
+    return joinpath(hw, f)
 end
+
+EDM.gpu_power(::ROCBackend) =
+    parse(Int, strip(read(_amd_power_file(_amd_device_sysfs()), String))) / 1.0e6   # µW → W
 
 function EDM.gpu_utilization(::ROCBackend)
     dev = _amd_device_sysfs()
     rd(f) = isfile(joinpath(dev, f)) ? parse(Int, strip(read(joinpath(dev, f), String))) / 100 : NaN
     return (compute = rd("gpu_busy_percent"), memory = rd("mem_busy_percent"))
+end
+
+# Telemetry child: HIP is touched only HERE to resolve each device's sysfs paths once; the
+# spawned scripts/gputrace.sh then reads the amdgpu driver's counters (VRAM included, via
+# `mem_info_vram_used` — no hipMemGetInfo) from its own process, immune to the solver's HIP
+# locks and Julia's GC/timer coupling. Sysfs paths contain no ':' so the devspec join is safe.
+function EDM.gpu_telemetry_child_cmd(::ROCBackend, device_ids::AbstractVector{<:Integer},
+        dt::Real, stopfile::AbstractString)
+    script = joinpath(pkgdir(EDM), "scripts", "gputrace.sh")
+    specs = map(device_ids) do i
+        card = _amd_device_sysfs(AMDGPU.devices()[i])
+        mb = joinpath(card, "mem_busy_percent")   # absent on some devices (e.g. iGPUs) → nan
+        join([string(i), _amd_power_file(card), joinpath(card, "gpu_busy_percent"),
+            isfile(mb) ? mb : "-", joinpath(card, "mem_info_vram_used")], ":")
+    end
+    return `sh $script $dt $(getpid()) $stopfile $specs`
 end
 
 end

--- a/ext/EDMCUDAExt.jl
+++ b/ext/EDMCUDAExt.jl
@@ -29,4 +29,16 @@ EDM.gpu_sm_count(::CUDABackend) =
 EDM.gpu_max_threads_per_sm(::CUDABackend) =
     CUDA.attribute(CUDA.device(), CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR)
 
+# Telemetry child: the CUDA runtime is touched only HERE to map our ordinals to NVML uuids
+# (stable under CUDA_VISIBLE_DEVICES); the spawned scripts/gputrace_cuda.sh then runs one
+# `nvidia-smi -lms` daemon per device from its own process, immune to the solver's CUDA
+# locks and Julia's GC/timer coupling.
+function EDM.gpu_telemetry_child_cmd(::CUDABackend, device_ids::AbstractVector{<:Integer},
+        dt::Real, stopfile::AbstractString)
+    script = joinpath(pkgdir(EDM), "scripts", "gputrace_cuda.sh")
+    cudevs = collect(CUDA.devices())
+    specs = ["GPU-$(CUDA.uuid(cudevs[i]))=$i" for i in device_ids]
+    return `sh $script $(round(Int, 1000 * dt)) $(getpid()) $stopfile $specs`
+end
+
 end

--- a/scripts/gpu_telemetry.jl
+++ b/scripts/gpu_telemetry.jl
@@ -1,42 +1,95 @@
-# GPU telemetry for the solver manifests' [gpu] section — shared by thomson_scattering.jl + lpwa.jl.
-# A static device snapshot (name, SMs, capacity, VRAM, thread-fill occupancy) plus a sampler that
-# records power / compute-util / mem-util / VRAM over the accumulate_field window on a spawned
-# thread. Uses the vendor-agnostic gpu_api (CUDA=NVML, AMD=sysfs), which the scripts already
-# `using`. Everything is wrapped so a telemetry hiccup NEVER breaks a run — it just omits the section.
+# GPU telemetry for the solver manifests' [gpu] section — shared by thomson_scattering.jl,
+# lpwa.jl and occupancy_bench.jl. A static device snapshot (name, SMs, capacity, VRAM,
+# thread-fill occupancy) plus a sampler that records power / compute-util / mem-util / VRAM
+# per device over the accumulate_field window and streams the time series to a gputrace TSV.
+# Everything is wrapped so a telemetry hiccup NEVER breaks a run — it just omits the section.
+#
+# The sampler is a CHILD PROCESS (gpu_telemetry_child_cmd → scripts/gputrace{,_cuda}.sh), not
+# a Julia task. Two in-process designs failed on the production W7900 host:
+#   * ticking through the vendor runtime (hipGetDeviceProperties/hipMemGetInfo) wedges behind
+#     a kernel stream backed up with queued launches — hour-long runs recorded samples=2
+#     (spawn + teardown) and all-zero utilization stats;
+#   * even a runtime-free sysfs tick is suspended wholesale: Julia's GC/libuv-timer coupling
+#     stops sleeping tasks while the host thread allocates (0 ticks/15 s under pure-CPU alloc
+#     churn regardless of thread count; 1 tick/98.5 s over a real accumulate_field window).
+# The child shares nothing with this process, so neither failure mode applies. It appends
+# rows to the TSV as it samples (the trace survives a mid-run crash) and stops cooperatively
+# when a stopfile appears — or on its own if this process dies, so it cannot be orphaned.
 
-# Run `f()` while a background task samples the CURRENT device every `dt` seconds. Returns
-# (result_of_f, samples::Vector{NTuple{4,Float64}} = (power_W, compute_util, mem_util, vram_used_B)).
-# `f` is FIRST so the do-block form works: `with_gpu_sampler(backend, dt) do … end` (Julia prepends
-# the closure). The sampler is the sole writer and the caller reads `samples` only after wait() ⇒ no
-# data race. Needs ≥2 Julia threads or the sampler starves behind the field kernel (caller should warn).
-function with_gpu_sampler(f, backend, dt::Real)
-    running = Threads.Atomic{Bool}(true)
-    samples = NTuple{4, Float64}[]
-    sampler = Threads.@spawn begin
-        while running[]
-            try
-                u = gpu_utilization(backend)
-                m = gpu_memory_info(backend)
-                push!(samples, (gpu_power(backend), Float64(u.compute), Float64(u.memory), Float64(m.used)))
-            catch
-                # transient telemetry read failure — drop this sample, keep sampling
-            end
-            sleep(dt)
-        end
+# Run `f()` while a child process samples `devices` (1-based vendor ids) every `dt` seconds.
+# `f` is FIRST so the do-block form works: `with_gpu_sampler(backend, dt; kw...) do … end`.
+# Without `tracefile`, samples go to a temp file that is deleted after parsing.
+# Returns (result_of_f, telemetry) with telemetry a NamedTuple:
+#   samples :: Vector{NTuple{6,Float64}} — rows (t_rel_s, device, power_W, compute_util, mem_util, vram_used_B)
+#   ticks   :: Int                       — sample rounds (= rows of the first device)
+#   dt, window :: Float64                — requested cadence / sampled window, seconds
+#   starved :: Bool                      — ticks ≪ window/dt ⇒ stats unreliable (also @warn'ed)
+#   trace   :: Union{String,Nothing}     — the TSV (absolute epoch timestamps), or nothing
+function with_gpu_sampler(f, backend, dt::Real;
+        devices::AbstractVector{<:Integer} = 1:1, tracefile::Union{String, Nothing} = nothing)
+    trace = something(tracefile, tempname() * ".tsv")
+    stopfile = trace * ".stop"
+    t0 = time()
+    child = try
+        cmd = gpu_telemetry_child_cmd(backend, devices, dt, stopfile)
+        open(io -> println(io, "# epoch_s\tdevice\tpower_W\tcompute_util\tmem_util\tvram_used_B"),
+            trace, "w")
+        # append applies to every file redirect in one pipeline() call, so silence stderr in an
+        # inner pipeline and append stdout to the trace in the outer one.
+        run(pipeline(pipeline(cmd; stderr = devnull); stdout = trace, append = true); wait = false)
+    catch err
+        @warn "GPU telemetry unavailable — running without the sampler" exception = err
+        nothing
     end
-    result = f()
-    running[] = false
-    wait(sampler)
-    return result, samples
+    if child === nothing
+        return f(), (samples = NTuple{6, Float64}[], ticks = 0, dt = Float64(dt),
+            window = 0.0, starved = false, trace = nothing)
+    end
+
+    local result
+    try
+        result = f()
+    finally
+        touch(stopfile)
+        deadline = time() + 2 + 2dt   # child polls the stopfile once per tick
+        while process_running(child) && time() < deadline
+            sleep(0.1)
+        end
+        process_running(child) && kill(child)
+        wait(child)
+        rm(stopfile; force = true)
+    end
+    window = time() - t0
+
+    samples = NTuple{6, Float64}[]
+    for line in eachline(trace)
+        startswith(line, '#') && continue
+        parts = split(line, '\t')
+        length(parts) == 6 || continue
+        vals = map(x -> tryparse(Float64, x), parts)
+        any(isnothing, vals) && continue
+        push!(samples, (vals[1] - t0, vals[2], vals[3], vals[4], vals[5], vals[6]))
+    end
+    tracefile === nothing && rm(trace; force = true)
+
+    ticks = isempty(samples) ? 0 : count(s -> s[2] == samples[1][2], samples)
+    # Watchdog: the out-of-process child should make starvation impossible — but if it ever
+    # recurs, say so loudly and mark the manifest instead of shipping silent zeros again.
+    starved = window > 10 * dt && ticks < 0.5 * window / dt
+    starved &&
+        @warn "GPU telemetry sampler starved: $ticks ticks over $(round(window; digits = 1)) s at dt=$(dt) s — [gpu] sample stats are unreliable"
+    return result, (samples = samples, ticks = ticks, dt = Float64(dt), window = window,
+        starved = starved, trace = tracefile)
 end
 
-# Static device snapshot + reduced sampler stats → the manifest's [gpu] table (a plain Dict that
-# RunManifests writes verbatim as a top-level section). `n_threads` = the pixel-parallel launch size
-# (Nx·Ny) for thread-fill occupancy. In a sharded (device_count>1) run the sampler sees only its own
-# current device; the static props are per-device (identical hardware) and device_count records the fan-out.
-# Returns `nothing` if telemetry is unavailable (e.g. no vendor extension) so the caller just omits [gpu].
+# Static device snapshot + reduced sampler stats → the manifest's [gpu] table (a plain Dict
+# that RunManifests writes verbatim as a top-level section). `n_threads` = the pixel-parallel
+# launch size (Nx·Ny) for thread-fill occupancy. Stats reduce over ALL devices' rows
+# (device_count records the fan-out; the per-device time series lives in the gputrace TSV);
+# NaN entries (counters a device doesn't expose) are skipped per column. Returns `nothing` if
+# telemetry is unavailable (e.g. no vendor extension) so the caller just omits [gpu].
 function gpu_manifest_section(backend, backend_name::AbstractString, n_threads::Integer,
-        device_count::Integer, samples::Vector{NTuple{4, Float64}})
+        device_count::Integer, telem)
     try
         gpu = Dict{String, Any}(
             "backend" => String(backend_name),
@@ -47,17 +100,19 @@ function gpu_manifest_section(backend, backend_name::AbstractString, n_threads::
             "memory_total" => Int(gpu_memory_info(backend).total),
             "thread_fill_occupancy" => Float64(thread_fill_occupancy(backend, n_threads)),
         )
-        if !isempty(samples)
-            _mean(v) = sum(v) / length(v)
-            pw = Float64[s[1] for s in samples]
-            cu = Float64[s[2] for s in samples]
-            mu = Float64[s[3] for s in samples]
-            vr = Float64[s[4] for s in samples]
-            gpu["samples"] = length(samples)
-            gpu["power_mean"] = _mean(pw);          gpu["power_peak"] = maximum(pw)
-            gpu["compute_util_mean"] = _mean(cu);   gpu["compute_util_peak"] = maximum(cu)
-            gpu["memory_util_mean"] = _mean(mu);    gpu["memory_util_peak"] = maximum(mu)
-            gpu["vram_used_peak"] = maximum(vr)
+        if telem.ticks > 0
+            gpu["samples"] = telem.ticks
+            gpu["sample_dt"] = telem.dt
+            gpu["sampler_starved"] = telem.starved
+            col(i) = Float64[s[i] for s in telem.samples if !isnan(s[i])]
+            for (key, i) in (("power", 3), ("compute_util", 4), ("memory_util", 5))
+                v = col(i)
+                isempty(v) && continue
+                gpu[key * "_mean"] = sum(v) / length(v)
+                gpu[key * "_peak"] = maximum(v)
+            end
+            vr = col(6)
+            isempty(vr) || (gpu["vram_used_peak"] = maximum(vr))
         end
         return gpu
     catch err

--- a/scripts/gputrace.sh
+++ b/scripts/gputrace.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# GPU telemetry child sampler over amdgpu driver sysfs — spawned by with_gpu_sampler
+# (scripts/gpu_telemetry.jl). Runs OUT OF PROCESS because no in-process Julia sampler
+# survives the solver: GC + libuv-timer coupling suspends sleeping tasks entirely while
+# the host thread allocates (measured: 0 ticks/15 s on pure CPU churn, 1 tick/98.5 s on a
+# real accumulate_field window).
+#
+# Emits one TSV row per device per tick on STDOUT (the parent redirects into the gputrace
+# TSV next to the run outputs):
+#   epoch_s <TAB> device <TAB> power_W <TAB> compute_util <TAB> mem_util <TAB> vram_used_B
+#
+# Usage: gputrace.sh <dt_s> <parent_pid> <stopfile> <devspec>...
+#   devspec = id:power_file:busy_file:membusy_file:vram_file  (membusy_file "-" if absent)
+# Exits when <stopfile> appears or the parent dies — cooperative stop, no signals, no orphans.
+dt=$1; ppid=$2; stop=$3; shift 3
+
+while [ ! -e "$stop" ] && kill -0 "$ppid" 2>/dev/null; do
+    now=$(date +%s.%N)
+    for spec in "$@"; do
+        awk -v now="$now" -v spec="$spec" 'BEGIN {
+            split(spec, a, ":")
+            if ((getline p < a[2]) <= 0) exit   # transient read failure -> drop this row
+            if ((getline b < a[3]) <= 0) exit
+            m = "nan"
+            if (a[4] != "-" && (getline mm < a[4]) > 0) m = mm / 100
+            if ((getline v < a[5]) <= 0) exit
+            printf "%.2f\t%s\t%.1f\t%.2f\t%s\t%.0f\n", now, a[1], p / 1e6, b / 100, m, v
+        }'
+    done
+    sleep "$dt"
+done

--- a/scripts/gputrace_cuda.sh
+++ b/scripts/gputrace_cuda.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# GPU telemetry child sampler over nvidia-smi (NVML) — the CUDA counterpart of gputrace.sh;
+# see there for why sampling runs out of process. Emits the same canonical TSV rows on STDOUT:
+#   epoch_s <TAB> device <TAB> power_W <TAB> compute_util <TAB> mem_util <TAB> vram_used_B
+# (epoch at whole-second resolution — awk systime(); fine for the >=1 s production cadence).
+#
+# Usage: gputrace_cuda.sh <dt_ms> <parent_pid> <stopfile> <uuid=ordinal>...
+#   uuid = the GPU-... NVML uuid (stable under CUDA_VISIBLE_DEVICES); ordinal = our 1-based id
+# One nvidia-smi daemon per device; all are reaped when <stopfile> appears or the parent dies.
+dt_ms=$1; ppid=$2; stop=$3; shift 3
+
+pids=""
+for spec in "$@"; do
+    uuid=${spec%%=*}; ord=${spec#*=}
+    nvidia-smi -i "$uuid" \
+        --query-gpu=power.draw,utilization.gpu,utilization.memory,memory.used \
+        --format=csv,noheader,nounits -lms "$dt_ms" 2>/dev/null \
+        | awk -v dev="$ord" -F', *' \
+            '{ printf "%d\t%s\t%.1f\t%.2f\t%.2f\t%.0f\n", systime(), dev, $1, $2 / 100, $3 / 100, $4 * 1048576; fflush() }' &
+    pids="$pids $!"
+done
+
+while [ ! -e "$stop" ] && kill -0 "$ppid" 2>/dev/null; do
+    sleep 1
+done
+kill $pids 2>/dev/null
+wait

--- a/scripts/lpwa.jl
+++ b/scripts/lpwa.jl
@@ -190,11 +190,12 @@ screen = ObserverScreen(
 # Multi-GPU: when >1 device is visible (e.g. SLURM --gres=gpu:h200:2) shard the electrons across
 # them — linear superposition ⇒ the summed partials are exact; one device ⇒ the plain path.
 ndev = gpu_device_count(gpu_backend)
-Threads.nthreads() >= 2 ||
-    @warn "only $(Threads.nthreads()) Julia thread — the GPU telemetry sampler starves behind the kernel; [gpu] sample stats may be empty (run with -t≥2)"
-# Sample GPU power/util/VRAM on a spawned thread across the accumulate_field window (→ manifest [gpu]).
+# Sample GPU power/util/VRAM across the accumulate_field window on all sharded devices
+# (→ manifest [gpu] stats + the gputrace TSV time series; see gpu_telemetry.jl).
+gputracefile = joinpath(OUTDIR, "gputrace_$(RUN_TAG).tsv")
 t_field = @elapsed begin
-    fld, gpu_samples = with_gpu_sampler(gpu_backend, GPU_SAMPLE_DT) do
+    fld, gpu_telem = with_gpu_sampler(gpu_backend, GPU_SAMPLE_DT;
+            devices = 1:ndev, tracefile = gputracefile) do
         if ndev > 1
             @info "sharding electrons across $ndev devices"
             accumulate_field_sharded(
@@ -290,6 +291,7 @@ outputs = Dict{String, Any}(
     "datafile" => basename(datafile),
     "log" => "run_$(RUN_TAG).log",   # captured by the run wrapper; travels with the run
 )
+gpu_telem.trace === nothing || (outputs["gpu_trace"] = basename(gpu_telem.trace))
 if !SKIP_POST
     outputs["harmonic_maps"] = basename(hprod.hmapsfile)
     outputs["plots"] = basename.(plotfiles)
@@ -306,7 +308,7 @@ timing = Dict{String, Any}(
 sharding = Dict{String, Any}("electrons" => ndev)
 # GPU telemetry → [gpu] (static device snapshot + power/util/VRAM stats over the field window).
 # `nothing` (no vendor extension / telemetry error) ⇒ the section is simply omitted.
-gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_samples)
+gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_telem)
 extra = Dict{String, Any}("model" => model_params, "timing" => timing, "sharding" => sharding)
 gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(

--- a/scripts/occupancy_bench.jl
+++ b/scripts/occupancy_bench.jl
@@ -1,14 +1,14 @@
 # Occupancy + telemetry bench for accumulate_field at PRODUCTION screen size. Occupancy is set by
 # the per-launch thread count (Nx·Ny), not the electron count — so a handful of electrons (EDM_N,
 # default 20) measures the prod-size kernel cheaply. Reports the STATIC thread-fill occupancy, plus
-# power / utilization sampled — on a SEPARATE OS THREAD — DURING the accumulate_field run.
+# power / utilization sampled — by an OUT-OF-PROCESS child — DURING the accumulate_field run.
 #
 #   EDM_GPU_BACKEND=cuda EDM_NX=400 EDM_NSAMPLES=6000 EDM_N=20 \
-#     julia +release -t2 --startup=no --project=scripts scripts/occupancy_bench.jl
+#     julia +release --startup=no --project=scripts scripts/occupancy_bench.jl
 #
-# Needs ≥2 Julia threads (-t2): the sampler runs on a spawned thread while the main thread drives the
-# launch-bound accumulate_field loop (which never yields, so a cooperative @async sampler would
-# starve). NVML/sysfs reads are host-side + thread-safe and GPU work is async, so they overlap.
+# Sampling uses with_gpu_sampler (gpu_telemetry.jl): an out-of-process child reading driver
+# sysfs / nvidia-smi, so it can't starve behind the launch-bound accumulate_field loop, wedge
+# on the HIP runtime, or be suspended by Julia's GC the way in-process samplers were.
 # Setup mirrors thomson_scattering.jl (LaguerreGauss circular beam, sunflower electrons); the bench
 # does NOT serialize the (prod-size, ~46–92 GB) field cube — it only times the kernel + telemetry.
 
@@ -29,6 +29,8 @@ elseif GPU_BACKEND == "rocm"
 else
     error("EDM_GPU_BACKEND must be \"cuda\" or \"rocm\", got $(repr(GPU_BACKEND))")
 end
+
+include(joinpath(@__DIR__, "gpu_telemetry.jl"))   # with_gpu_sampler (out-of-process sampler child)
 
 const c = 137.03599908330932
 const NX = parse(Int, get(ENV, "EDM_NX", "400"))
@@ -99,43 +101,31 @@ nthr = NX * NX
 @printf("thread-fill occupancy @ NX=%d (%d threads/electron) = %.3f  (>1 ⇒ waves)\n",
     NX, nthr, thread_fill_occupancy(backend, nthr))
 
-# ── telemetry sampler on a spawned OS thread (power/util DURING the run) ──
-Threads.nthreads() >= 2 ||
-    @warn "only $(Threads.nthreads()) Julia thread — the sampler will starve; rerun with -t2"
-const running = Threads.Atomic{Bool}(true)
-const samples = NTuple{5, Float64}[]   # (t, power_W, compute_util, mem_util, vram_used_B); single writer
-t0 = time()
-sampler = Threads.@spawn begin
-    while running[]
-        u = gpu_utilization(backend)
-        m = gpu_memory_info(backend)
-        push!(samples, (time() - t0, gpu_power(backend), Float64(u.compute), Float64(u.memory), Float64(m.used)))
-        sleep(SAMPLE_DT)
+# ── the measured run (split mode, like prod; no serialization — bench only), telemetry sampled DURING ──
+GC.gc()
+println("accumulating field ($NELEC electrons, NX=$NX, Ns=$NSAMPLES, split) …")
+t_field = @elapsed begin
+    fld, telem = with_gpu_sampler(backend, SAMPLE_DT; devices = [gpu_device(backend)]) do
+        accumulate_field(
+            trajs, screen, GPUKernelRK4(), backend;
+            n_substeps = NSUBSTEPS, mode = Val(:split), sync_per_electron = false)
     end
 end
 
-# ── the measured run (split mode, like prod; no serialization — bench only) ──
-GC.gc()
-println("accumulating field ($NELEC electrons, NX=$NX, Ns=$NSAMPLES, split) …")
-t_field = @elapsed fld = accumulate_field(
-    trajs, screen, GPUKernelRK4(), backend; n_substeps = NSUBSTEPS, mode = Val(:split), sync_per_electron = false)
-running[] = false
-wait(sampler)
-
 # ── report ──
-pw = Float64[s[2] for s in samples]
-cu = Float64[s[3] for s in samples]
-mu = Float64[s[4] for s in samples]
-vr = Float64[s[5] for s in samples]
+samples = telem.samples   # rows (t, device, power_W, compute_util, mem_util, vram_used_B)
+pw = Float64[s[3] for s in samples]
+cu = Float64[s[4] for s in samples]
+mu = Float64[s[5] for s in samples]
+vr = Float64[s[6] for s in samples]
 @printf("\nrun: %d electrons in %.1f s  (%d telemetry samples @ %.2gs)\n", NELEC, t_field, length(samples), SAMPLE_DT)
 if !isempty(pw)
     @printf("power (W):     mean %.1f   peak %.1f   min %.1f\n", mean(pw), maximum(pw), minimum(pw))
     @printf("compute util:  mean %.2f   peak %.2f\n", mean(cu), maximum(cu))
     @printf("memory util:   mean %.2f   peak %.2f\n", mean(mu), maximum(mu))
 end
-# Kernel-active window (compute util above noise) — isolates the kernel from the host pullback,
-# which on AMD pegs the CPU and starves the sampler, concentrating samples in the active window.
-let act = Float64[s[1] for s in samples if s[3] > 0.05]
+# Kernel-active window (compute util above noise) — isolates the kernel from the host pullback.
+let act = Float64[s[1] for s in samples if s[4] > 0.05]
     isempty(act) || @printf("GPU-active window: %.1f–%.1f s  (≈%.1f s kernel; @elapsed incl. host pullback = %.1f s)\n",
         minimum(act), maximum(act), maximum(act) - minimum(act), t_field)
 end

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -200,11 +200,12 @@ screen = ObserverScreen(
 # Multi-GPU: when >1 device is visible (e.g. SLURM --gres=gpu:h200:2) shard the electrons across
 # them — linear superposition ⇒ the summed partials are exact; one device ⇒ the plain path.
 ndev = gpu_device_count(gpu_backend)
-Threads.nthreads() >= 2 ||
-    @warn "only $(Threads.nthreads()) Julia thread — the GPU telemetry sampler starves behind the kernel; [gpu] sample stats may be empty (run with -t≥2)"
-# Sample GPU power/util/VRAM on a spawned thread across the accumulate_field window (→ manifest [gpu]).
+# Sample GPU power/util/VRAM across the accumulate_field window on all sharded devices
+# (→ manifest [gpu] stats + the gputrace TSV time series; see gpu_telemetry.jl).
+gputracefile = joinpath(OUTDIR, "gputrace_$(RUN_TAG).tsv")
 t_field = @elapsed begin
-    fld, gpu_samples = with_gpu_sampler(gpu_backend, GPU_SAMPLE_DT) do
+    fld, gpu_telem = with_gpu_sampler(gpu_backend, GPU_SAMPLE_DT;
+            devices = 1:ndev, tracefile = gputracefile) do
         if ndev > 1
             @info "sharding electrons across $ndev devices"
             accumulate_field_sharded(
@@ -276,6 +277,7 @@ outputs = Dict{String, Any}(
     "datafile" => basename(datafile),
     "log" => "run_$(RUN_TAG).log",   # captured by the run wrapper; travels with the run
 )
+gpu_telem.trace === nothing || (outputs["gpu_trace"] = basename(gpu_telem.trace))
 if !SKIP_POST
     outputs["harmonic_maps"] = basename(hprod.hmapsfile)   # reduced maps → resolve_hmaps finds them directly
     outputs["plots"] = basename.(plotfiles)
@@ -311,7 +313,7 @@ timing = Dict{String, Any}(
 sharding = Dict{String, Any}("electrons" => ndev)
 # GPU telemetry → [gpu] (static device snapshot + power/util/VRAM stats over the field window).
 # `nothing` (no vendor extension / telemetry error) ⇒ the section is simply omitted.
-gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_samples)
+gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_telem)
 extra = Dict{String, Any}("timing" => timing, "sharding" => sharding)
 gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(

--- a/src/ElectronDynamicsModels.jl
+++ b/src/ElectronDynamicsModels.jl
@@ -47,7 +47,8 @@ export ReferenceFrame, Worldline,
     GPUCubicSpline, GPUKernelRK4, GPUKernelTsit5, recommended_n_substeps,
     retarded_time_problem,
     gpu_device_count, gpu_device, gpu_device!, gpu_name, gpu_power, gpu_utilization,
-    gpu_memory_info, gpu_sm_count, gpu_max_threads_per_sm, thread_fill_occupancy,
+    gpu_memory_info, gpu_telemetry_child_cmd, gpu_sm_count, gpu_max_threads_per_sm,
+    thread_fill_occupancy,
     accumulate_field_sharded,
     hann, blackman_harris
 

--- a/src/gpu_api.jl
+++ b/src/gpu_api.jl
@@ -44,6 +44,23 @@ function gpu_utilization end
 Current-device global memory, in bytes."""
 function gpu_memory_info end
 
+"""    gpu_telemetry_child_cmd(backend, device_ids, dt, stopfile) -> Cmd
+
+Build the OUT-OF-PROCESS telemetry sampler command for the (1-based) `device_ids`: a child
+that emits one canonical TSV row per device every `dt` seconds on stdout
+(`epoch_s  device  power_W  compute_util  mem_util  vram_used_B`; `nan` for counters a
+device doesn't expose) and exits when `stopfile` appears or the parent dies. The vendor
+runtime is touched only while BUILDING the command (resolving sysfs paths / NVML uuids);
+the child itself reads driver sysfs (AMD, scripts/gputrace.sh) or runs `nvidia-smi -lms`
+(NVIDIA, scripts/gputrace_cuda.sh) and shares nothing with this process.
+
+Sampling must live out of process: an in-process tick either wedges on the vendor runtime
+behind a backed-up kernel stream, or — even with a runtime-free tick — is suspended wholesale
+with the sleeping task by Julia's GC/libuv-timer coupling while the solver's host thread
+allocates (measured on the production W7900 host: 0 ticks/15 s under pure-CPU alloc churn,
+1 tick/98.5 s over a real `accumulate_field` window)."""
+function gpu_telemetry_child_cmd end
+
 """    gpu_sm_count(backend) -> Int
 
 Streaming-multiprocessor (CU on AMD) count of the current device."""
@@ -70,6 +87,10 @@ for f in (
 end
 gpu_device!(b::KA.Backend, ::Integer) = error(
     "gpu_device!: no GPU vendor extension loaded for ", typeof(b), " — load CUDA.jl or AMDGPU.jl"
+)
+gpu_telemetry_child_cmd(b::KA.Backend, ::AbstractVector{<:Integer}, ::Real, ::AbstractString) = error(
+    "gpu_telemetry_child_cmd: no GPU vendor extension loaded for ", typeof(b),
+    " — load CUDA.jl or AMDGPU.jl"
 )
 
 """


### PR DESCRIPTION
The [gpu] sample stats of hour-long runs were garbage — every linpol_maps_N5k run has samples=2 over a ~3400 s field window with all-zero utilization and idle power: the in-process sampler task wedged for the whole accumulate_field window. Two distinct mechanisms, both measured on the W7900 host that produced the bad manifests:

* the tick called into the HIP runtime (hipGetDeviceProperties via _amd_device_sysfs + hipMemGetInfo), which blocks behind a kernel stream backed up with queued launches;
* even with a runtime-free (pure sysfs) tick, Julia's GC/libuv-timer coupling suspends sleeping tasks wholesale while the host thread allocates: 0 ticks/15 s under pure-CPU alloc churn (any thread count), 1 tick/98.5 s over a real accumulate_field window.

So the sampler now runs OUT OF PROCESS, still driven from Julia by the same with_gpu_sampler API.

Validated on the W7900: 42/42 expected ticks (peaks 0.99 util / 242 W) over an alloc-churn workload that starves any in-process sampler, and 380 samples @ 0.25 s over a real 96 s accumulate_field window (power 8-254 W, util peak 1.0, kernel-active window cleanly resolved); gputrace.sh cadence and both termination paths verified standalone.