### PR TITLE
gpu: Newton light-cone retarded-time solve (GPUKernelNewton, Experimental)

### DIFF
--- a/scripts/benchmark_newton_field_gpu.jl
+++ b/scripts/benchmark_newton_field_gpu.jl
@@ -1,0 +1,158 @@
+# Benchmark: GPUKernelNewton vs GPUKernelRK4 on the FIELD path (the production
+# path; register-pressure risk case — see the findfirst-spline experiment).
+# Split mode (production default). Physics identical to benchmark_newton_gpu.jl.
+#
+# Run from the worktree root:
+#   julia --project=scripts --threads=auto scripts/benchmark_newton_field_gpu.jl
+
+using ElectronDynamicsModels
+using ModelingToolkit
+using OrdinaryDiffEqVerner, OrdinaryDiffEqTsit5
+using OrdinaryDiffEqNonlinearSolve
+using SciMLBase
+using StaticArrays
+using SymbolicIndexingInterface
+using LinearAlgebra
+using AcceleratedKernels
+using AMDGPU
+using Printf
+
+const backend = AMDGPU.ROCBackend()
+const c = 137.03599908330932
+
+const ω = 0.057
+const τ = 150 / ω
+const λ = 2π * c / ω
+const w₀ = 75λ
+const Rmax = 3.25w₀
+const a₀ = 0.1
+
+@named world = Worldline(:τ, :atomic)
+@named laser = LaguerreGaussLaser(;
+    wavelength = λ, a0 = a₀, beam_waist = w₀, radial_index = 2, azimuthal_index = -2,
+    world, temporal_profile = :gaussian, temporal_width = τ, focus_position = 0.0,
+    polarization = :circular,
+)
+@named elec = ClassicalElectron(; laser)
+const sys = mtkcompile(elec)
+
+const τi = -8τ
+const τf = 8τ
+const prob = ODEProblem{false, SciMLBase.FullSpecialize}(
+    sys, [sys.x => [τi * c, 0.0, 0.0, 0.0], sys.u => [c, 0.0, 0.0, 0.0]], (τi, τf);
+    u0_constructor = SVector{8}, fully_determined = true,
+)
+const set_x = setsym_oop(prob, [Initial(sys.x); Initial(sys.u)])
+
+const ϕ = (1 + √5) / 2
+radius(k, n, b) = k > n - b ? 1.0 : sqrt(k - 0.5) / sqrt(n - (b + 1) / 2)
+function sunflower(n, α)
+    pts = Vector{Vector{Float64}}()
+    stride = 2π / ϕ^2
+    b = round(Int, α * sqrt(n))
+    for k in 1:n
+        r = radius(k, n, b)
+        push!(pts, [r * cos(k * stride), r * sin(k * stride)])
+    end
+    return pts
+end
+function abserr(a₀)
+    amp = log10(a₀)
+    return 10^(-amp^2 / 27 + 32amp / 27 - 220 / 27)
+end
+
+function build_trajs(N)
+    xμ = [SVector{4, Float64}(τi * c, r[1], r[2], 0.0) for r in Rmax * sunflower(N, 2)]
+    function prob_func(prob, ctx)
+        u0_new, p = set_x(prob, SVector{8}(xμ[ctx.sim_id]..., c, 0.0, 0.0, 0.0))
+        return remake(prob; u0 = u0_new, p)
+    end
+    ens = EnsembleProblem(prob; prob_func, safetycopy = false)
+    sol = solve(ens, Vern9(), EnsembleThreads(); reltol = 1.0e-12, abstol = abserr(a₀), trajectories = N)
+    return trajectory_interpolants(sol)
+end
+
+const Z = 2.0e5λ
+const δt = 2π / ω / 5
+const x⁰_start = c * τi + hypot(Z, 25w₀ + Rmax)
+build_screen(Nx, Ns) = ObserverScreen(LinRange(-25w₀, 25w₀, Nx), LinRange(-25w₀, 25w₀, Nx), Z, range(start = x⁰_start, step = c * δt, length = Ns); c)
+
+relerr(A, Aref) = norm(A .- Aref) / norm(Aref)
+relerr_fields(F, Fref) = max(relerr(F.E, Fref.E), relerr(F.B, Fref.B))
+
+function warmup()
+    t = build_trajs(2)
+    s = build_screen(4, 16)
+    accumulate_field(t, s, GPUKernelRK4(), backend; n_substeps = 2)
+    accumulate_field(t, s, GPUKernelNewton(), backend; n_iters = 2)
+    return nothing
+end
+
+function time_min(f, k)
+    best = Inf
+    local A
+    for _ in 1:k
+        t = @elapsed A = f()
+        best = min(best, t)
+    end
+    return best, A
+end
+
+# (300, 400²) split-mode buffers ≈ 4 × 3.84 GB ≈ 15.4 GB — fits the W7900.
+const configs = [
+    (N = 300, Nx = 200, k = 2, rk4_sweep = (1, 8), newton_sweep = (1, 2, 3)),
+    (N = 300, Nx = 400, k = 1, rk4_sweep = (1,), newton_sweep = (2,)),
+]
+const N_samples = 1000
+
+function main()
+    println("Backend: ", backend)
+    println("Warming up (JIT)…")
+    warmup()
+
+    trajs_cache = Dict{Int, Any}()
+
+    for cfg in configs
+        N, Nx, k = cfg.N, cfg.Nx, cfg.k
+        @printf("\n========== FIELD (split)  N=%d  screen=%d×%d  N_samples=%d  (min of %d) ==========\n",
+            N, Nx, Nx, N_samples, k)
+        flush(stdout)
+
+        trajs = get!(() -> build_trajs(N), trajs_cache, N)
+        screen = build_screen(Nx, N_samples)
+
+        # Anchor: converged RK4 at ns=8 when it's in the sweep, else ns=1.
+        ns_anchor = maximum(cfg.rk4_sweep)
+        t_anchor, F_anchor = time_min(() -> accumulate_field(
+            trajs, screen, GPUKernelRK4(), backend; n_substeps = ns_anchor), k)
+
+        @printf("%-22s %10s %10s %10s\n", "method", "relerr", "time(s)", "x anchor")
+        @printf("%-22s %10s %10.3f %10.2f\n", "RK4 n_substeps=$ns_anchor", "anchor", t_anchor, 1.0)
+        flush(stdout)
+
+        for ns in cfg.rk4_sweep
+            ns == ns_anchor && continue
+            t, F = time_min(() -> accumulate_field(
+                trajs, screen, GPUKernelRK4(), backend; n_substeps = ns), k)
+            @printf("%-22s %10.2e %10.3f %10.2f\n",
+                "RK4 n_substeps=$ns", relerr_fields(F, F_anchor), t, t_anchor / t)
+            F = nothing
+            flush(stdout)
+        end
+
+        for n in cfg.newton_sweep
+            t, F = time_min(() -> accumulate_field(
+                trajs, screen, GPUKernelNewton(), backend; n_iters = n), k)
+            @printf("%-22s %10.2e %10.3f %10.2f\n",
+                "Newton n_iters=$n", relerr_fields(F, F_anchor), t, t_anchor / t)
+            F = nothing
+            flush(stdout)
+        end
+
+        F_anchor = nothing
+        GC.gc()
+    end
+    return nothing
+end
+
+main()

