### PR TITLE
test: atol for near-zero components in the k_direction sign-flip loop

### DIFF
--- a/test/laguerre_gauss.jl
+++ b/test/laguerre_gauss.jl
@@ -369,11 +369,16 @@ end
     for x in (0.0, 0.4), y in (0.0, 0.5), z in (-0.3, 0.0, 0.5), t in (0.0, 0.7)
         r_neg     = fe_neg_c([t, x, y, z])
         r_pos_at_neg = fe_pos_c([t, x, y, -z])
-        @test r_neg.E[1] ≈  r_pos_at_neg.E[1]
-        @test r_neg.E[2] ≈  r_pos_at_neg.E[2]
-        @test r_neg.E[3] ≈ -r_pos_at_neg.E[3]
-        @test r_neg.B[1] ≈ -r_pos_at_neg.B[1]
-        @test r_neg.B[2] ≈ -r_pos_at_neg.B[2]
-        @test r_neg.B[3] ≈ -r_pos_at_neg.B[3]
+        # atol: components that are physical zeros at a sample point (e.g. E_z
+        # on axis) come out as O(1e-14) roundoff whose value differs between the
+        # ±ẑ code paths — a bare ≈ (relative) comparison trips on that noise.
+        # Fields are O(1) in these units, so 1e-10 is far above roundoff and far
+        # below any real component.
+        @test r_neg.E[1] ≈  r_pos_at_neg.E[1] atol = 1e-10
+        @test r_neg.E[2] ≈  r_pos_at_neg.E[2] atol = 1e-10
+        @test r_neg.E[3] ≈ -r_pos_at_neg.E[3] atol = 1e-10
+        @test r_neg.B[1] ≈ -r_pos_at_neg.B[1] atol = 1e-10
+        @test r_neg.B[2] ≈ -r_pos_at_neg.B[2] atol = 1e-10
+        @test r_neg.B[3] ≈ -r_pos_at_neg.B[3] atol = 1e-10
     end
 end


### PR DESCRIPTION
Fixes the deterministic failure currently blocking #29's CI (and any fresh-manifest run):

```
k_direction (±ẑ propagation): Test Failed at test/laguerre_gauss.jl:374
  Expression: r_neg.E[3] ≈ -(r_pos_at_neg.E[3])
   Evaluated: 3.618442769626261e-14 ≈ 3.618764437576268e-14
```

**Not related to #29** — that PR touches no field-evaluation code (scripts, plotting ext, RunManifests, harmonics only), and the failure reproduces byte-for-byte on current `main`-lineage code with a freshly resolved test environment.

Root cause: the sign-flip loop compares each component with a bare `≈` (relative tolerance ~1.5e-8). At sample points where a component is a physical zero (e.g. `E_z` on axis), both codepaths produce O(1e-14) roundoff — but *different* roundoff (the ±ẑ paths order the arithmetic differently), so the relative comparison fails on noise. A dependency update shifted the roundoff enough to trip it.

Fix: `atol = 1e-10` on the six component comparisons — fields are O(1) in these units, so ~4 orders above the noise floor and ~10 below signal. 151/151 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)