--- a/scripts/benchmark_newton_gpu.jl
+++ b/scripts/benchmark_newton_gpu.jl
@@ -1,0 +1,161 @@
+# Benchmark: GPUKernelNewton (per-slot light-cone Newton solve) vs GPUKernelRK4
+# (retarded-time ODE march) on the potential path.  Physics identical to
+# benchmark_experimental_gpu.jl / thomson_scattering.jl (a₀ = 0.1 circular LG).
+#
+# Accuracy anchor per rung is RK4 n_substeps = 8 (converged; absolute accuracy
+# vs the tight CPU reference is established separately by
+# diag_newton_precision.jl at the (100, 50) size).  The RK4 ns=1 vs ns=8 pair
+# doubles as a sanity check that the timing is kernel-bound: if those two run
+# at the same speed, the rung is upload/write-bound and eval savings can't show.
+#
+# Run from the worktree root:
+#   julia --project=scripts --threads=auto scripts/benchmark_newton_gpu.jl
+
+using ElectronDynamicsModels
+using ModelingToolkit
+using OrdinaryDiffEqVerner, OrdinaryDiffEqTsit5
+using OrdinaryDiffEqNonlinearSolve
+using SciMLBase
+using StaticArrays
+using SymbolicIndexingInterface
+using LinearAlgebra
+using AcceleratedKernels
+using AMDGPU
+using Printf
+
+const backend = AMDGPU.ROCBackend()
+const c = 137.03599908330932
+
+const ω = 0.057
+const τ = 150 / ω
+const λ = 2π * c / ω
+const w₀ = 75λ
+const Rmax = 3.25w₀
+const a₀ = 0.1
+
+@named world = Worldline(:τ, :atomic)
+@named laser = LaguerreGaussLaser(;
+    wavelength = λ, a0 = a₀, beam_waist = w₀, radial_index = 2, azimuthal_index = -2,
+    world, temporal_profile = :gaussian, temporal_width = τ, focus_position = 0.0,
+    polarization = :circular,
+)
+@named elec = ClassicalElectron(; laser)
+const sys = mtkcompile(elec)
+
+const τi = -8τ
+const τf = 8τ
+const prob = ODEProblem{false, SciMLBase.FullSpecialize}(
+    sys, [sys.x => [τi * c, 0.0, 0.0, 0.0], sys.u => [c, 0.0, 0.0, 0.0]], (τi, τf);
+    u0_constructor = SVector{8}, fully_determined = true,
+)
+const set_x = setsym_oop(prob, [Initial(sys.x); Initial(sys.u)])
+
+const ϕ = (1 + √5) / 2
+radius(k, n, b) = k > n - b ? 1.0 : sqrt(k - 0.5) / sqrt(n - (b + 1) / 2)
+function sunflower(n, α)
+    pts = Vector{Vector{Float64}}()
+    stride = 2π / ϕ^2
+    b = round(Int, α * sqrt(n))
+    for k in 1:n
+        r = radius(k, n, b)
+        push!(pts, [r * cos(k * stride), r * sin(k * stride)])
+    end
+    return pts
+end
+function abserr(a₀)
+    amp = log10(a₀)
+    return 10^(-amp^2 / 27 + 32amp / 27 - 220 / 27)
+end
+
+function build_trajs(N)
+    xμ = [SVector{4, Float64}(τi * c, r[1], r[2], 0.0) for r in Rmax * sunflower(N, 2)]
+    function prob_func(prob, ctx)
+        u0_new, p = set_x(prob, SVector{8}(xμ[ctx.sim_id]..., c, 0.0, 0.0, 0.0))
+        return remake(prob; u0 = u0_new, p)
+    end
+    ens = EnsembleProblem(prob; prob_func, safetycopy = false)
+    sol = solve(ens, Vern9(), EnsembleThreads(); reltol = 1.0e-12, abstol = abserr(a₀), trajectories = N)
+    return trajectory_interpolants(sol)
+end
+
+const Z = 2.0e5λ
+const δt = 2π / ω / 5
+const x⁰_start = c * τi + hypot(Z, 25w₀ + Rmax)
+build_screen(Nx, Ns) = ObserverScreen(LinRange(-25w₀, 25w₀, Nx), LinRange(-25w₀, 25w₀, Nx), Z, range(start = x⁰_start, step = c * δt, length = Ns); c)
+
+relerr(A, Aref) = norm(A .- Aref) / norm(Aref)
+
+function warmup()
+    t = build_trajs(2)
+    s = build_screen(4, 16)
+    accumulate_potential(t, s, GPUKernelRK4(), backend; n_substeps = 2)
+    accumulate_potential(t, s, GPUKernelNewton(), backend; n_iters = 2)
+    return nothing
+end
+
+# min-of-k wall time; returns (t_min, last result)
+function time_min(f, k)
+    best = Inf
+    local A
+    for _ in 1:k
+        t = @elapsed A = f()
+        best = min(best, t)
+    end
+    return best, A
+end
+
+const configs = [
+    (N = 100, Nx = 50, k = 3),
+    (N = 300, Nx = 50, k = 3),
+    (N = 1000, Nx = 200, k = 2),
+]
+const N_samples = 1000
+
+function main()
+    println("Backend: ", backend)
+    println("Warming up (JIT)…")
+    warmup()
+
+    trajs_cache = Dict{Int, Any}()
+
+    for cfg in configs
+        N, Nx, k = cfg.N, cfg.Nx, cfg.k
+        @printf("\n========== N=%d  screen=%d×%d  N_samples=%d  (min of %d) ==========\n",
+            N, Nx, Nx, N_samples, k)
+        flush(stdout)
+
+        trajs = get!(() -> build_trajs(N), trajs_cache, N)
+        screen = build_screen(Nx, N_samples)
+
+        # Accuracy anchor: converged RK4 (absolute accuracy of this anchor is
+        # pinned by diag_newton_precision.jl against the tight CPU reference).
+        t_rk48, A_anchor = time_min(() -> accumulate_potential(
+            trajs, screen, GPUKernelRK4(), backend; n_substeps = 8), k)
+
+        @printf("%-22s %10s %10s %10s %10s\n", "method", "relerr", "time(s)", "x rk4ns1", "x rk4ns8")
+
+        t_rk41, A = time_min(() -> accumulate_potential(
+            trajs, screen, GPUKernelRK4(), backend; n_substeps = 1), k)
+        @printf("%-22s %10.2e %10.3f %10.2f %10.2f\n",
+            "RK4 n_substeps=1", relerr(A, A_anchor), t_rk41, 1.0, t_rk48 / t_rk41)
+        @printf("%-22s %10s %10.3f %10.2f %10.2f\n",
+            "RK4 n_substeps=8", "anchor", t_rk48, t_rk41 / t_rk48, 1.0)
+        A = nothing
+        flush(stdout)
+
+        for n in (1, 2, 3)
+            t, A = time_min(() -> accumulate_potential(
+                trajs, screen, GPUKernelNewton(), backend; n_iters = n), k)
+            @printf("%-22s %10.2e %10.3f %10.2f %10.2f\n",
+                "Newton n_iters=$n", relerr(A, A_anchor), t, t_rk41 / t, t_rk48 / t)
+            A = nothing
+            flush(stdout)
+        end
+
+        A_anchor = nothing
+        GC.gc()
+    end
+    return nothing
+end
+
+main()

--- a/scripts/diag_newton_precision.jl
+++ b/scripts/diag_newton_precision.jl
@@ -1,0 +1,96 @@
+# V3 — GPU precision of the Newton light-cone kernel at the a₀=0.1 production
+# setup, against the tight-tolerance CPU reference (diag_precision.jl layout
+# with GPUKernelNewton rows added).
+
+using ElectronDynamicsModels
+using ModelingToolkit
+using OrdinaryDiffEqVerner, OrdinaryDiffEqTsit5
+using OrdinaryDiffEqNonlinearSolve
+using SciMLBase
+using StaticArrays
+using SymbolicIndexingInterface
+using LinearAlgebra
+using AcceleratedKernels
+using AMDGPU
+using Printf
+
+const backend = AMDGPU.ROCBackend()
+const c = 137.03599908330932
+
+const ω = 0.057
+const τ = 150 / ω
+const λ = 2π * c / ω
+const w₀ = 75λ
+const Rmax = 3.25w₀
+const a₀ = 0.1
+
+@named world = Worldline(:τ, :atomic)
+@named laser = LaguerreGaussLaser(;
+    wavelength = λ, a0 = a₀, beam_waist = w₀, radial_index = 2, azimuthal_index = -2,
+    world, temporal_profile = :gaussian, temporal_width = τ, focus_position = 0.0,
+    polarization = :circular,
+)
+@named elec = ClassicalElectron(; laser)
+const sys = mtkcompile(elec)
+
+const τi = -8τ
+const τf = 8τ
+const prob = ODEProblem{false, SciMLBase.FullSpecialize}(
+    sys, [sys.x => [τi * c, 0.0, 0.0, 0.0], sys.u => [c, 0.0, 0.0, 0.0]], (τi, τf);
+    u0_constructor = SVector{8}, fully_determined = true,
+)
+const set_x = setsym_oop(prob, [Initial(sys.x); Initial(sys.u)])
+
+const ϕ = (1 + √5) / 2
+radius(k, n, b) = k > n - b ? 1.0 : sqrt(k - 0.5) / sqrt(n - (b + 1) / 2)
+function sunflower(n, α)
+    pts = Vector{Vector{Float64}}()
+    stride = 2π / ϕ^2
+    b = round(Int, α * sqrt(n))
+    for k in 1:n
+        r = radius(k, n, b)
+        push!(pts, [r * cos(k * stride), r * sin(k * stride)])
+    end
+    return pts
+end
+function abserr(a₀)
+    amp = log10(a₀)
+    return 10^(-amp^2 / 27 + 32amp / 27 - 220 / 27)
+end
+
+function build_trajs(N)
+    xμ = [SVector{4, Float64}(τi * c, r[1], r[2], 0.0) for r in Rmax * sunflower(N, 2)]
+    function prob_func(prob, ctx)
+        u0_new, p = set_x(prob, SVector{8}(xμ[ctx.sim_id]..., c, 0.0, 0.0, 0.0))
+        return remake(prob; u0 = u0_new, p)
+    end
+    ens = EnsembleProblem(prob; prob_func, safetycopy = false)
+    sol = solve(ens, Vern9(), EnsembleThreads(); reltol = 1.0e-12, abstol = abserr(a₀), trajectories = N)
+    return trajectory_interpolants(sol)
+end
+
+const Z = 2.0e5λ
+const δt = 2π / ω / 5
+const x⁰_start = c * τi + hypot(Z, 25w₀ + Rmax)
+build_screen(Nx, Ns) = ObserverScreen(LinRange(-25w₀, 25w₀, Nx), LinRange(-25w₀, 25w₀, Nx), Z, range(start = x⁰_start, step = c * δt, length = Ns); c)
+
+relerr(A, Aref) = norm(A .- Aref) / norm(Aref)
+
+function main()
+    trajs = build_trajs(100)
+    screen = build_screen(50, 1000)
+
+    A_tight = accumulate_potential(trajs, screen, Tsit5(); reltol = 1.0e-12, abstol = 1.0e-12)
+    A_rk4_1 = accumulate_potential(trajs, screen, GPUKernelRK4(), backend; n_substeps = 1)
+    A_rk4_8 = accumulate_potential(trajs, screen, GPUKernelRK4(), backend; n_substeps = 8)
+
+    @printf("RK4 n_substeps=1  vs tight-cpu-ref : %.3e\n", relerr(A_rk4_1, A_tight))
+    @printf("RK4 n_substeps=8  vs tight-cpu-ref : %.3e\n", relerr(A_rk4_8, A_tight))
+    for n in (1, 2, 3)
+        A_newton = accumulate_potential(trajs, screen, GPUKernelNewton(), backend; n_iters = n)
+        @printf("Newton n_iters=%d  vs tight-cpu-ref : %.3e\n", n, relerr(A_newton, A_tight))
+    end
+    return nothing
+end
+
+main()

--- a/scripts/v1_newton_root_check.jl
+++ b/scripts/v1_newton_root_check.jl
@@ -1,0 +1,144 @@
+# V1 — host-side check of the Newton light-cone solve (kernel_newton.jl math)
+# against a tight-tolerance ODE solve of the retarded-time equation.
+#
+# Replicates the per-pixel loop of `_gpu_newton_one_electron!` on the host
+# (same `_lightcone_eval`, same window/predictor/correction logic), records the
+# per-slot τ_r, and compares against Vern9 at reltol=abstol=1e-12 on
+# `retarded_time_rhs`. Uses the analytic worldline from test/gpu_radiation.jl —
+# no MTK solve, runs in seconds, no GPU.
+#
+# Run from the worktree root: julia --project=scripts scripts/v1_newton_root_check.jl
+
+using ElectronDynamicsModels
+using ElectronDynamicsModels: TrajectoryInterpolant, ObserverScreen, to_gpu,
+    _lightcone_eval, retarded_time_rhs, advanced_time
+using DataInterpolations
+using StaticArrays
+using OrdinaryDiffEqVerner
+using SciMLBase
+using LinearAlgebra
+using Printf
+
+# ── analytic worldline (copied from test/gpu_radiation.jl) ──────────────────
+function analytic_traj(; g, A, Ω, vz, τspan, N, K = 1.0)
+    @assert g > sqrt(vz^2 + (A * Ω)^2) "worldline must stay timelike"
+    ts = collect(range(τspan[1], τspan[2], length = N))
+    us = [SVector{8}(
+        g * τ, A * sin(Ω * τ), 0.0, vz * τ,
+        g, A * Ω * cos(Ω * τ), 0.0, vz,
+    ) for τ in ts]
+    itp = CubicSpline(us, ts; extrapolation = ExtrapolationType.Extension)
+    as = [SVector{4}(0.0, -A * Ω^2 * sin(Ω * τ), 0.0, 0.0) for τ in ts]
+    a_itp = CubicSpline(as, ts; extrapolation = ExtrapolationType.Extension)
+    return TrajectoryInterpolant(itp, a_itp, SVector{4, Int}(1, 2, 3, 4),
+        SVector{4, Int}(5, 6, 7, 8), K)
+end
+
+# ── host replica of the kernel's per-pixel Newton march ─────────────────────
+# Same math and control flow as _gpu_newton_one_electron!, but records τ and
+# the final residual f at every slot instead of accumulating the potential.
+function newton_march(gpu_traj, r_obs, x⁰_samples, τi, τf; n_iters)
+    x⁰_first = first(x⁰_samples)
+    δx⁰ = step(x⁰_samples)
+    N_samples = length(x⁰_samples)
+
+    v_i = gpu_traj.itp(τi)
+    d_i = SVector{3}(r_obs[j] - v_i[gpu_traj.x_idxs[1 + j]] for j in 1:3)
+    R_i = norm(d_i)
+    x⁰_i_px = v_i[gpu_traj.x_idxs[1]] + R_i
+    v_f = gpu_traj.itp(τf)
+    x⁰_f_px = v_f[gpu_traj.x_idxs[1]] +
+        norm(SVector{3}(r_obs[j] - v_f[gpu_traj.x_idxs[1 + j]] for j in 1:3))
+
+    inv_δ = inv(δx⁰)
+    k_start = max(1, floor(Int, (x⁰_i_px - x⁰_first) * inv_δ) + 2)
+    k_end = min(N_samples, ceil(Int, (x⁰_f_px - x⁰_first) * inv_δ))
+
+    τs = fill(NaN, N_samples)
+    fs = fill(NaN, N_samples)
+    k_start > k_end && return τs, fs, k_start, k_end
+
+    u_i = SVector{4}(v_i[gpu_traj.u_idxs[j]] for j in 1:4)
+    rhs = R_i / (R_i * u_i[1] - d_i ⋅ u_i[SA[2, 3, 4]])
+    τ = τi
+    x⁰_target = x⁰_first + (k_start - 1) * δx⁰
+    Δ = x⁰_target - x⁰_i_px
+
+    for k in k_start:k_end
+        τ = clamp(τ + Δ * rhs, τi, τf)
+        v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+        for _ in 1:n_iters
+            τ = clamp(τ + f * rhs, τi, τf)
+            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+        end
+        τs[k] = τ
+        fs[k] = f
+        x⁰_target += δx⁰
+        Δ = δx⁰
+    end
+    return τs, fs, k_start, k_end
+end
+
+# ── tight-tolerance ODE reference, scattered onto the same slots ────────────
+function ode_reference(traj, r_obs, x⁰_samples, τi, τf)
+    x⁰_i = advanced_time(traj, τi, r_obs)
+    x⁰_f = advanced_time(traj, τf, r_obs)
+    prob = ODEProblem{false, SciMLBase.FullSpecialize}(
+        retarded_time_rhs, τi, (x⁰_i, x⁰_f), (traj, r_obs))
+    sol = solve(prob, Vern9(); reltol = 1.0e-12, abstol = 1.0e-12,
+        saveat = x⁰_samples, save_start = false, save_end = false)
+    τ_ref = fill(NaN, length(x⁰_samples))
+    δ = step(x⁰_samples)
+    for (t, τ) in zip(sol.t, sol.u)
+        idx = round(Int, (t - first(x⁰_samples)) / δ) + 1
+        1 <= idx <= length(τ_ref) && (τ_ref[idx] = τ)
+    end
+    return τ_ref
+end
+
+function run_case(name, traj, screen; pixels)
+    τi, τf = first(traj.itp.t), last(traj.itp.t)
+    gpu_traj = to_gpu(traj)   # host-side GPUCubicSpline
+    println("\n═══ $name ═══  (τ span = $(τf - τi), δx⁰ = $(round(step(screen.x⁰_samples), sigdigits=3)))")
+    for (ix, iy) in pixels
+        r_obs = SVector{3}(screen.x_grid[ix], screen.y_grid[iy], screen.z)
+        τ_ref = ode_reference(traj, r_obs, screen.x⁰_samples, τi, τf)
+        @printf("  pixel (%2d,%2d):  ", ix, iy)
+        for n_iters in 0:3
+            τs, fs, k_lo, k_hi = newton_march(gpu_traj, r_obs, screen.x⁰_samples, τi, τf; n_iters)
+            both = findall(k -> !isnan(τs[k]) && !isnan(τ_ref[k]), 1:length(τ_ref))
+            # drop the window-edge slots where the strict-interior conventions differ
+            interior = filter(k -> k_lo + 1 <= k <= k_hi - 1, both)
+            Δτ = maximum(abs.(τs[interior] .- τ_ref[interior])) / (τf - τi)
+            fmax = maximum(abs.(fs[interior]))
+            @printf("it=%d: Δτ=%.1e |f|=%.1e   ", n_iters, Δτ, fmax)
+        end
+        println()
+    end
+end
+
+# ── regime 1: transverse (test/gpu_radiation.jl bulk-pattern setup) ─────────
+traj_t = analytic_traj(; g = 1.2, A = 0.25, Ω = 2.0, vz = 0.0,
+    τspan = (0.0, 20.0), N = 6000)
+τi, τf = 0.0, 20.0
+z = 50.0
+grid = LinRange(-8.0, 8.0, 9)
+screen_t = ObserverScreen(grid, grid, z,
+    LinRange(1.2τi + (z - 16.0), 1.2τf + (z + 16.0), 240); c = 1.0)
+run_case("transverse (vz = 0)", traj_t, screen_t;
+    pixels = [(1, 1), (5, 5), (9, 1), (3, 7), (9, 9)])
+
+# ── regime 2: forward Doppler (vz ≈ c — Newton stress test) ─────────────────
+g, vz = 1.05, 0.95
+traj_d = analytic_traj(; g, A = 0.15, Ω = 2.0, vz,
+    τspan = (0.0, 20.0), N = 8000)
+z = 60.0
+grid_d = LinRange(-6.0, 6.0, 7)
+screen_d = ObserverScreen(grid_d, grid_d, z,
+    LinRange(g * τi + (z - vz * 20.0 - 6.0), g * 20.0 + (z + 6.0), 200); c = 1.0)
+run_case("forward Doppler (vz = 0.95)", traj_d, screen_d;
+    pixels = [(1, 1), (4, 4), (7, 1), (2, 6), (7, 7)])
+
+println("\nΔτ is relative to the τ span; |f| is the raw light-cone residual (same units as x⁰).")
+println("it=0 column = Euler predictor alone (no correction) — each added iteration")
+println("should shrink the error quadratically until the spline/cancellation floor.")

--- a/scripts/v2_newton_kernel_check.jl
+++ b/scripts/v2_newton_kernel_check.jl
@@ -1,0 +1,63 @@
+# V2 — the actual GPUKernelNewton kernel on the CPU backend vs the adaptive
+# Vern9 CPU reference, in both analytic regimes of test/gpu_radiation.jl,
+# alongside GPUKernelRK4 for context. A-level (accumulated potential) errors.
+#
+# Run from the worktree root: julia --project=scripts scripts/v2_newton_kernel_check.jl
+
+using ElectronDynamicsModels
+using ElectronDynamicsModels: TrajectoryInterpolant, ObserverScreen
+using DataInterpolations
+using StaticArrays
+using KernelAbstractions: CPU
+using OrdinaryDiffEqVerner
+using LinearAlgebra
+using Printf
+
+function analytic_traj(; g, A, Ω, vz, τspan, N, K = 1.0)
+    @assert g > sqrt(vz^2 + (A * Ω)^2) "worldline must stay timelike"
+    ts = collect(range(τspan[1], τspan[2], length = N))
+    us = [SVector{8}(
+        g * τ, A * sin(Ω * τ), 0.0, vz * τ,
+        g, A * Ω * cos(Ω * τ), 0.0, vz,
+    ) for τ in ts]
+    itp = CubicSpline(us, ts; extrapolation = ExtrapolationType.Extension)
+    as = [SVector{4}(0.0, -A * Ω^2 * sin(Ω * τ), 0.0, 0.0) for τ in ts]
+    a_itp = CubicSpline(as, ts; extrapolation = ExtrapolationType.Extension)
+    return TrajectoryInterpolant(itp, a_itp, SVector{4, Int}(1, 2, 3, 4),
+        SVector{4, Int}(5, 6, 7, 8), K)
+end
+
+rel_l2(a, b) = norm(a .- b) / norm(b)
+
+function run_case(name, traj, screen)
+    trajs = [traj]
+    A_ref = accumulate_potential(trajs, screen, Vern9())
+    println("\n═══ $name ═══")
+    for n in (1, 8)
+        e = rel_l2(accumulate_potential(trajs, screen, GPUKernelRK4(), CPU(); n_substeps = n), A_ref)
+        @printf("  RK4    n_substeps=%d : rel_l2 = %.2e\n", n, e)
+    end
+    for n in (1, 2, 3, 4)
+        e = rel_l2(accumulate_potential(trajs, screen, GPUKernelNewton(), CPU(); n_iters = n), A_ref)
+        @printf("  Newton n_iters=%d   : rel_l2 = %.2e\n", n, e)
+    end
+end
+
+# regime 1: transverse
+traj_t = analytic_traj(; g = 1.2, A = 0.25, Ω = 2.0, vz = 0.0,
+    τspan = (0.0, 20.0), N = 6000)
+z = 50.0
+grid = LinRange(-8.0, 8.0, 9)
+screen_t = ObserverScreen(grid, grid, z,
+    LinRange(0.0 + (z - 16.0), 1.2 * 20.0 + (z + 16.0), 240); c = 1.0)
+run_case("transverse (vz = 0)", traj_t, screen_t)
+
+# regime 2: forward Doppler
+g, vz = 1.05, 0.95
+traj_d = analytic_traj(; g, A = 0.15, Ω = 2.0, vz,
+    τspan = (0.0, 20.0), N = 8000)
+z = 60.0
+grid_d = LinRange(-6.0, 6.0, 7)
+screen_d = ObserverScreen(grid_d, grid_d, z,
+    LinRange(g * 0.0 + (z - vz * 20.0 - 6.0), g * 20.0 + (z + 6.0), 200); c = 1.0)
+run_case("forward Doppler (vz = 0.95)", traj_d, screen_d)

--- a/src/ElectronDynamicsModels.jl
+++ b/src/ElectronDynamicsModels.jl
@@ -66,15 +66,16 @@ include("field_evaluator.jl")
 include("gpu/interp.jl")
 include("gpu/accumulate.jl")
 include("gpu/kernel_rk4.jl")
-include("gpu/kernel_newton.jl")
 include("gpu_api.jl")   # vendor GPU API (device mgmt + telemetry); impls in ext/EDM{CUDA,AMDGPU}Ext.jl
 include("gpu/multidevice.jl")   # accumulate_field_sharded: electron sharding across GPUs
 
-# Experimental: batched/Tsit5 GPU path, under active development.
+# Experimental: batched/Tsit5 GPU path and the Newton light-cone retarded-time
+# solve — production staging, under active development.
 module Experimental
     include("gpu/experimental.jl")
+    include("gpu/kernel_newton.jl")
 end
 
-using .Experimental: GPUKernelTsit5
+using .Experimental: GPUKernelTsit5, GPUKernelNewton
 
 end

--- a/src/ElectronDynamicsModels.jl
+++ b/src/ElectronDynamicsModels.jl
@@ -44,7 +44,7 @@ export ReferenceFrame, Worldline,
     ring_pixels, phase_winding_fit,
     plot_harmonic_grid, plot_phase_grid, plot_phase_with_rings, plot_phase_polar, plot_power_spectrum, harmonic_colorrange, symmetric_colorrange,
     lienard_wiechert_F, lienard_wiechert_F_split, extract_EB, faraday, stress_energy,
-    GPUCubicSpline, GPUKernelRK4, GPUKernelTsit5, recommended_n_substeps,
+    GPUCubicSpline, GPUKernelRK4, GPUKernelTsit5, GPUKernelNewton, recommended_n_substeps,
     retarded_time_problem,
     gpu_device_count, gpu_device, gpu_device!, gpu_name, gpu_power, gpu_utilization,
     gpu_memory_info, gpu_telemetry_child_cmd, gpu_sm_count, gpu_max_threads_per_sm,
@@ -66,6 +66,7 @@ include("field_evaluator.jl")
 include("gpu/interp.jl")
 include("gpu/accumulate.jl")
 include("gpu/kernel_rk4.jl")
+include("gpu/kernel_newton.jl")
 include("gpu_api.jl")   # vendor GPU API (device mgmt + telemetry); impls in ext/EDM{CUDA,AMDGPU}Ext.jl
 include("gpu/multidevice.jl")   # accumulate_field_sharded: electron sharding across GPUs
 

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -1,0 +1,338 @@
+# ── Newton light-cone GPU kernel: per-slot root solve + LW accumulation ──
+# Experimental alternative to the GPUKernelRK4 march (kernel_rk4.jl): instead of
+# integrating dτ_r/dx⁰ = 1/(u⁰ − u⃗·n̂) between saveat slots, solve the light-cone
+# condition (FFT_v2.pdf eq. 1.2)
+#     f(τ) = x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)|  =  0
+# at each slot with warm-started Newton corrections.  f is strictly monotone
+# decreasing — f′(τ) = −(u⁰ − u⃗·n̂) < 0 since u⁰ ≥ |u⃗| on a timelike worldline —
+# so the root is unique and the Newton derivative comes for free from the same
+# spline eval that provides the residual.  Unlike the RK4 march, the per-slot
+# error does not accumulate along the observer-time grid.
+
+"""
+    GPUKernelNewton
+
+Sentinel solver type selecting the Newton light-cone GPU kernel path: the
+retarded proper time at each saveat slot is obtained by solving the light-cone
+condition `x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)| = 0` with `n_iters` warm-started
+Newton corrections, instead of marching the retarded-time ODE as
+[`GPUKernelRK4`](@ref) does.
+"""
+struct GPUKernelNewton end
+
+# One spline eval → light-cone residual f, Newton factor rhs = −1/f′, and the
+# geometric pieces the accumulation reuses.  The Newton update is
+# τ ← τ + f·rhs with rhs = 1/(u⁰ − u⃗·n̂) = r_norm/xr_dot_u > 0, and the final
+# (converged) eval doubles as the accumulation eval: `v` carries the full
+# [xμ; uμ] state and K/xr_dot_u = K·rhs/r_norm.
+@inline function _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+    v = gpu_traj.itp(τ)
+    x⁰ = v[gpu_traj.x_idxs[1]]
+    d¹ = r_obs[1] - v[gpu_traj.x_idxs[2]]
+    d² = r_obs[2] - v[gpu_traj.x_idxs[3]]
+    d³ = r_obs[3] - v[gpu_traj.x_idxs[4]]
+    r_norm = sqrt(d¹ * d¹ + d² * d² + d³ * d³)
+    u⁰ = v[gpu_traj.u_idxs[1]]
+    u¹ = v[gpu_traj.u_idxs[2]]
+    u² = v[gpu_traj.u_idxs[3]]
+    u³ = v[gpu_traj.u_idxs[4]]
+    # m_dot(xr, uμ) with xr = (r_norm, d¹, d², d³)
+    xr_dot_u = r_norm * u⁰ - (d¹ * u¹ + d² * u² + d³ * u³)
+    rhs = r_norm / xr_dot_u
+    f = x⁰_target - x⁰ - r_norm
+    return v, f, rhs, r_norm, d¹, d², d³
+end
+
+# Per-electron AK.foreachindex pass over (Nx × Ny) pixels; same closure pattern
+# as _gpu_unified_one_electron! (see the @kernel note at the top of
+# kernel_rk4.jl).  Window computation copied verbatim from the RK4 kernel; the
+# RK4 bridge+march is replaced by an Euler predictor + fixed-count Newton
+# corrections per slot (uniform trip count → no warp divergence).
+function _gpu_newton_one_electron!(
+        A_buf, gpu_traj,
+        x_grid, y_grid, z_screen,
+        x⁰_first, δx⁰, N_samples, Nx, Ny,
+        τi, τf, pixel_iter, backend, n_iters
+    )
+    K = gpu_traj.K
+    AK.foreachindex(pixel_iter, backend) do i_lin
+        # Column-major unpacking: ix runs fastest, iy outer
+        ix = ((i_lin - 1) % Nx) + 1
+        iy = ((i_lin - 1) ÷ Nx) + 1
+        r_obs = SVector{3}(x_grid[ix], y_grid[iy], z_screen)
+
+        # Pixel-specific advanced-time window x⁰_i, x⁰_f
+        v_i = gpu_traj.itp(τi)
+        d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
+        d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]
+        d_i³ = r_obs[3] - v_i[gpu_traj.x_idxs[4]]
+        R_i = sqrt(d_i¹^2 + d_i²^2 + d_i³^2)
+        x⁰_i_px = v_i[gpu_traj.x_idxs[1]] + R_i
+
+        v_f = gpu_traj.itp(τf)
+        d_f¹ = r_obs[1] - v_f[gpu_traj.x_idxs[2]]
+        d_f² = r_obs[2] - v_f[gpu_traj.x_idxs[3]]
+        d_f³ = r_obs[3] - v_f[gpu_traj.x_idxs[4]]
+        x⁰_f_px = v_f[gpu_traj.x_idxs[1]] + sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
+
+        inv_δ = inv(δx⁰)
+        # Strict-interior slot range matching Tsit5 with save_start/save_end=false.
+        k_start = max(1, floor(Int, (x⁰_i_px - x⁰_first) * inv_δ) + 2)
+        k_end = min(N_samples, ceil(Int, (x⁰_f_px - x⁰_first) * inv_δ))
+
+        if k_start > k_end
+            return
+        end
+
+        # Warm start at the window edge: τ(x⁰_i_px) = τi exactly, and the v_i
+        # eval above already provides rhs(τi) for the first predictor stride —
+        # no RK4 bridge needed.
+        u⁰_i = v_i[gpu_traj.u_idxs[1]]
+        u¹_i = v_i[gpu_traj.u_idxs[2]]
+        u²_i = v_i[gpu_traj.u_idxs[3]]
+        u³_i = v_i[gpu_traj.u_idxs[4]]
+        rhs = R_i / (R_i * u⁰_i - (d_i¹ * u¹_i + d_i² * u²_i + d_i³ * u³_i))
+        τ = τi
+        x⁰_target = x⁰_first + (k_start - 1) * δx⁰
+        Δ = x⁰_target - x⁰_i_px   # ∈ (0, δx⁰] unless k_start clamped to 1
+
+        for k in k_start:k_end
+            # Euler predictor from the previous slot's converged state, then
+            # fixed-count Newton corrections on the light-cone residual.
+            τ = clamp(τ + Δ * rhs, τi, τf)
+            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+            for _ in 1:n_iters
+                τ = clamp(τ + f * rhs, τi, τf)
+                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+            end
+
+            # Accumulate from the last residual eval — zero extra spline evals.
+            coeff = K * rhs / r_norm   # = K / m_dot(xr, uμ)
+            @inbounds A_buf[ix, iy, 1, k] += coeff * v[gpu_traj.u_idxs[1]]
+            @inbounds A_buf[ix, iy, 2, k] += coeff * v[gpu_traj.u_idxs[2]]
+            @inbounds A_buf[ix, iy, 3, k] += coeff * v[gpu_traj.u_idxs[3]]
+            @inbounds A_buf[ix, iy, 4, k] += coeff * v[gpu_traj.u_idxs[4]]
+
+            x⁰_target += δx⁰
+            Δ = δx⁰
+        end
+    end
+    return
+end
+
+"""
+    accumulate_potential(trajs, screen, ::GPUKernelNewton, backend; n_iters = 2, sync_per_electron = true)
+
+Newton light-cone GPU path: like the [`GPUKernelRK4`](@ref) unified kernel, but
+the retarded proper time at each saveat slot is found by solving the light-cone
+condition `x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)| = 0` directly (`n_iters`
+warm-started Newton corrections per slot) instead of integrating the
+retarded-time ODE between slots.
+
+Spline-eval budget per slot is `n_iters + 1` (the final residual eval doubles
+as the accumulation eval), vs `4·n_substeps + 1` for the RK4 march; and the
+per-slot error does not accumulate along the march, so accuracy is set by the
+convergence of the last Newton step alone.
+
+`sync_per_electron` as in the `GPUKernelRK4` method.
+"""
+function accumulate_potential(
+        trajs::Vector{<:TrajectoryInterpolant},
+        screen::ObserverScreen,
+        ::GPUKernelNewton,
+        backend::Backend;
+        n_iters::Int = 2,
+        sync_per_electron::Bool = true,
+    )
+    Nx, Ny = length(screen.x_grid), length(screen.y_grid)
+    N_samples = length(screen.x⁰_samples)
+
+    # Pixel-fastest layout (Nx, Ny leading) so warp-adjacent pixel-threads
+    # (consecutive ix) write consecutive addresses → coalesced accumulation.
+    A_buf = Adapt.adapt(backend, zeros(Nx, Ny, 4, N_samples))
+
+    x⁰_first = first(screen.x⁰_samples)
+    δx⁰ = step(screen.x⁰_samples)
+
+    # Iteration target: one element per pixel. Sentinel array; never read.
+    pixel_iter = Adapt.adapt(backend, zeros(Int8, Nx, Ny))
+
+    for traj in trajs
+        gpu_traj = Adapt.adapt(backend, to_gpu(traj))
+        τi = first(traj.itp.t)
+        τf = last(traj.itp.t)
+        _gpu_newton_one_electron!(
+            A_buf, gpu_traj,
+            screen.x_grid, screen.y_grid, screen.z,
+            x⁰_first, δx⁰, N_samples, Nx, Ny,
+            τi, τf, pixel_iter, backend, n_iters,
+        )
+        sync_per_electron && KernelAbstractions.synchronize(backend)
+        finalize(gpu_traj.itp.t)
+        finalize(gpu_traj.itp.h)
+        finalize(gpu_traj.itp.z)
+        finalize(gpu_traj.itp.c1)
+        finalize(gpu_traj.itp.c2)
+    end
+
+    return permutedims(Array(A_buf), (4, 3, 1, 2))
+end
+
+# ── Field variant of the Newton light-cone kernel ──
+# Identical per-slot Newton solve to `_gpu_newton_one_electron!`; each slot then
+# writes the split Liénard–Wiechert (E, B) exactly as
+# `_gpu_unified_field_one_electron!` does, reusing the converged residual eval
+# (`v`, `d`, `r_norm`) for the geometry, plus the unavoidable `a_itp` eval.
+function _gpu_newton_field_one_electron!(
+        mode::Val, E1_buf, B1_buf, E2_buf, B2_buf, gpu_traj, c,
+        x_grid, y_grid, z_screen,
+        x⁰_first, δx⁰, N_samples, Nx, Ny,
+        τi, τf, pixel_iter, backend, n_iters
+    )
+    K = gpu_traj.K
+    AK.foreachindex(pixel_iter, backend) do i_lin
+        # Column-major unpacking: ix runs fastest, iy outer
+        ix = ((i_lin - 1) % Nx) + 1
+        iy = ((i_lin - 1) ÷ Nx) + 1
+        r_obs = SVector{3}(x_grid[ix], y_grid[iy], z_screen)
+
+        # Pixel-specific advanced-time window x⁰_i, x⁰_f
+        v_i = gpu_traj.itp(τi)
+        d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
+        d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]
+        d_i³ = r_obs[3] - v_i[gpu_traj.x_idxs[4]]
+        R_i = sqrt(d_i¹^2 + d_i²^2 + d_i³^2)
+        x⁰_i_px = v_i[gpu_traj.x_idxs[1]] + R_i
+
+        v_f = gpu_traj.itp(τf)
+        d_f¹ = r_obs[1] - v_f[gpu_traj.x_idxs[2]]
+        d_f² = r_obs[2] - v_f[gpu_traj.x_idxs[3]]
+        d_f³ = r_obs[3] - v_f[gpu_traj.x_idxs[4]]
+        x⁰_f_px = v_f[gpu_traj.x_idxs[1]] + sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
+
+        inv_δ = inv(δx⁰)
+        # Strict-interior slot range matching Tsit5 with save_start/save_end=false.
+        k_start = max(1, floor(Int, (x⁰_i_px - x⁰_first) * inv_δ) + 2)
+        k_end = min(N_samples, ceil(Int, (x⁰_f_px - x⁰_first) * inv_δ))
+
+        if k_start > k_end
+            return
+        end
+
+        u⁰_i = v_i[gpu_traj.u_idxs[1]]
+        u¹_i = v_i[gpu_traj.u_idxs[2]]
+        u²_i = v_i[gpu_traj.u_idxs[3]]
+        u³_i = v_i[gpu_traj.u_idxs[4]]
+        rhs = R_i / (R_i * u⁰_i - (d_i¹ * u¹_i + d_i² * u²_i + d_i³ * u³_i))
+        τ = τi
+        x⁰_target = x⁰_first + (k_start - 1) * δx⁰
+        Δ = x⁰_target - x⁰_i_px
+
+        for k in k_start:k_end
+            τ = clamp(τ + Δ * rhs, τi, τf)
+            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+            for _ in 1:n_iters
+                τ = clamp(τ + f * rhs, τi, τf)
+                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+            end
+
+            # Field write from the converged eval (X reuses r_norm and d).
+            uμ = v[gpu_traj.u_idxs]
+            𝔞μ = gpu_traj.a_itp(τ)
+            X = SVector{4}(r_norm, d¹, d², d³)
+            F_near, F_far = lienard_wiechert_F_split(X, uμ, 𝔞μ, K, c)
+            E_near, B_near = extract_EB(F_near, c)
+            E_far, B_far = extract_EB(F_far, c)
+
+            for j in 1:3
+                if mode === Val(:split)
+                    @inbounds E1_buf[ix, iy, j, k] += E_far[j]
+                    @inbounds B1_buf[ix, iy, j, k] += B_far[j]
+                    @inbounds E2_buf[ix, iy, j, k] += E_near[j]
+                    @inbounds B2_buf[ix, iy, j, k] += B_near[j]
+                else
+                    @inbounds E1_buf[ix, iy, j, k] += E_far[j] + E_near[j]
+                    @inbounds B1_buf[ix, iy, j, k] += B_far[j] + B_near[j]
+                end
+            end
+
+            x⁰_target += δx⁰
+            Δ = δx⁰
+        end
+    end
+    return
+end
+
+"""
+    accumulate_field(trajs, screen, ::GPUKernelNewton, backend; n_iters = 2, mode = Val(:split), sync_per_electron = true)
+
+Field counterpart of the `GPUKernelNewton` [`accumulate_potential`](@ref)
+method: per-slot Newton light-cone solve instead of the RK4 retarded-time
+march, otherwise identical in buffers, `mode`, and streaming to the
+`GPUKernelRK4` [`accumulate_field`](@ref) method.
+"""
+function accumulate_field(
+        trajs::Vector{<:TrajectoryInterpolant},
+        screen::ObserverScreen,
+        ::GPUKernelNewton,
+        backend::Backend;
+        n_iters::Int = 2,
+        mode::Val = Val(:split),
+        sync_per_electron::Bool = true,
+    )
+    Nx, Ny = length(screen.x_grid), length(screen.y_grid)
+    N_samples = length(screen.x⁰_samples)
+    c = screen.c
+
+    E1_buf = Adapt.adapt(backend, zeros(Nx, Ny, 3, N_samples))
+    B1_buf = Adapt.adapt(backend, zeros(Nx, Ny, 3, N_samples))
+    if mode == Val(:split)
+        E2_buf = Adapt.adapt(backend, zeros(Nx, Ny, 3, N_samples))
+        B2_buf = Adapt.adapt(backend, zeros(Nx, Ny, 3, N_samples))
+    else
+        E2_buf = E1_buf
+        B2_buf = B1_buf
+    end
+
+    x⁰_first = first(screen.x⁰_samples)
+    δx⁰ = step(screen.x⁰_samples)
+
+    pixel_iter = Adapt.adapt(backend, zeros(Int8, Nx, Ny))
+
+    for traj in trajs
+        gpu_traj = Adapt.adapt(backend, to_gpu(traj; with_acceleration = true))
+        τi = first(traj.itp.t)
+        τf = last(traj.itp.t)
+        _gpu_newton_field_one_electron!(
+            mode, E1_buf, B1_buf, E2_buf, B2_buf, gpu_traj, c,
+            screen.x_grid, screen.y_grid, screen.z,
+            x⁰_first, δx⁰, N_samples, Nx, Ny,
+            τi, τf, pixel_iter, backend, n_iters,
+        )
+        sync_per_electron && KernelAbstractions.synchronize(backend)
+        finalize(gpu_traj.itp.t)
+        finalize(gpu_traj.itp.h)
+        finalize(gpu_traj.itp.z)
+        finalize(gpu_traj.itp.c1)
+        finalize(gpu_traj.itp.c2)
+        finalize(gpu_traj.a_itp.t)
+        finalize(gpu_traj.a_itp.h)
+        finalize(gpu_traj.a_itp.z)
+        finalize(gpu_traj.a_itp.c1)
+        finalize(gpu_traj.a_itp.c2)
+    end
+
+    if mode == Val(:split)
+        E_far = permutedims(Array(E1_buf), (4, 3, 1, 2))
+        B_far = permutedims(Array(B1_buf), (4, 3, 1, 2))
+        E_near = permutedims(Array(E2_buf), (4, 3, 1, 2))
+        B_near = permutedims(Array(B2_buf), (4, 3, 1, 2))
+        E = E_far .+ E_near
+        B = B_far .+ B_near
+        return (; E, B, E_far, B_far)
+    else
+        E = permutedims(Array(E1_buf), (4, 3, 1, 2))
+        B = permutedims(Array(B1_buf), (4, 3, 1, 2))
+        return (; E, B)
+    end
+end

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -4,7 +4,7 @@
 #
 # Alternative to the GPUKernelRK4 march (kernel_rk4.jl): instead of
 # integrating dτ_r/dx⁰ = 1/(u⁰ − u⃗·n̂) between saveat slots, solve the light-cone
-# condition (FFT_v2.pdf eq. 1.2)
+# condition
 #     f(τ) = x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)|  =  0
 # at each slot with warm-started Newton corrections.  f is strictly monotone
 # decreasing — f′(τ) = −(u⁰ − u⃗·n̂) < 0 since u⁰ ≥ |u⃗| on a timelike worldline —
@@ -19,9 +19,6 @@
 # to ~1.3× faster on the field path.  Strongly-relativistic forward-scattering
 # geometries need n_iters = 3 (the analog of RK4 needing n_substeps = 8 there).
 
-# Shared deps: experimental.jl (included first in this module) already imports
-# Adapt, AK, KernelAbstractions, Backend, StaticArrays, TrajectoryInterpolant,
-# ObserverScreen, and accumulate_potential.  This file additionally needs:
 using ..ElectronDynamicsModels: to_gpu, lienard_wiechert_F_split, extract_EB
 import ..ElectronDynamicsModels: accumulate_field
 
@@ -43,17 +40,20 @@ struct GPUKernelNewton end
 # [xμ; uμ] state and K/xr_dot_u = K·rhs/r_norm.
 @inline function _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
     v = gpu_traj.itp(τ)
-    x⁰ = v[gpu_traj.x_idxs[1]]
+    x⁰ = v[gpu_traj.x_idxs[1]] # x⁰(τ)
     d¹ = r_obs[1] - v[gpu_traj.x_idxs[2]]
     d² = r_obs[2] - v[gpu_traj.x_idxs[3]]
     d³ = r_obs[3] - v[gpu_traj.x_idxs[4]]
     r_norm = sqrt(d¹ * d¹ + d² * d² + d³ * d³)
+    # x⁰_target - x⁰(τ) = ||r_obs - x(τ)|| = ||R||
     u⁰ = v[gpu_traj.u_idxs[1]]
     u¹ = v[gpu_traj.u_idxs[2]]
     u² = v[gpu_traj.u_idxs[3]]
     u³ = v[gpu_traj.u_idxs[4]]
+    # X^μ = x^μ - x^μ(τ) = (x⁰_target - x⁰(τ), R)
     # m_dot(xr, uμ) with xr = (r_norm, d¹, d², d³)
     xr_dot_u = r_norm * u⁰ - (d¹ * u¹ + d² * u² + d³ * u³)
+    # n̂ = R/||R|| => X ⋅ u = r_norm * (u⁰ - n̂ ⋅ u⃗)
     rhs = r_norm / xr_dot_u
     f = x⁰_target - x⁰ - r_norm
     return v, f, rhs, r_norm, d¹, d², d³

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -1,5 +1,8 @@
 # ── Newton light-cone GPU kernel: per-slot root solve + LW accumulation ──
-# Experimental alternative to the GPUKernelRK4 march (kernel_rk4.jl): instead of
+# Lives in the `Experimental` submodule (production staging, like the batched
+# Tsit5 path) and extends the parent `accumulate_potential`/`accumulate_field`.
+#
+# Alternative to the GPUKernelRK4 march (kernel_rk4.jl): instead of
 # integrating dτ_r/dx⁰ = 1/(u⁰ − u⃗·n̂) between saveat slots, solve the light-cone
 # condition (FFT_v2.pdf eq. 1.2)
 #     f(τ) = x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)|  =  0
@@ -8,6 +11,19 @@
 # so the root is unique and the Newton derivative comes for free from the same
 # spline eval that provides the residual.  Unlike the RK4 march, the per-slot
 # error does not accumulate along the observer-time grid.
+#
+# Measured on the W7900 (a₀ = 0.1 production setup, see
+# reports/newton_lightcone_retarded_time.typ): n_iters = 1 sits at the accuracy
+# floor (9.4e-11 vs tight reference; RK4 n_substeps = 1 is 9.5e-10) and runs
+# 1.5–2.0× faster than RK4 n_substeps = 1 on the potential path, time-neutral
+# to ~1.3× faster on the field path.  Strongly-relativistic forward-scattering
+# geometries need n_iters = 3 (the analog of RK4 needing n_substeps = 8 there).
+
+# Shared deps: experimental.jl (included first in this module) already imports
+# Adapt, AK, KernelAbstractions, Backend, StaticArrays, TrajectoryInterpolant,
+# ObserverScreen, and accumulate_potential.  This file additionally needs:
+using ..ElectronDynamicsModels: to_gpu, lienard_wiechert_F_split, extract_EB
+import ..ElectronDynamicsModels: accumulate_field
 
 """
     GPUKernelNewton

--- a/test/gpu_radiation.jl
+++ b/test/gpu_radiation.jl
@@ -76,6 +76,59 @@ rel_l2(a, b) = norm(a .- b) / norm(b)
         @test rel_l2(A_ak, A_ref) < 5.0e-3
     end
 
+    @testset "GPUKernelNewton matches reference (bulk pattern)" begin
+        # Same transverse setup as the RK4 bulk-pattern test, through the
+        # Newton light-cone kernel. In this gentle regime a single warm-started
+        # Newton correction per slot already sits at the reference floor.
+        traj = analytic_traj(; g = 1.2, A = 0.25, Ω = 2.0, vz = 0.0,
+            τspan = (0.0, 20.0), N = 6000)
+        trajs = [traj]
+        τi, τf = first(traj.itp.t), last(traj.itp.t)
+
+        z = 50.0
+        Nx = Ny = 9
+        half = 8.0
+        x_grid = LinRange(-half, half, Nx)
+        y_grid = LinRange(-half, half, Ny)
+        x⁰ = LinRange(1.2τi + (z - 2half), 1.2τf + (z + 2half), 240)
+        screen = ObserverScreen(x_grid, y_grid, z, x⁰; c = 1.0)
+
+        A_ref = accumulate_potential(trajs, screen, Vern9())
+        A_newton = accumulate_potential(trajs, screen, GPUKernelNewton(), CPU(); n_iters = 1)
+
+        @test size(A_newton) == size(A_ref)
+        @test all(isfinite, A_newton)
+        @test rel_l2(A_newton, A_ref) < 5.0e-3
+    end
+
+    @testset "n_iters drives Newton convergence (forward Doppler)" begin
+        # Stress regime for the light-cone solve: dτ_r per slot is large and f
+        # is curved off-axis, so the Euler predictor lands far and iterations
+        # are genuinely needed. n_iters = 3 (4 spline evals/slot) matches the
+        # RK4 n_substeps = 8 floor (33 evals/slot).
+        traj = analytic_traj(; g = 1.05, A = 0.15, Ω = 2.0, vz = 0.95,
+            τspan = (0.0, 20.0), N = 8000)
+        trajs = [traj]
+        τi, τf = first(traj.itp.t), last(traj.itp.t)
+        g, vz = 1.05, 0.95
+
+        z = 60.0
+        Nx = Ny = 7
+        half = 6.0
+        x_grid = LinRange(-half, half, Nx)
+        y_grid = LinRange(-half, half, Ny)
+        x⁰ = LinRange(g * τi + (z - vz * τf - half), g * τf + (z + half), 200)
+        screen = ObserverScreen(x_grid, y_grid, z, x⁰; c = 1.0)
+
+        A_ref = accumulate_potential(trajs, screen, Vern9())
+        err(n) = rel_l2(accumulate_potential(trajs, screen, GPUKernelNewton(), CPU(); n_iters = n), A_ref)
+
+        e1, e3 = err(1), err(3)
+        @test e1 > 1.0e-2          # a single correction is not enough here
+        @test e3 < 5.0e-3          # three corrections reach reference agreement
+        @test e3 < e1              # adding corrections reduces the discrepancy
+    end
+
     @testset "n_substeps drives RK4 convergence (forward Doppler)" begin
         # Relativistic drift toward the screen ⇒ u⃗·n̂ ≈ u⁰ ⇒ the retarded-time
         # integrand swings hard, so n_substeps = 1 is visibly under-resolved.
@@ -133,6 +186,33 @@ rel_l2(a, b) = norm(a .- b) / norm(b)
         @test rel_l2(gpu.E, ref.E) < 5.0e-3         # total field matches
         @test rel_l2(gpu.B, ref.B) < 5.0e-3
         @test rel_l2(gpu.E_far, ref.E_far) < 5.0e-3 # radiation bucket matches
+        @test rel_l2(gpu.B_far, ref.B_far) < 5.0e-3
+    end
+
+    @testset "GPUKernelNewton field matches reference (split E/B)" begin
+        # Field path through the Newton light-cone kernel, same setup as the
+        # RK4 field test above.
+        traj = analytic_traj(; g = 1.2, A = 0.25, Ω = 2.0, vz = 0.0,
+            τspan = (0.0, 20.0), N = 6000)
+        trajs = [traj]
+        τi, τf = first(traj.itp.t), last(traj.itp.t)
+
+        z = 50.0
+        Nx = Ny = 9
+        half = 8.0
+        x_grid = LinRange(-half, half, Nx)
+        y_grid = LinRange(-half, half, Ny)
+        x⁰ = LinRange(1.2τi + (z - 2half), 1.2τf + (z + 2half), 240)
+        screen = ObserverScreen(x_grid, y_grid, z, x⁰; c = 1.0)
+
+        ref = accumulate_field(trajs, screen, Vern9())
+        gpu = accumulate_field(trajs, screen, GPUKernelNewton(), CPU(); n_iters = 2)
+
+        @test keys(gpu) == (:E, :B, :E_far, :B_far)
+        @test all(isfinite, gpu.E) && all(isfinite, gpu.B)
+        @test rel_l2(gpu.E, ref.E) < 5.0e-3
+        @test rel_l2(gpu.B, ref.B) < 5.0e-3
+        @test rel_l2(gpu.E_far, ref.E_far) < 5.0e-3
         @test rel_l2(gpu.B_far, ref.B_far) < 5.0e-3
     end
 end


### PR DESCRIPTION
## Summary

Adds `GPUKernelNewton` — an alternative retarded-time strategy for the unified GPU Liénard–Wiechert kernels that solves the light-cone condition (`FFT_v2.pdf` eq. 1.2)

```
f(τ) = x⁰_target − x⁰(τ) − |r_obs − r(τ)| = 0
```

per saveat sample with warm-started Newton corrections, instead of marching `dτ_r/dx⁰ = 1/(u⁰ − u·n̂)` with fixed-step RK4. Staged in the `Experimental` submodule (alongside `GPUKernelTsit5`), re-exported at top level; the production `GPUKernelRK4` path is untouched.

**Why it wins:** `f` is strictly monotone decreasing (`u⁰ ≥ |u|` on a timelike worldline) so the root is unique; the Newton derivative is the reciprocal of the existing RHS — free from the same spline eval; and the converged residual eval doubles as the accumulation eval. A sample costs `n_iters + 1` spline evals vs `4·n_substeps + 1` for RK4, with per-sample (non-accumulating) error.

## Results (W7900, a₀ = 0.1 production setup)

- **Accuracy** vs tight CPU reference (100 e⁻, 50², 1000 samples): RK4 ns=1 `9.5e-10` · RK4 ns=8 `5.7e-11` · **Newton it=1 `9.4e-11` — at the floor with one correction** (it=2/3 identical).
- **Potential path speed**, Newton it=1 vs RK4 ns=1: **1.80× / 1.97× / 1.49×** at (100,50²) / (300,50²) / (1000,200²); 9–11× vs the equal-accuracy ns=8 anchor.
- **Field path (split)**: it=1 time-neutral with ns=1 at 200² but **17× more accurate** (4.9e-8 vs 8.2e-7 rel. converged anchor), 4× faster than equal-accuracy ns=8; ~1.15–1.3× faster at 400². No register-pressure regression.
- Forward-Doppler stress regime (analytic vz=0.95c): needs `n_iters=3` — where RK4 needs ns=8 — still 8× fewer evals.

Full write-up with interactive convergence/benchmark explorers: [research.314159265.dev/reports/newton-lightcone](https://research.314159265.dev/reports/newton-lightcone/) (token-gated; source in `reports/newton_lightcone/`).

## Contents

- `src/gpu/kernel_newton.jl` — `_lightcone_eval`, per-pixel Newton march (window logic mirrors `kernel_rk4.jl` verbatim), `accumulate_potential`/`accumulate_field` methods (kwarg `n_iters`, default 2; fixed iteration count → no warp divergence)
- `test/gpu_radiation.jl` — 3 new testsets (bulk-pattern, n_iters convergence in the forward-Doppler regime, split-field), 28 pass
- `scripts/` — validation ladder (`v1_newton_root_check.jl`, `v2_newton_kernel_check.jl`, `diag_newton_precision.jl`) and benchmarks (`benchmark_newton_gpu.jl`, `benchmark_newton_field_gpu.jl`)

The interactive report bundle is deliberately NOT in this repo — results artifacts (like plots) live with the dashboard: the bundle is versioned in `EDM_results_dashboard` and served from the data volume.

## Recommended usage

`n_iters = 1` for a₀ ≲ 0.1 campaigns (potential and field); `n_iters = 3` for strongly-relativistic forward-scattering geometries. Promotion to production default pending a high-a₀ sweep and a full-campaign A/B (e.g. a lowa0_maps cell).

Note: rebased onto main from `worktree-newton-lightcone` (without the spline-error-analysis parent commit and without the report files); the worktree branch stays as the full experiment record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
