### PR TITLE
GPUKernelNewton production wiring + a0 sweep campaigns

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -189,6 +189,12 @@ function run_spec_from_manifest(manifest::AbstractDict)
     haskey(cfg, "harmonics") && (env["EDM_HARMONICS"] = join(cfg["harmonics"], ","))
     haskey(cfg, "reltol") && (env["EDM_RELTOL"] = string(cfg["reltol"]))
     haskey(cfg, "abstol") && (env["EDM_ABSTOL"] = string(cfg["abstol"]))
+    # Retarded-time GPU solver — guarded: absent in pre-Newton manifests (⇒ rk4 default).
+    # The manifest records the dashboard-canonical kernel name; map it to the env value.
+    solver_env = Dict("GPUKernelRK4" => "rk4", "GPUKernelNewton" => "newton")
+    alg = get(cfg, "accumulation_alg", nothing)
+    haskey(solver_env, alg) && (env["EDM_GPU_SOLVER"] = solver_env[alg])
+    haskey(cfg, "newton_iters") && (env["EDM_NEWTON_ITERS"] = string(cfg["newton_iters"]))
     sv = get(cfg, "interp_saveat", "adaptive")
     sv != "adaptive" && (env["EDM_INTERP_SAVEAT"] = string(sv))
     return (; commit, env)

--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -190,10 +190,15 @@ function run_spec_from_manifest(manifest::AbstractDict)
     haskey(cfg, "reltol") && (env["EDM_RELTOL"] = string(cfg["reltol"]))
     haskey(cfg, "abstol") && (env["EDM_ABSTOL"] = string(cfg["abstol"]))
     # Retarded-time GPU solver — guarded: absent in pre-Newton manifests (⇒ rk4 default).
-    # The manifest records the dashboard-canonical kernel name; map it to the env value.
+    # The manifest records the dashboard-canonical kernel name; emit BOTH knob spellings so
+    # replay works on any pinned commit (EDM_ACCUM_ALG = canonical, EDM_GPU_SOLVER = the
+    # legacy alias the first newton-campaign scripts read).
     solver_env = Dict("GPUKernelRK4" => "rk4", "GPUKernelNewton" => "newton")
     alg = get(cfg, "accumulation_alg", nothing)
-    haskey(solver_env, alg) && (env["EDM_GPU_SOLVER"] = solver_env[alg])
+    if haskey(solver_env, alg)
+        env["EDM_ACCUM_ALG"] = solver_env[alg]
+        env["EDM_GPU_SOLVER"] = solver_env[alg]
+    end
     haskey(cfg, "newton_iters") && (env["EDM_NEWTON_ITERS"] = string(cfg["newton_iters"]))
     sv = get(cfg, "interp_saveat", "adaptive")
     sv != "adaptive" && (env["EDM_INTERP_SAVEAT"] = string(sv))

--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -332,12 +332,16 @@ function write_derived(
     return joinpath(dir, name)
 end
 
-# Normalise one comparison side spec to (label, dir, script). Accepts a NamedTuple
-# `(; label, dir[, script])`, a `Dict`, or a `(label, dir[, script])` tuple.
+# Normalise one comparison side spec to (label, dir, script, where). Accepts a NamedTuple
+# `(; label, dir[, script][, var"where"])`, a `Dict` (keys "label"/"dir"/"script"/"where"),
+# or a `(label, dir[, script])` tuple. `where` — a Dict of canonical-param => value
+# constraints — selects WHICH runs of `dir` form this side (for same-dir sides).
 function _side_fields(s)
-    s isa AbstractDict && return (s["label"], s["dir"], get(s, "script", nothing))
-    s isa NamedTuple && return (s.label, s.dir, hasproperty(s, :script) ? s.script : nothing)
-    s isa Tuple && return (s[1], s[2], length(s) >= 3 ? s[3] : nothing)
+    s isa AbstractDict &&
+        return (s["label"], s["dir"], get(s, "script", nothing), get(s, "where", nothing))
+    s isa NamedTuple && return (s.label, s.dir, hasproperty(s, :script) ? s.script : nothing,
+        hasproperty(s, :where) ? getproperty(s, :where) : nothing)
+    s isa Tuple && return (s[1], s[2], length(s) >= 3 ? s[3] : nothing, nothing)
     return error("write_comparison: unrecognised side spec of type $(typeof(s))")
 end
 
@@ -352,10 +356,13 @@ runs) are compared, matched cell-by-cell along a shared swept axis.
 `sides` is a vector of at least two side specs — each a NamedTuple `(; label, dir[, script])`,
 a `Dict`, or a `(label, dir[, script])` tuple. `dir` is a results-dir **basename** the dashboard
 resolves to the sweep auto-detected there; the optional `script` disambiguates a dir holding more
-than one sweep (e.g. an LPWA and a Thomson run in the same folder). `differs` is a free-form label
-for what distinguishes the sides (e.g. `"method"`); `along` names the shared swept axis to match on
-— **omit it** to let the dashboard infer the sides' common axis (the usual case, since a per-pair
-caller can't see what the whole campaign sweeps).
+than one sweep (e.g. an LPWA and a Thomson run in the same folder). A side may also carry a
+`where` Dict of canonical-param => value constraints (Dict key `"where"`, or NT field
+`var"where"`) restricting the side to the matching runs of its dir — required when BOTH sides
+live in one campaign dir (e.g. two retarded-time kernels swept in one campaign). `differs` is a
+free-form label for what distinguishes the sides (e.g. `"method"`); `along` names the shared
+swept axis to match on — **omit it** to let the dashboard infer the sides' common axis (the
+usual case, since a per-pair caller can't see what the whole campaign sweeps).
 
 Idempotent: `filename` defaults to a deterministic slug of the side dirs, so a per-pair comparison
 re-run across a sweep rewrites ONE declaration instead of accumulating copies. Stamps the current
@@ -369,9 +376,11 @@ function write_comparison(
     sidedicts = Dict{String, Any}[]
     dirtags = String[]
     for s in sides
-        sl, sd, sc = _side_fields(s)
+        sl, sd, sc, sw = _side_fields(s)
         d = Dict{String, Any}("label" => string(sl), "dir" => string(sd))
         sc === nothing || (d["script"] = string(sc))
+        sw === nothing || isempty(sw) ||
+            (d["where"] = Dict{String, Any}(string(k) => v for (k, v) in pairs(sw)))
         push!(sidedicts, d)
         push!(dirtags, string(sd))
     end

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -33,7 +33,10 @@ BRANCH="${HOTAISLE_BRANCH:-main}"
 STATE="${HOTAISLE_STATE:-$HOME/.config/hotaisle/campaign_vm}"
 OUT="${HOTAISLE_OUT:-$HOME/campaign_out}"
 DEPOT_CACHE="${DEPOT_CACHE:-}"; DEPOT_CACHE_KEY="${DEPOT_CACHE_KEY:-$HOME/.config/runpod/depot_key}"   # shared cache (see depot_cache.sh)
-CM="$HOME/.ssh/cm-hotaisle.sock"
+# %C = per-destination hash — parallel invocations (2 VMs, distinct HOTAISLE_STATE) MUST NOT
+# share a master socket: ssh multiplexes on ControlPath alone, so a fixed path sends the second
+# VM's commands to the first VM (its warm's `rm -rf EDM` then kills that VM's running campaign).
+CM="$HOME/.ssh/cm-hotaisle-%C.sock"
 SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600"
 
 api()       { curl -fsS -X "$1" -H "Authorization: Token $TOK" "${@:3}" "$API$2"; }

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -49,8 +49,8 @@ price()     { api GET /virtual_machines/available/ | jq -r --argjson g "$GPUS" \
               '[.[]|select(.Specs.gpus[0].model=="MI300X" and .Specs.gpus[0].count==$g)|.OnDemandPrice*$g][0]//empty'; }
 
 # Persistent cost ledger (shared with runpod.sh; reported by orchestration/cost_report.sh).
-# Append-only TSV; rate_cents_h = the VM's $/h in CENTS captured at provision (list prices drift —
-# and Hot Aisle re-rates RUNNING VMs on a rise, so cost_report.sh also honours rate_change rows).
+# Append-only TSV; rate_cents_h = the VM's $/h in CENTS captured at provision (list prices drift;
+# top-up reconciliation 2026-07-17 confirmed a VM bills its provision-time list price for life).
 # A ledger write must NEVER break a campaign ⇒ every append is best-effort.
 LEDGER="${EDM_CLOUD_LEDGER:-$HOME/.config/edm-cloud-ledger.tsv}"
 ledger()    {   # ledger <vm> <event> <detail> [rate_cents_h] [balance_usd]

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -45,13 +45,29 @@ log()       { echo "[$(date -u +%FT%TZ)] $*"; }
 balance()   { api GET /balance/ | jq -r '.available_balance/100'; }
 min_resv()  { api GET /virtual_machines/available/ | jq -r --argjson g "$GPUS" \
               '[.[]|select(.Specs.gpus[0].model=="MI300X" and .Specs.gpus[0].count==$g)|.MinimumReservationMinutes][0]//1'; }
+price()     { api GET /virtual_machines/available/ | jq -r --argjson g "$GPUS" \
+              '[.[]|select(.Specs.gpus[0].model=="MI300X" and .Specs.gpus[0].count==$g)|.OnDemandPrice*$g][0]//empty'; }
+
+# Persistent cost ledger (shared with runpod.sh; reported by orchestration/cost_report.sh).
+# Append-only TSV; rate_cents_h = the VM's $/h in CENTS captured at provision (list prices drift —
+# and Hot Aisle re-rates RUNNING VMs on a rise, so cost_report.sh also honours rate_change rows).
+# A ledger write must NEVER break a campaign ⇒ every append is best-effort.
+LEDGER="${EDM_CLOUD_LEDGER:-$HOME/.config/edm-cloud-ledger.tsv}"
+ledger()    {   # ledger <vm> <event> <detail> [rate_cents_h] [balance_usd]
+    { mkdir -p "$(dirname "$LEDGER")"
+      [ -f "$LEDGER" ] || printf 'ts_utc\tprovider\tvm\tevent\tdetail\trate_cents_h\tbalance_usd\n' > "$LEDGER"
+      printf '%s\thotaisle\t%s\t%s\t%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$1" "$2" "$3" "${4:-}" "${5:-}" >> "$LEDGER"
+    } 2>/dev/null || true
+}
 
 provision() {
-    log "provisioning ${GPUS}×MI300X (balance \$$(balance))…"
+    local bal rate; bal=$(balance 2>/dev/null) || bal=""; rate=$(price 2>/dev/null) || rate=""
+    log "provisioning ${GPUS}×MI300X (balance \$${bal:-?}, list ${rate:-?}¢/h)…"
     local vm; vm=$(api POST /virtual_machines/ -H "Content-Type: application/json" \
         --data-binary "{\"gpus\":[{\"model\":\"MI300X\",\"count\":$GPUS}]}")
     NAME=$(echo "$vm"|jq -r .name); IP=$(echo "$vm"|jq -r .ssh_access.ip_address); PROV_TS=$(date +%s)
     log "provisioned $NAME ($IP)"
+    ledger "$NAME" provision "gpus=$GPUS" "$rate" "$bal"
 }
 wait_ssh() { log "waiting for ssh…"; local i; for i in $(seq 1 40); do ssh_vm true 2>/dev/null && return 0; sleep 15; done; return 1; }
 warm() {
@@ -130,6 +146,7 @@ run_campaign() {
     fi
     push_orchestration   # VM runs the driver's framework + this campaign file (works pre-merge too)
     notify hourglass_flowing_sand default "EDM hotaisle started" "$CAMPAIGN on $NAME (${GPUS}×MI300X)"
+    ledger "$NAME" campaign_start "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"
     log "launching $CAMPAIGN on the VM via the local backend (rocm), detached…"
     # nohup + a pidfile (not setsid): keeps the driver's PID so we can tell "still running" from "crashed".
     # juliaup's PATH lives in .bashrc/.profile, which a non-interactive ssh shell never sources — export
@@ -140,6 +157,7 @@ run_campaign() {
     until ssh_vm "grep -q '\\] ${CAMPAIGN} DONE' EDM/runs/${CAMPAIGN}.out 2>/dev/null"; do
         if ! ssh_vm "kill -0 \$(cat EDM/runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
             notify rotating_light urgent "EDM hotaisle CRASH" "$CAMPAIGN driver died with no DONE on $NAME — VM KEPT for inspection; teardown when done (verify in TUI)."
+            ledger "$NAME" campaign_crash "campaign=$CAMPAIGN driver died, no DONE"
             log "[ERROR] driver process gone, no DONE marker — likely crashed. VM $NAME KEPT. tail:"; ssh_vm "tail -n 20 EDM/runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[vm] /'
             return 1
         fi
@@ -151,6 +169,7 @@ run_campaign() {
         hotaisle@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
     download_verify "$OUT/$CAMPAIGN" || log "[verify] integrity problems — products also remain on VM:EDM/runs/$CAMPAIGN"
     notify white_check_mark default "EDM hotaisle done" "$CAMPAIGN → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM — run teardown."
+    ledger "$NAME" campaign_done "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"
     log "products → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM (state $STATE). Add more: $0 run <campaign>. Finish: $0 teardown"
 }
 
@@ -165,8 +184,10 @@ teardown() {
     /usr/bin/ssh -O exit -o ControlPath="$CM" hotaisle@"$IP" 2>/dev/null || true
     if api DELETE "/virtual_machines/$NAME/" >/dev/null 2>&1; then
         rm -f "$STATE"
-        log "API delete of $NAME accepted; balance \$$(balance). VERIFY it's gone in the TUI (ssh admin.hotaisle.app) — billing stops on TUI destroy."
-        notify checkered_flag default "EDM hotaisle torn down" "$NAME deleted; balance \$$(balance). Verify in TUI."
+        local bal; bal=$(balance 2>/dev/null) || bal=""
+        ledger "$NAME" teardown "" "" "$bal"
+        log "API delete of $NAME accepted; balance \$${bal:-?}. VERIFY it's gone in the TUI (ssh admin.hotaisle.app) — billing stops on TUI destroy."
+        notify checkered_flag default "EDM hotaisle torn down" "$NAME deleted; balance \$${bal:-?}. Verify in TUI."
     else
         notify rotating_light urgent "EDM teardown FAILED" "API DELETE of $NAME errored — VM likely STILL UP + billing. Destroy it in the TUI now (ssh admin.hotaisle.app)."
         log "[ERROR] API DELETE of $NAME FAILED — VM likely STILL UP + billing. DESTROY IN THE TUI. state kept at $STATE."

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -113,6 +113,15 @@ run_campaign() {
     . "$cf"   # CAMPAIGN (for product paths); the same file is re-read on the VM
     if vm_reachable; then
         log "reusing kept-warm VM $NAME ($IP) from $STATE (no provision/warm)"
+        # A reused VM keeps whatever clone it was warmed with — sync it to the requested
+        # branch or later commits silently run the WRONG scripts (campaign files ship via
+        # push_orchestration, but scripts/ + lib/ come from the VM's clone). Cheap no-op
+        # when already current; instantiate tops up any dep drift.
+        log "syncing VM clone to $BRANCH…"
+        ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && git fetch --quiet origin '$BRANCH' \
+            && git checkout --quiet '$BRANCH' && git merge --quiet --ff-only \"origin/$BRANCH\" \
+            && julia --startup=no --project=scripts -e 'using Pkg; Pkg.instantiate()' > /dev/null 2>&1 \
+            && git log --oneline -1" | sed 's/^/[vm-clone] /'
     else
         trap 'rc=$?; log "FAILED (rc=$rc) before VM was handed off"; notify rotating_light urgent "EDM hotaisle FAILED" "$CAMPAIGN setup errored (rc=$rc); tearing down"; teardown; exit $rc' ERR
         provision; wait_ssh; warm

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -126,7 +126,10 @@ grab_pod() {
                       dockerEntrypoint:["/bin/bash","-c"],dockerStartCmd:[$start]}
                      + (if $vol != "" then {networkVolumeId:$vol,volumeMountPath:"/workspace"} else {} end)')" 2>/dev/null)" || resp=""
             pid="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null)"
-            [ -n "$pid" ] && { POD="$pid"; log "grabbed $gpu → pod $POD ($BACKEND / $IMAGE)"; return 0; }
+            # Camping can run unattended for hours and billing starts HERE, before warm —
+            # ping as soon as a pod is secured, not only at campaign launch.
+            [ -n "$pid" ] && { POD="$pid"; log "grabbed $gpu → pod $POD ($BACKEND / $IMAGE)"; \
+                notify satellite default "EDM runpod grabbed" "$gpu → pod $POD (try $try/$MAXTRIES, billing started)"; return 0; }
         done
         [ $(( (try-1) % 10 )) -eq 0 ] && log "  no capacity yet (try $try/$MAXTRIES)…"
         sleep "$POLL"

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -52,6 +52,18 @@ rp()      { curl -fsS -H "Authorization: Bearer $TOK" -H "Content-Type: applicat
 ssh_vm()  { /usr/bin/ssh $SSHOPTS -p "$PORT" root@"$IP" "$@"; }
 log()     { echo "[$(date -u +%FT%TZ)] $*"; }
 
+# Persistent cost ledger (shared with hotaisle.sh; reported by orchestration/cost_report.sh).
+# rate_cents_h = the pod's costPerHr (converted to cents) captured at grab time — rates vary per
+# GPU type and drift. TODO: RunPod has a billing API (cf. MCP get-billing) — wire a cheap spend
+# read into the balance_usd column if/when useful. A ledger write must NEVER break a campaign.
+LEDGER="${EDM_CLOUD_LEDGER:-$HOME/.config/edm-cloud-ledger.tsv}"
+ledger()  {   # ledger <vm> <event> <detail> [rate_cents_h] [balance_usd]
+    { mkdir -p "$(dirname "$LEDGER")"
+      [ -f "$LEDGER" ] || printf 'ts_utc\tprovider\tvm\tevent\tdetail\trate_cents_h\tbalance_usd\n' > "$LEDGER"
+      printf '%s\trunpod\t%s\t%s\t%s\t%s\t%s\n' "$(date -u +%FT%TZ)" "$1" "$2" "$3" "${4:-}" "${5:-}" >> "$LEDGER"
+    } 2>/dev/null || true
+}
+
 # sshd bootstrap: sshd in the foreground IS the keep-alive; also authorize the injected key.
 # Needed on any image or the container crash-loops (rocm/pytorch's default CMD just exits).
 # rsync + zstd serve the depot cache restore/push and the product download, on ANY base image.
@@ -112,7 +124,7 @@ grab_pod() {
     local -a cands; mapfile -t cands < <(gpu_candidates)
     [ "${#cands[@]}" -gt 0 ] || { log "[ERROR] gpu_candidates returned nothing"; return 1; }
     log "grabbing (poll ${POLL}s ≤$MAXTRIES tries): ${cands[*]}"
-    local try gpu prof resp pid
+    local try gpu prof resp pid rate
     for ((try=1; try<=MAXTRIES; try++)); do
         for gpu in "${cands[@]}"; do
             prof="$(gpu_profile "$gpu")"; [ -n "$prof" ] || { log "no profile for '$gpu'"; continue; }
@@ -128,7 +140,10 @@ grab_pod() {
             pid="$(echo "$resp" | jq -r '.id // empty' 2>/dev/null)"
             # Camping can run unattended for hours and billing starts HERE, before warm —
             # ping as soon as a pod is secured, not only at campaign launch.
-            [ -n "$pid" ] && { POD="$pid"; log "grabbed $gpu → pod $POD ($BACKEND / $IMAGE)"; \
+            [ -n "$pid" ] && { POD="$pid"
+                rate="$(echo "$resp" | jq -r 'if .costPerHr then (.costPerHr*100|round) else empty end' 2>/dev/null)" || rate=""
+                ledger "$POD" provision "gpu=$gpu dc=$DC" "$rate"
+                log "grabbed $gpu → pod $POD ($BACKEND / $IMAGE, ${rate:-?}¢/h)"
                 notify satellite default "EDM runpod grabbed" "$gpu → pod $POD (try $try/$MAXTRIES, billing started)"; return 0; }
         done
         [ $(( (try-1) % 10 )) -eq 0 ] && log "  no capacity yet (try $try/$MAXTRIES)…"
@@ -216,6 +231,7 @@ monitor_and_download() {   # poll for DONE (crash = 3 consecutive dead liveness 
             if [ "$misses" -ge 3 ]; then
                 ssh_vm "cd EDM && grep -q '\\] ${CAMPAIGN} DONE' runs/${CAMPAIGN}.out 2>/dev/null" && break   # finished between checks
                 notify rotating_light urgent "EDM runpod CRASH" "$CAMPAIGN driver died with no DONE on $POD — pod KEPT; '$0 attach' to retry or teardown."
+                ledger "$POD" campaign_crash "campaign=$CAMPAIGN driver died, no DONE"
                 log "[ERROR] driver gone, no DONE — pod $POD KEPT. tail:"; ssh_vm "cd EDM && tail -n 20 runs/${CAMPAIGN}.out 2>/dev/null" | sed 's/^/[pod] /'; return 1
             fi
             log "  liveness check failed ($misses/3) — transient ssh blip or a real crash, retrying…"
@@ -239,6 +255,7 @@ monitor_and_download() {   # poll for DONE (crash = 3 consecutive dead liveness 
         log "campaign done; rsync skipped (RUNPOD_RSYNC_DOWNLOAD=0) — drain from the volume later: orchestration/drain.sh $CAMPAIGN"
     fi
     notify white_check_mark default "EDM runpod done" "$CAMPAIGN → $OUT/$CAMPAIGN ; pod $POD KEPT — run teardown."
+    ledger "$POD" campaign_done "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"
     log "products → $OUT/$CAMPAIGN ; pod $POD KEPT (state $STATE). More: $0 run <campaign>. Finish: $0 teardown"
 }
 
@@ -273,6 +290,7 @@ run_campaign() {
         log "$CAMPAIGN already RUNNING on the pod — monitoring it (no relaunch)"
     else
         notify hourglass_flowing_sand default "EDM runpod started" "$CAMPAIGN on $POD ($BACKEND @$DC)"
+        ledger "$POD" campaign_start "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"
         log "launching $CAMPAIGN on the pod via the local backend ($BACKEND), detached…"
         ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && rm -f runs/${CAMPAIGN}.out runs/${CAMPAIGN}.pid && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
     fi
@@ -291,7 +309,8 @@ teardown() {   # delete the pod (stops GPU billing); a volume, if attached, is K
     read -r POD IP PORT VOLID BACKEND < "$STATE"; [ "$VOLID" = "-" ] && VOLID=""
     /usr/bin/ssh -O exit -o ControlPath="$CM" root@"$IP" 2>/dev/null || true
     if rp -X DELETE "$API/pods/$POD" >/dev/null 2>&1; then
-        rm -f "$STATE"; log "deleted pod $POD${VOLID:+; volume $VOLID KEPT (drain via S3, then delete to stop storage \$)}"
+        rm -f "$STATE"; ledger "$POD" teardown "${VOLID:+volume=$VOLID kept}"
+        log "deleted pod $POD${VOLID:+; volume $VOLID KEPT (drain via S3, then delete to stop storage \$)}"
         notify checkered_flag default "EDM runpod torn down" "pod $POD deleted${VOLID:+; volume $VOLID kept}."
     else
         notify rotating_light urgent "EDM teardown FAILED" "DELETE of pod $POD errored — likely STILL billing. Delete in console."

--- a/orchestration/campaigns/newton_a0_high.sh
+++ b/orchestration/campaigns/newton_a0_high.sh
@@ -13,7 +13,7 @@ BASE=(
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
   EDM_POL=circular_minus
   EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
-  EDM_GPU_SOLVER=newton EDM_NEWTON_ITERS=3
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=3
   EDM_NSAMPLES=12160 EDM_SPP=32         # UNIFORM across cells (Nyquist h16, 380-period window):
                                         # keeps the a0 sweep 1-D on the dashboard and the maps
                                         # spectrally comparable; check a2's power spectrum before

--- a/orchestration/campaigns/newton_a0_high.sh
+++ b/orchestration/campaigns/newton_a0_high.sh
@@ -1,0 +1,30 @@
+# campaigns/newton_a0_high.sh — GPUKernelNewton high-a0 (nonlinear Thomson) half of the sweep.
+# n_iters=3: strongly-relativistic forward scattering is where the warm start needs the extra
+# correction (kernel_newton.jl header / newton_lightcone report).
+# Sampling at high a0: the arrival-time window is NSAMPLES/SPP laser periods — keep ≥ ~380 to
+# cover the ±8τ pulse crossing (the light-front crossing time is a0-independent, so the window
+# LENGTH is fine; it's the Nyquist harmonic = SPP/2 that high a0 outruns). Raising SPP at fixed
+# window ⇒ NSAMPLES = 380·SPP, and cell cost scales ∝ NSAMPLES (~56 min at 6000 on MI300X).
+CAMPAIGN=newton_a0_high
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=400 EDM_FIELD_MODE=total
+  EDM_N=10000 EDM_RELTOL=1e-12
+  EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
+  EDM_POL=circular_minus
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_GPU_SOLVER=newton EDM_NEWTON_ITERS=3
+  EDM_NSAMPLES=12160 EDM_SPP=32         # UNIFORM across cells (Nyquist h16, 380-period window):
+                                        # keeps the a0 sweep 1-D on the dashboard and the maps
+                                        # spectrally comparable; check a2's power spectrum before
+                                        # a5/a10 run — if content nears Nyquist, requeue those at
+                                        # SPP=48/NSAMPLES=18240 (VRAM caps NSAMPLES ≲ 22k at NX=400)
+)
+CELLS=(
+    "a2em1|EDM_A0=0.2"
+    "a5em1|EDM_A0=0.5"
+    "a1|EDM_A0=1"
+    "a2|EDM_A0=2"
+    "a5|EDM_A0=5"
+    "a10|EDM_A0=10"
+)

--- a/orchestration/campaigns/newton_a0_low.sh
+++ b/orchestration/campaigns/newton_a0_low.sh
@@ -12,7 +12,7 @@ BASE=(
   EDM_N=10000 EDM_RELTOL=1e-12
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
   EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
-  EDM_GPU_SOLVER=newton EDM_NEWTON_ITERS=2
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
 )
 CELLS=(
   "circ_a1em3|EDM_POL=circular_minus EDM_A0=1e-3"
@@ -23,6 +23,6 @@ CELLS=(
   # RK4 controls — the same-hardware solver A/B baseline at both a0 decades (the 1e-3 one
   # doubles as a Newton-vs-RK4 check in the spline-floor regime). No _it1 twins for rk4:
   # n_iters doesn't exist there, they'd be duplicate runs.
-  "circ_a1e1_rk4|EDM_POL=circular_minus EDM_A0=0.1 EDM_GPU_SOLVER=rk4 EDM_NSUBSTEPS=1"
-  "circ_a1em3_rk4|EDM_POL=circular_minus EDM_A0=1e-3 EDM_GPU_SOLVER=rk4 EDM_NSUBSTEPS=1"
+  "circ_a1e1_rk4|EDM_POL=circular_minus EDM_A0=0.1 EDM_ACCUM_ALG=rk4 EDM_NSUBSTEPS=1"
+  "circ_a1em3_rk4|EDM_POL=circular_minus EDM_A0=1e-3 EDM_ACCUM_ALG=rk4 EDM_NSUBSTEPS=1"
 )

--- a/orchestration/campaigns/newton_a0_low.sh
+++ b/orchestration/campaigns/newton_a0_low.sh
@@ -1,0 +1,28 @@
+# campaigns/newton_a0_low.sh — GPUKernelNewton shakeout: low-a0 half of the a0 sweep.
+# Circular_minus only (the production/lpwa-compare convention; the high-a0 half is circular too).
+# Solver A/B is self-contained: the _rk4 control cell shares BASE + hardware with the Newton
+# cells, so any drift is the retarded-time solver alone — no reliance on old cross-hardware runs.
+# Second axis: n_iters ∈ {2, 1} — the _it1 twins test whether a single Newton correction already
+# sits at the accuracy floor at low a0 (kernel_newton.jl says yes at a0=0.1 on the potential
+# path; this is the field-path confirmation + same-GPU timing).
+CAMPAIGN=newton_a0_low
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=400 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=split
+  EDM_N=10000 EDM_RELTOL=1e-12
+  EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_GPU_SOLVER=newton EDM_NEWTON_ITERS=2
+)
+CELLS=(
+  "circ_a1em3|EDM_POL=circular_minus EDM_A0=1e-3"
+  "circ_a1e1|EDM_POL=circular_minus EDM_A0=0.1"
+  # n_iters=1 twins (same physics cells; is one Newton correction enough at low a0?)
+  "circ_a1em3_it1|EDM_POL=circular_minus EDM_A0=1e-3 EDM_NEWTON_ITERS=1"
+  "circ_a1e1_it1|EDM_POL=circular_minus EDM_A0=0.1 EDM_NEWTON_ITERS=1"
+  # RK4 controls — the same-hardware solver A/B baseline at both a0 decades (the 1e-3 one
+  # doubles as a Newton-vs-RK4 check in the spline-floor regime). No _it1 twins for rk4:
+  # n_iters doesn't exist there, they'd be duplicate runs.
+  "circ_a1e1_rk4|EDM_POL=circular_minus EDM_A0=0.1 EDM_GPU_SOLVER=rk4 EDM_NSUBSTEPS=1"
+  "circ_a1em3_rk4|EDM_POL=circular_minus EDM_A0=1e-3 EDM_GPU_SOLVER=rk4 EDM_NSUBSTEPS=1"
+)

--- a/orchestration/cost_report.sh
+++ b/orchestration/cost_report.sh
@@ -211,7 +211,16 @@ END {
     if (used_def) print "[warn] some VMs lacked a recorded rate and no fallback was available (priced at $0)"
     for (i = 1; i <= nn; i++) { if (i == 1) print "\nnotes:"; print "  " notes[i] }
 }
-function html_out(   i, p, vm) {
+function rbar(x, y, w, h, r, fill, title,   p) {   # horizontal bar, 4px rounded data-end, square baseline end
+    if (w < r + 1)
+        p = sprintf("<rect x=\"%.1f\" y=\"%.1f\" width=\"%.2f\" height=\"%d\" fill=\"%s\"/>", x, y, (w < 0.75 ? 0.75 : w), h, fill)
+    else
+        p = sprintf("<path d=\"M%.1f %.1f h%.2f a%d %d 0 0 1 %d %d v%d a%d %d 0 0 1 -%d %d h-%.2f z\" fill=\"%s\"/>", \
+                    x, y, w - r, r, r, r, r, h - 2*r, r, r, r, r, w - r, fill)
+    if (title != "") p = "<g><title>" title "</title>" p "</g>"
+    return p
+}
+function html_out(   i, j, k, p, vm, m, ord, mx, GUT, PW, BH, PITCH, y, w, wc, wo, fh, lab) {
     print "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
     print "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
     print "<title>EDM cloud costs</title><style>"
@@ -229,15 +238,71 @@ function html_out(   i, p, vm) {
     print "tr.total td{border-top:1px solid var(--border-2);font-weight:600}"
     print ".note{color:var(--muted);font-size:12px;margin-top:6px}"
     print ".run{color:var(--accent);font-weight:600}"
+    print ":root{--s1:#2a78d6;--s2:#008300}"   # validated 2-slot categorical palette (light mode, white surface)
+    print ".viz{margin:6px 0 10px} .viz svg{width:100%;height:auto;display:block;max-width:760px}"
+    print ".viz text{font-family:var(--ui);font-size:12px}"
+    print ".viz .lab{fill:#6a7284} .viz .val{fill:var(--ink)} .viz .inlab{fill:#fff}"
+    print ".legend{font-size:12px;color:#6a7284;margin:2px 0 4px}"
+    print ".legend span{margin-right:16px}"
+    print ".sw{display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:6px;vertical-align:-1px}"
     print "</style></head><body><main>"
     print "<h1>EDM cloud campaign costs</h1>"
     printf "<p class=\"meta\">updated %s &middot; window %s → %s &middot; derived from the cost ledger + run-manifest [timing] (never stored in run metadata)</p>\n", iso(systime()), iso(since), iso(until)
+    # ── figure: cost per campaign (single series → no legend; magnitude, sorted desc) ──
+    GUT = 210; PW = 440; BH = 16; PITCH = 26
+    m = 0
+    for (i = 1; i <= nm; i++) if (cusd[i] > 0) ord[++m] = i
+    for (j = 2; j <= m; j++) {   # insertion sort desc by USD
+        k = ord[j]; i = j - 1
+        while (i > 0 && cusd[ord[i]] < cusd[k]) { ord[i+1] = ord[i]; i-- }
+        ord[i+1] = k
+    }
+    if (m > 0) {
+        mx = cusd[ord[1]]
+        fh = m * PITCH + 12
+        printf "<h2>Cost per campaign</h2><div class=\"viz\"><svg viewBox=\"0 0 720 %d\" role=\"img\" aria-label=\"Cost per campaign, USD\">\n", fh
+        printf "<line x1=\"%d\" y1=\"4\" x2=\"%d\" y2=\"%d\" stroke=\"#c3c2b7\" stroke-width=\"1\"/>\n", GUT, GUT, fh - 4
+        for (j = 1; j <= m; j++) {
+            i = ord[j]; y = 6 + (j - 1) * PITCH; w = cusd[i] / mx * PW
+            printf "<text x=\"%d\" y=\"%d\" text-anchor=\"end\" class=\"lab\">%s</text>\n", GUT - 8, y + 12, esc(mname[i])
+            print rbar(GUT + 1, y, w, BH, 4, "var(--s1)", \
+                       esc(mname[i]) " — " esc(cvm[i]) " — " sprintf("%.2f GPU-h — $%.2f", msec[i] / 3600.0, cusd[i]))
+            printf "<text x=\"%.1f\" y=\"%d\" class=\"val\">$%.2f</text>\n", GUT + 1 + w + 6, y + 12, cusd[i]
+        }
+        print "</svg></div>"
+    }
     if (nm > 0) {
         print "<h2>Per campaign</h2><table><tr><th>campaign</th><th>provider</th><th>vm</th><th class=\"n\">cells</th><th class=\"n\">GPU-h</th><th class=\"n\">USD</th></tr>"
         for (i = 1; i <= nm; i++)
             printf "<tr><td>%s</td><td>%s</td><td>%s</td><td class=\"n\">%d</td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td></tr>\n", esc(mname[i]), (cvm[i] == "-") ? "&mdash;" : esc(vprovider[cvm[i]]), (cvm[i] == "-") ? "&mdash;" : esc(cvm[i]), mcells[i], msec[i] / 3600.0, cusd[i]
         print "</table>"
         print "<p class=\"note\">campaigns marked &mdash; have no cloud-ledger attribution (local / SLURM / pre-ledger) and are shown at $0.</p>"
+    }
+    # ── figure: per-VM compute vs overhead (2 series → legend; stacked, 2px surface gaps) ──
+    m = 0; mx = 0
+    for (i = 1; i <= nv; i++) {
+        vm = vlist[i]; if (vm in vskip) continue
+        ord[++m] = i; if (vusd[vm] > mx) mx = vusd[vm]
+    }
+    if (m > 0 && mx > 0) {
+        fh = m * PITCH + 12
+        print "<h2>Per VM: compute vs overhead</h2>"
+        print "<p class=\"legend\"><span><span class=\"sw\" style=\"background:var(--s1)\"></span>compute (manifest-backed)</span><span><span class=\"sw\" style=\"background:var(--s2)\"></span>overhead + in-flight</span></p>"
+        printf "<div class=\"viz\"><svg viewBox=\"0 0 720 %d\" role=\"img\" aria-label=\"Per-VM wall-clock cost split into compute and overhead, USD\">\n", fh
+        printf "<line x1=\"%d\" y1=\"4\" x2=\"%d\" y2=\"%d\" stroke=\"#c3c2b7\" stroke-width=\"1\"/>\n", GUT, GUT, fh - 4
+        for (j = 1; j <= m; j++) {
+            vm = vlist[ord[j]]; y = 6 + (j - 1) * PITCH
+            wc = (csum[vm] > 0 ? csum[vm] : 0) / mx * PW
+            wo = (vusd[vm] - csum[vm] > 0 ? vusd[vm] - csum[vm] : 0) / mx * PW
+            printf "<text x=\"%d\" y=\"%d\" text-anchor=\"end\" class=\"lab\">%s</text>\n", GUT - 8, y + 12, esc(vm)
+            if (wc > 0.1) printf "<g><title>%s — compute $%.2f</title><rect x=\"%d\" y=\"%d\" width=\"%.2f\" height=\"%d\" fill=\"var(--s1)\"/></g>\n", esc(vm), csum[vm], GUT + 1, y, wc, BH
+            if (wo > 0.1) print rbar(GUT + 1 + wc + (wc > 0.1 ? 2 : 0), y, wo, BH, 4, "var(--s2)", \
+                                     esc(vm) " — overhead $" sprintf("%.2f", vusd[vm] - csum[vm]) ((vm in vdown) ? "" : " — still running"))
+            lab = sprintf("$%.2f", csum[vm] + 0)
+            if (wc > length(lab) * 6.8 + 14) printf "<text x=\"%d\" y=\"%d\" class=\"inlab\">%s</text>\n", GUT + 8, y + 12, lab
+            printf "<text x=\"%.1f\" y=\"%d\" class=\"val\">$%.2f</text>\n", GUT + 1 + wc + 2 + wo + 6, y + 12, vusd[vm]
+        }
+        print "</svg></div>"
     }
     print "<h2>Per VM</h2><table><tr><th>vm</th><th>provider</th><th class=\"n\">wall-h</th><th class=\"n\">wall USD</th><th class=\"n\">compute USD</th><th class=\"n\">overhead USD</th><th></th></tr>"
     for (i = 1; i <= nv; i++) {

--- a/orchestration/cost_report.sh
+++ b/orchestration/cost_report.sh
@@ -25,9 +25,21 @@
 #     never stored in run metadata — a rate correction heals everything by regeneration.
 # Rate for a VM missing a provision rate: live Hot Aisle API lookup (token file), else
 # --rate-cents, else 0 + warning. Plain bash + GNU awk/date; jq/curl only for the API fallback.
+#
+# MULTI-MACHINE: each campaign-driving machine appends to its own local ledger. The reporter
+# merges the main ledger with every *.tsv under ~/.config/edm-cloud-ledgers/ (drop other
+# machines' ledgers there — the dashboard publish hook rsyncs them in), or takes explicit
+# --ledger FILE (repeatable; replaces the defaults). Byte-identical rows are deduped, so a
+# ledger accidentally present twice is harmless. Convention: account-scoped rows (topup,
+# balance) live ONLY in the publish hub's own ledger or provider lifetime sums double-count;
+# machine-scoped rows (provision/campaign/teardown) live where the campaign was driven.
+# Campaign→VM attribution matches dir=… first (machine-local paths), then falls back to the
+# campaign=<name> token when exactly one VM claims that name (ambiguous names never match).
 set -euo pipefail
 
 LEDGER="${EDM_CLOUD_LEDGER:-$HOME/.config/edm-cloud-ledger.tsv}"
+LEDGER_DIR="${EDM_CLOUD_LEDGER_DIR:-$HOME/.config/edm-cloud-ledgers}"
+LEDGERS=()
 SINCE="1970-01-01T00:00:00Z"
 UNTIL="$(date -u +%FT%TZ)"
 RATE_FALLBACK=""
@@ -37,27 +49,35 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --since)      SINCE=${2:?}; shift 2 ;;
         --until)      UNTIL=${2:?}; shift 2 ;;
-        --ledger)     LEDGER=${2:?}; shift 2 ;;
+        --ledger)     LEDGERS+=("${2:?}"); shift 2 ;;
         --rate-cents) RATE_FALLBACK=${2:?}; shift 2 ;;
         --html)       HTML_FILE=${2:?}; shift 2 ;;
         -h|--help)    sed -n '2,28p' "$0"; exit 0 ;;
         *)            DIRS+=("$1"); shift ;;
     esac
 done
-[ -f "$LEDGER" ] || { echo "no ledger at $LEDGER (nothing recorded yet?)" >&2; exit 1; }
+if [ ${#LEDGERS[@]} -eq 0 ]; then   # defaults: the machine ledger + any synced-in remote ledgers
+    [ -f "$LEDGER" ] && LEDGERS+=("$LEDGER")
+    if [ -d "$LEDGER_DIR" ]; then
+        for f in "$LEDGER_DIR"/*.tsv; do [ -f "$f" ] && LEDGERS+=("$f"); done
+    fi
+fi
+[ ${#LEDGERS[@]} -gt 0 ] || { echo "no ledger at $LEDGER or $LEDGER_DIR/*.tsv (nothing recorded yet?)" >&2; exit 1; }
 SINCE_E=$(date -u -d "$SINCE" +%s)
 UNTIL_E=$(date -u -d "$UNTIL" +%s)
 
 # Current Hot Aisle list price (cents/GPU-h) — fetched ONLY if a provision row lacks a rate.
+# Team handle stays out of git: HOTAISLE_TEAM (config.env) or ~/.config/hotaisle/team.
 hotaisle_list_rate() {
     local tokf="${HOTAISLE_TOKEN_FILE:-$HOME/.config/hotaisle/token}"
-    [ -f "$tokf" ] || return 1
+    local team="${HOTAISLE_TEAM:-$(cat "$HOME/.config/hotaisle/team" 2>/dev/null)}"
+    [ -f "$tokf" ] && [ -n "$team" ] || return 1
     curl -fsS --max-time 10 -H "Authorization: Token $(cat "$tokf")" \
-        "https://admin.hotaisle.app/api/teams/${HOTAISLE_TEAM:-REDACTED}/virtual_machines/available/" \
+        "https://admin.hotaisle.app/api/teams/${team}/virtual_machines/available/" \
       | jq -r '[.[]|select(.Specs.gpus[0].model=="MI300X" and .Specs.gpus[0].count==1)|.OnDemandPrice][0] // empty'
 }
 API_RATE=""
-if tail -n +2 "$LEDGER" | awk -F'\t' '$4=="provision" && $2=="hotaisle" && $6==""{ex=1} END{exit !ex}'; then
+if awk -F'\t' 'FNR>1 && $4=="provision" && $2=="hotaisle" && $6==""{ex=1} END{exit !ex}' "${LEDGERS[@]}"; then
     API_RATE=$(hotaisle_list_rate 2>/dev/null || true)
 fi
 
@@ -78,7 +98,9 @@ digest_manifests() {   # M \t realdir \t name \t cells \t gpu_seconds
 
 tag_ledger() {   # L \t ts \t provider \t vm \t event \t detail \t rate \t balance
     # NOT a bash read loop: with IFS=$'\t' consecutive tabs collapse and empty fields shift.
-    tail -n +2 "$LEDGER" | awk -F'\t' -v OFS='\t' 'NF { print "L", $0 }'
+    # Merge every ledger (header-stripped); sort -u dedupes byte-identical rows (a ledger
+    # synced twice is harmless) and ISO timestamps sort lexicographically = chronologically.
+    awk 'FNR > 1' "${LEDGERS[@]}" | sort -u | awk -F'\t' -v OFS='\t' 'NF { print "L", $0 }'
 }
 
 run_report() {
@@ -117,6 +139,10 @@ $1 == "L" {
                                     if (e >= since && e <= until) notes[++nn] = iso(e) "  " prov " rate_change → " rate "¢/h  (" det ")" }
     else if (ev == "campaign_start" || ev == "campaign_done") {
         if (match(det, /dir=[^\t ]+/)) dirvm[substr(det, RSTART + 4, RLENGTH - 4)] = vm
+        if (match(det, /campaign=[^\t ]+/)) {   # name fallback for cross-machine dirs
+            cn = substr(det, RSTART + 9, RLENGTH - 9)
+            if ((cn in namevm) && namevm[cn] != vm) nameamb[cn] = 1; else namevm[cn] = vm
+        }
     }
     else if (ev == "campaign_crash" && e >= since && e <= until) { notes[++nn] = iso(e) "  " vm "  " det }
     else if (ev == "incident"       && e >= since && e <= until) { notes[++nn] = iso(e) "  " det }
@@ -150,7 +176,8 @@ END {
     }
     # ── per-campaign compute (unattributed dirs = non-cloud/pre-ledger → $0) ──
     for (i = 1; i <= nm; i++) {
-        cvm[i] = (mdir[i] in dirvm) ? dirvm[mdir[i]] : "-"
+        cvm[i] = (mdir[i] in dirvm) ? dirvm[mdir[i]] : \
+                 ((mname[i] in namevm) && !(mname[i] in nameamb) ? namevm[mname[i]] : "-")
         cusd[i] = (cvm[i] != "-") ? msec[i] / 3600.0 * vavg[cvm[i]] : 0
         if (cvm[i] != "-") { csum[cvm[i]] += cusd[i]; tot_compute += cusd[i] }
     }

--- a/orchestration/cost_report.sh
+++ b/orchestration/cost_report.sh
@@ -2,24 +2,27 @@
 # cost_report.sh — EDM cloud spend report from the persistent cost ledger + run manifests.
 #
 #   bash orchestration/cost_report.sh [--since ISO] [--until ISO] [--ledger FILE] \
-#        [--rate-cents N] [results_dir ...]
+#        [--rate-cents N] [--html FILE] [results_dir ...]
 #
 # The ledger (~/.config/edm-cloud-ledger.tsv, appended by backends/hotaisle.sh and runpod.sh) is
 # an append-only TSV:  ts_utc  provider  vm  event  detail  rate_cents_h  balance_usd
 # events: provision (rate_cents_h = the VM's $/h in CENTS at provision — list prices drift, so the
-# offering price is captured per-row), campaign_start / campaign_done / campaign_crash (detail
-# carries campaign=<name> dir=<outdir>), teardown, topup (detail amount=<usd>), balance,
-# rate_change (provider-wide re-rate of RUNNING VMs — Hot Aisle applies list-price rises to
-# in-flight VMs, observed 2026-07-17 199→299), incident (free text, surfaced as a note).
+# offering price is captured per-row; reconciliation vs authoritative top-ups confirmed 2026-07-17
+# that Hot Aisle bills a VM at its provision-time list price for its whole life), campaign_start /
+# campaign_done / campaign_crash (detail carries campaign=<name> dir=<outdir>), teardown, topup
+# (detail amount=<usd>), balance, rate_change (generic provider-wide re-rate hook, integrated
+# piecewise — unused so far), incident (free text, surfaced as a note).
 #
-# What it prints:
+# What it prints (text to stdout, or a self-contained HTML page with --html FILE):
 #   • per-campaign compute = Σ [timing].total over run_<uuid>.toml in each results dir given,
-#     priced at the owning VM's time-averaged rate (attribution via campaign_* rows' dir=…)
+#     priced at the owning VM's time-averaged rate (attribution via campaign_* rows' dir=…);
+#     dirs with no ledger attribution are non-cloud (local/SLURM) or pre-ledger → shown at $0
 #   • per-VM wall-clock cost (provision→teardown clipped to the window; running VMs bill through
-#     --until, integrated piecewise across rate_change rows) and overhead = wall − compute.
-#     Cells still IN FLIGHT have no manifest yet, so they appear as overhead until their
-#     run_<uuid>.toml lands — rerun after the campaign downloads/publishes.
-#   • topups, first/last balance and the ledger-implied spend for reconciliation.
+#     --until) and overhead = wall − compute. Cells still IN FLIGHT have no manifest yet, so they
+#     appear as overhead until their run_<uuid>.toml lands — rerun after download/publish.
+#   • per-provider reconciliation: window top-ups + balance-implied spend, and LIFETIME
+#     top-ups vs last known balance ⇒ lifetime spend. Costs stay DERIVED (ledger + manifests),
+#     never stored in run metadata — a rate correction heals everything by regeneration.
 # Rate for a VM missing a provision rate: live Hot Aisle API lookup (token file), else
 # --rate-cents, else 0 + warning. Plain bash + GNU awk/date; jq/curl only for the API fallback.
 set -euo pipefail
@@ -28,6 +31,7 @@ LEDGER="${EDM_CLOUD_LEDGER:-$HOME/.config/edm-cloud-ledger.tsv}"
 SINCE="1970-01-01T00:00:00Z"
 UNTIL="$(date -u +%FT%TZ)"
 RATE_FALLBACK=""
+HTML_FILE=""
 DIRS=()
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -35,7 +39,8 @@ while [ $# -gt 0 ]; do
         --until)      UNTIL=${2:?}; shift 2 ;;
         --ledger)     LEDGER=${2:?}; shift 2 ;;
         --rate-cents) RATE_FALLBACK=${2:?}; shift 2 ;;
-        -h|--help)    sed -n '2,25p' "$0"; exit 0 ;;
+        --html)       HTML_FILE=${2:?}; shift 2 ;;
+        -h|--help)    sed -n '2,28p' "$0"; exit 0 ;;
         *)            DIRS+=("$1"); shift ;;
     esac
 done
@@ -76,10 +81,13 @@ tag_ledger() {   # L \t ts \t provider \t vm \t event \t detail \t rate \t balan
     tail -n +2 "$LEDGER" | awk -F'\t' -v OFS='\t' 'NF { print "L", $0 }'
 }
 
+run_report() {
 { digest_manifests; tag_ledger; } | awk -F'\t' \
-    -v since="$SINCE_E" -v until="$UNTIL_E" -v fallback="$RATE_FALLBACK" -v api_rate="$API_RATE" '
+    -v since="$SINCE_E" -v until="$UNTIL_E" -v fallback="$RATE_FALLBACK" -v api_rate="$API_RATE" \
+    -v html="${HTML_FILE:+1}" '
 function iso(e) { return strftime("%Y-%m-%dT%H:%M:%SZ", e, 1) }
 function epoch(ts,   t) { t = ts; gsub(/[-:TZ]/, " ", t); return mktime(t, 1) }   # ISO-8601 Z → UTC epoch (gawk)
+function esc(s) { gsub(/&/, "\\&amp;", s); gsub(/</, "\\&lt;", s); gsub(/>/, "\\&gt;", s); return s }
 function vmcost(vm, a, b,   p, i, j, n, t, r, c, seg_t, seg_r) {
     # integrate the VM hourly rate over [a,b]: provision rate, stepped by provider rate_change rows
     if (b <= a) return 0
@@ -101,6 +109,7 @@ $1 == "M" { nm++; mdir[nm] = $2; mname[nm] = $3; mcells[nm] = $4; msec[nm] = $5;
 $1 == "L" {
     e = epoch($2); prov = $3; vm = $4; ev = $5; det = $6; rate = $7; bal = $8
     if (e < 0) { printf "[warn] unparsable ts skipped: %s\n", $2 > "/dev/stderr"; next }
+    if (prov != "" && !(prov in pseen)) { pseen[prov] = 1; plist[++np] = prov }
     if (vm != "" && vm != "-" && !(vm in known)) { known[vm] = 1; vlist[++nv] = vm; vprovider[vm] = prov }
     if      (ev == "provision")   { vprov[vm] = e; vrate[vm] = rate + 0 }
     else if (ev == "teardown")    { vdown[vm] = e }
@@ -111,48 +120,125 @@ $1 == "L" {
     }
     else if (ev == "campaign_crash" && e >= since && e <= until) { notes[++nn] = iso(e) "  " vm "  " det }
     else if (ev == "incident"       && e >= since && e <= until) { notes[++nn] = iso(e) "  " det }
-    else if (ev == "topup"          && e >= since && e <= until) {
-        tn++; if (match(det, /amount=[0-9.]+/)) tsum += substr(det, RSTART + 7, RLENGTH - 7) + 0
+    else if (ev == "topup") {
+        amt = 0; if (match(det, /amount=[0-9.]+/)) amt = substr(det, RSTART + 7, RLENGTH - 7) + 0
+        lt_sum[prov] += amt; lt_n[prov]++
+        if (e >= since && e <= until) { wt_sum[prov] += amt; wt_n[prov]++ }
     }
-    if (bal != "" && e >= since && e <= until) {
-        if (!bf_set || e < bf_e)  { bf_e = e; bf = bal + 0; bf_set = 1 }
-        if (!bl_set || e >= bl_e) { bl_e = e; bl = bal + 0; bl_set = 1 }
+    if (bal != "") {
+        if (!(prov in lb_e) || e >= lb_e[prov]) { lb_e[prov] = e; lb[prov] = bal + 0 }
+        if (e >= since && e <= until) {
+            if (!(prov in wbf_e) || e < wbf_e[prov])  { wbf_e[prov] = e; wbf[prov] = bal + 0 }
+            if (!(prov in wbl_e) || e >= wbl_e[prov]) { wbl_e[prov] = e; wbl[prov] = bal + 0 }
+        }
     }
     next
 }
 END {
     def_rate = (fallback != "") ? fallback + 0 : ((api_rate != "") ? api_rate + 0 : 0)
+    # ── per-VM wall / cost ──
     for (i = 1; i <= nv; i++) {
         vm = vlist[i]
         if (!(vm in vprov) && !(vm in vdown)) { vskip[vm] = 1; continue }   # attribution-only vm
-        a = (vm in vprov)  ? vprov[vm] : since; if (a < since) a = since
-        b = (vm in vdown)  ? vdown[vm] : until; if (b > until) b = until
+        if ((vm in vprov) && vrate[vm] == 0 && def_rate == 0) used_def = 1
+        a = (vm in vprov) ? vprov[vm] : since; if (a < since) a = since
+        b = (vm in vdown) ? vdown[vm] : until; if (b > until) b = until
         vwall[vm] = (b > a) ? (b - a) / 3600.0 : 0
         vusd[vm]  = vmcost(vm, a, b)
         vavg[vm]  = (vwall[vm] > 0) ? vusd[vm] / vwall[vm] : 0
+        tot_wall += vusd[vm]
     }
+    # ── per-campaign compute (unattributed dirs = non-cloud/pre-ledger → $0) ──
+    for (i = 1; i <= nm; i++) {
+        cvm[i] = (mdir[i] in dirvm) ? dirvm[mdir[i]] : "-"
+        cusd[i] = (cvm[i] != "-") ? msec[i] / 3600.0 * vavg[cvm[i]] : 0
+        if (cvm[i] != "-") { csum[cvm[i]] += cusd[i]; tot_compute += cusd[i] }
+    }
+    if (html) { html_out(); exit }
+    # ── text output ──
     printf "== EDM cloud spend  %s → %s ==\n", iso(since), iso(until)
     if (nm > 0) {
         printf "\n%-28s %-9s %-16s %5s %8s %9s\n", "campaign", "provider", "vm", "cells", "GPU-h", "USD"
-        for (i = 1; i <= nm; i++) {
-            vm = (mdir[i] in dirvm) ? dirvm[mdir[i]] : "?"
-            if (vm == "?" || vavg[vm] == 0) used_def = 1
-            r  = (vm != "?" && vavg[vm] > 0) ? vavg[vm] : def_rate / 100.0
-            usd = msec[i] / 3600.0 * r
-            csum[vm] += usd; tot_compute += usd
-            printf "%-28s %-9s %-16s %5d %8.2f %9.2f\n", mname[i], (vm == "?") ? "?" : vprovider[vm], vm, mcells[i], msec[i] / 3600.0, usd
-        }
+        for (i = 1; i <= nm; i++)
+            printf "%-28s %-9s %-16s %5d %8.2f %9.2f\n", mname[i], (cvm[i] == "-") ? "-" : vprovider[cvm[i]], cvm[i], mcells[i], msec[i] / 3600.0, cusd[i]
     }
     printf "\n%-16s %-9s %8s %9s %12s %13s\n", "vm", "provider", "wall-h", "wall-USD", "compute-USD", "overhead-USD"
     for (i = 1; i <= nv; i++) {
         vm = vlist[i]; if (vm in vskip) continue
         printf "%-16s %-9s %8.2f %9.2f %12.2f %13.2f%s\n", vm, vprovider[vm], vwall[vm], vusd[vm], csum[vm] + 0, vusd[vm] - csum[vm], (vm in vdown) ? "" : "  (still running)"
-        tot_wall += vusd[vm]
     }
     printf "\nTOTAL wall-clock spend in window: $%.2f  (manifest-backed compute $%.2f; overhead + in-flight cells $%.2f)\n", tot_wall, tot_compute, tot_wall - tot_compute
-    if (tn > 0) printf "topups in window: $%.2f (%d)\n", tsum, tn
-    if (bf_set && bl_set && bl_e > bf_e)
-        printf "ledger-implied spend ($%.2f @%s + topups − $%.2f @%s): $%.2f\n", bf, iso(bf_e), bl, iso(bl_e), bf + tsum - bl
-    if (def_rate == 0 && used_def) print "[warn] some rows lacked a rate and no fallback was available (priced at $0)"
+    for (i = 1; i <= np; i++) {
+        p = plist[i]
+        if (!(p in lt_sum) && !(p in lb)) continue
+        printf "\n%s:", p
+        if (p in wt_sum) printf " window top-ups $%.2f (%d)", wt_sum[p], wt_n[p]
+        if ((p in wbf_e) && (p in wbl_e) && wbl_e[p] > wbf_e[p])
+            printf "; implied window spend $%.2f ($%.2f @%s + top-ups − $%.2f @%s)", wbf[p] + wt_sum[p] - wbl[p], wbf[p], iso(wbf_e[p]), wbl[p], iso(wbl_e[p])
+        if (p in lt_sum) {
+            printf "\n%s lifetime: top-ups $%.2f (%d)", p, lt_sum[p], lt_n[p]
+            if (p in lb) printf ", balance $%.2f @%s ⇒ spent $%.2f", lb[p], iso(lb_e[p]), lt_sum[p] - lb[p]
+        }
+        printf "\n"
+    }
+    if (used_def) print "[warn] some VMs lacked a recorded rate and no fallback was available (priced at $0)"
     for (i = 1; i <= nn; i++) { if (i == 1) print "\nnotes:"; print "  " notes[i] }
+}
+function html_out(   i, p, vm) {
+    print "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+    print "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+    print "<title>EDM cloud costs</title><style>"
+    print ":root{--ink:#1a1d24;--muted:#6a7284;--border:#dee2ea;--border-2:#c5cad6;--accent:#3b6fb3;"
+    print "--ui:system-ui,-apple-system,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif;"
+    print "--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,\"Liberation Mono\",monospace}"
+    print "html,body{margin:0;padding:0;background:#fff;color:var(--ink);font-family:var(--ui);font-size:14px;line-height:1.5}"
+    print "main{max-width:960px;margin:0 auto;padding:24px 16px}"
+    print "h1{font-size:20px;margin:0 0 4px} h2{font-size:15px;margin:28px 0 8px}"
+    print ".meta{color:var(--muted);font-family:var(--mono);font-size:11px;margin:0 0 16px}"
+    print "table{border-collapse:collapse;width:100%;font-size:13px}"
+    print "th,td{padding:4px 10px;border-bottom:1px solid var(--border);text-align:left;white-space:nowrap}"
+    print "th{color:var(--muted);font-weight:600;border-bottom:1px solid var(--border-2)}"
+    print "td.n,th.n{text-align:right;font-family:var(--mono)}"
+    print "tr.total td{border-top:1px solid var(--border-2);font-weight:600}"
+    print ".note{color:var(--muted);font-size:12px;margin-top:6px}"
+    print ".run{color:var(--accent);font-weight:600}"
+    print "</style></head><body><main>"
+    print "<h1>EDM cloud campaign costs</h1>"
+    printf "<p class=\"meta\">updated %s &middot; window %s → %s &middot; derived from the cost ledger + run-manifest [timing] (never stored in run metadata)</p>\n", iso(systime()), iso(since), iso(until)
+    if (nm > 0) {
+        print "<h2>Per campaign</h2><table><tr><th>campaign</th><th>provider</th><th>vm</th><th class=\"n\">cells</th><th class=\"n\">GPU-h</th><th class=\"n\">USD</th></tr>"
+        for (i = 1; i <= nm; i++)
+            printf "<tr><td>%s</td><td>%s</td><td>%s</td><td class=\"n\">%d</td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td></tr>\n", esc(mname[i]), (cvm[i] == "-") ? "&mdash;" : esc(vprovider[cvm[i]]), (cvm[i] == "-") ? "&mdash;" : esc(cvm[i]), mcells[i], msec[i] / 3600.0, cusd[i]
+        print "</table>"
+        print "<p class=\"note\">campaigns marked &mdash; have no cloud-ledger attribution (local / SLURM / pre-ledger) and are shown at $0.</p>"
+    }
+    print "<h2>Per VM</h2><table><tr><th>vm</th><th>provider</th><th class=\"n\">wall-h</th><th class=\"n\">wall USD</th><th class=\"n\">compute USD</th><th class=\"n\">overhead USD</th><th></th></tr>"
+    for (i = 1; i <= nv; i++) {
+        vm = vlist[i]; if (vm in vskip) continue
+        printf "<tr><td>%s</td><td>%s</td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td><td>%s</td></tr>\n", esc(vm), esc(vprovider[vm]), vwall[vm], vusd[vm], csum[vm] + 0, vusd[vm] - csum[vm], (vm in vdown) ? "" : "<span class=\"run\">still running</span>"
+    }
+    printf "<tr class=\"total\"><td>total</td><td></td><td class=\"n\"></td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td><td></td></tr>\n", tot_wall, tot_compute, tot_wall - tot_compute
+    print "</table>"
+    print "<p class=\"note\">overhead = wall-clock − manifest-backed compute: provision/warm, idle gaps, drain tails, incidents — and cells still in flight (their manifests have not landed yet).</p>"
+    print "<h2>Providers &mdash; lifetime</h2><table><tr><th>provider</th><th class=\"n\">top-ups (window)</th><th class=\"n\">top-ups (lifetime)</th><th class=\"n\">last balance</th><th></th><th class=\"n\">lifetime spend</th></tr>"
+    for (i = 1; i <= np; i++) {
+        p = plist[i]
+        if (!(p in lt_sum) && !(p in lb)) continue
+        printf "<tr><td>%s</td><td class=\"n\">%.2f</td><td class=\"n\">%.2f</td><td class=\"n\">%s</td><td>%s</td><td class=\"n\">%s</td></tr>\n", esc(p), wt_sum[p] + 0, lt_sum[p] + 0, (p in lb) ? sprintf("%.2f", lb[p]) : "?", (p in lb) ? "<span class=\"meta\">@" iso(lb_e[p]) "</span>" : "", (p in lb) ? sprintf("%.2f", lt_sum[p] - lb[p]) : "?"
+    }
+    print "</table>"
+    if (nn > 0) {
+        print "<h2>Notes</h2>"
+        for (i = 1; i <= nn; i++) printf "<p class=\"note\">%s</p>\n", esc(notes[i])
+    }
+    print "</main></body></html>"
 }'
+}
+
+if [ -n "$HTML_FILE" ]; then
+    tmp="${HTML_FILE}.tmp.$$"
+    run_report > "$tmp" && mv "$tmp" "$HTML_FILE"
+    echo "wrote $HTML_FILE" >&2
+else
+    run_report
+fi

--- a/orchestration/cost_report.sh
+++ b/orchestration/cost_report.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# cost_report.sh — EDM cloud spend report from the persistent cost ledger + run manifests.
+#
+#   bash orchestration/cost_report.sh [--since ISO] [--until ISO] [--ledger FILE] \
+#        [--rate-cents N] [results_dir ...]
+#
+# The ledger (~/.config/edm-cloud-ledger.tsv, appended by backends/hotaisle.sh and runpod.sh) is
+# an append-only TSV:  ts_utc  provider  vm  event  detail  rate_cents_h  balance_usd
+# events: provision (rate_cents_h = the VM's $/h in CENTS at provision — list prices drift, so the
+# offering price is captured per-row), campaign_start / campaign_done / campaign_crash (detail
+# carries campaign=<name> dir=<outdir>), teardown, topup (detail amount=<usd>), balance,
+# rate_change (provider-wide re-rate of RUNNING VMs — Hot Aisle applies list-price rises to
+# in-flight VMs, observed 2026-07-17 199→299), incident (free text, surfaced as a note).
+#
+# What it prints:
+#   • per-campaign compute = Σ [timing].total over run_<uuid>.toml in each results dir given,
+#     priced at the owning VM's time-averaged rate (attribution via campaign_* rows' dir=…)
+#   • per-VM wall-clock cost (provision→teardown clipped to the window; running VMs bill through
+#     --until, integrated piecewise across rate_change rows) and overhead = wall − compute.
+#     Cells still IN FLIGHT have no manifest yet, so they appear as overhead until their
+#     run_<uuid>.toml lands — rerun after the campaign downloads/publishes.
+#   • topups, first/last balance and the ledger-implied spend for reconciliation.
+# Rate for a VM missing a provision rate: live Hot Aisle API lookup (token file), else
+# --rate-cents, else 0 + warning. Plain bash + GNU awk/date; jq/curl only for the API fallback.
+set -euo pipefail
+
+LEDGER="${EDM_CLOUD_LEDGER:-$HOME/.config/edm-cloud-ledger.tsv}"
+SINCE="1970-01-01T00:00:00Z"
+UNTIL="$(date -u +%FT%TZ)"
+RATE_FALLBACK=""
+DIRS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --since)      SINCE=${2:?}; shift 2 ;;
+        --until)      UNTIL=${2:?}; shift 2 ;;
+        --ledger)     LEDGER=${2:?}; shift 2 ;;
+        --rate-cents) RATE_FALLBACK=${2:?}; shift 2 ;;
+        -h|--help)    sed -n '2,25p' "$0"; exit 0 ;;
+        *)            DIRS+=("$1"); shift ;;
+    esac
+done
+[ -f "$LEDGER" ] || { echo "no ledger at $LEDGER (nothing recorded yet?)" >&2; exit 1; }
+SINCE_E=$(date -u -d "$SINCE" +%s)
+UNTIL_E=$(date -u -d "$UNTIL" +%s)
+
+# Current Hot Aisle list price (cents/GPU-h) — fetched ONLY if a provision row lacks a rate.
+hotaisle_list_rate() {
+    local tokf="${HOTAISLE_TOKEN_FILE:-$HOME/.config/hotaisle/token}"
+    [ -f "$tokf" ] || return 1
+    curl -fsS --max-time 10 -H "Authorization: Token $(cat "$tokf")" \
+        "https://admin.hotaisle.app/api/teams/${HOTAISLE_TEAM:-REDACTED}/virtual_machines/available/" \
+      | jq -r '[.[]|select(.Specs.gpus[0].model=="MI300X" and .Specs.gpus[0].count==1)|.OnDemandPrice][0] // empty'
+}
+API_RATE=""
+if tail -n +2 "$LEDGER" | awk -F'\t' '$4=="provision" && $2=="hotaisle" && $6==""{ex=1} END{exit !ex}'; then
+    API_RATE=$(hotaisle_list_rate 2>/dev/null || true)
+fi
+
+digest_manifests() {   # M \t realdir \t name \t cells \t gpu_seconds
+    local d rd
+    for d in ${DIRS[@]+"${DIRS[@]}"}; do
+        rd=$(realpath "$d" 2>/dev/null || echo "$d")
+        if ! ls "$d"/run_*.toml >/dev/null 2>&1; then
+            printf 'M\t%s\t%s\t0\t0\n' "$rd" "$(basename "$rd")"; continue
+        fi
+        awk -v dir="$rd" -v name="$(basename "$rd")" -F' *= *' '
+            FNR==1 { insec=0 }
+            /^\[/  { insec = ($0=="[timing]") }
+            insec && $1=="total" { s += $2; n++; nextfile }
+            END    { printf "M\t%s\t%s\t%d\t%.1f\n", dir, name, n, s+0 }' "$d"/run_*.toml
+    done
+}
+
+tag_ledger() {   # L \t ts \t provider \t vm \t event \t detail \t rate \t balance
+    # NOT a bash read loop: with IFS=$'\t' consecutive tabs collapse and empty fields shift.
+    tail -n +2 "$LEDGER" | awk -F'\t' -v OFS='\t' 'NF { print "L", $0 }'
+}
+
+{ digest_manifests; tag_ledger; } | awk -F'\t' \
+    -v since="$SINCE_E" -v until="$UNTIL_E" -v fallback="$RATE_FALLBACK" -v api_rate="$API_RATE" '
+function iso(e) { return strftime("%Y-%m-%dT%H:%M:%SZ", e, 1) }
+function epoch(ts,   t) { t = ts; gsub(/[-:TZ]/, " ", t); return mktime(t, 1) }   # ISO-8601 Z → UTC epoch (gawk)
+function vmcost(vm, a, b,   p, i, j, n, t, r, c, seg_t, seg_r) {
+    # integrate the VM hourly rate over [a,b]: provision rate, stepped by provider rate_change rows
+    if (b <= a) return 0
+    p = vprovider[vm]; n = 0
+    seg_t[++n] = a; seg_r[n] = (vrate[vm] > 0) ? vrate[vm] : def_rate
+    for (i = 1; i <= nrc[p]; i++)
+        if (rct[p, i] <= a) { if (vrate[vm] == 0 || rct[p, i] >= vprov[vm]) seg_r[1] = rcr[p, i] }
+        else if (rct[p, i] < b) { seg_t[++n] = rct[p, i]; seg_r[n] = rcr[p, i] }
+    for (i = 2; i <= n; i++) {   # insertion sort (rate_change rows may be unordered)
+        t = seg_t[i]; r = seg_r[i]; j = i - 1
+        while (j > 0 && seg_t[j] > t) { seg_t[j+1] = seg_t[j]; seg_r[j+1] = seg_r[j]; j-- }
+        seg_t[j+1] = t; seg_r[j+1] = r
+    }
+    c = 0
+    for (i = 1; i <= n; i++) { t = (i < n) ? seg_t[i+1] : b; c += (t - seg_t[i]) / 3600.0 * seg_r[i] / 100.0 }
+    return c
+}
+$1 == "M" { nm++; mdir[nm] = $2; mname[nm] = $3; mcells[nm] = $4; msec[nm] = $5; next }
+$1 == "L" {
+    e = epoch($2); prov = $3; vm = $4; ev = $5; det = $6; rate = $7; bal = $8
+    if (e < 0) { printf "[warn] unparsable ts skipped: %s\n", $2 > "/dev/stderr"; next }
+    if (vm != "" && vm != "-" && !(vm in known)) { known[vm] = 1; vlist[++nv] = vm; vprovider[vm] = prov }
+    if      (ev == "provision")   { vprov[vm] = e; vrate[vm] = rate + 0 }
+    else if (ev == "teardown")    { vdown[vm] = e }
+    else if (ev == "rate_change") { nrc[prov]++; rct[prov, nrc[prov]] = e; rcr[prov, nrc[prov]] = rate + 0
+                                    if (e >= since && e <= until) notes[++nn] = iso(e) "  " prov " rate_change → " rate "¢/h  (" det ")" }
+    else if (ev == "campaign_start" || ev == "campaign_done") {
+        if (match(det, /dir=[^\t ]+/)) dirvm[substr(det, RSTART + 4, RLENGTH - 4)] = vm
+    }
+    else if (ev == "campaign_crash" && e >= since && e <= until) { notes[++nn] = iso(e) "  " vm "  " det }
+    else if (ev == "incident"       && e >= since && e <= until) { notes[++nn] = iso(e) "  " det }
+    else if (ev == "topup"          && e >= since && e <= until) {
+        tn++; if (match(det, /amount=[0-9.]+/)) tsum += substr(det, RSTART + 7, RLENGTH - 7) + 0
+    }
+    if (bal != "" && e >= since && e <= until) {
+        if (!bf_set || e < bf_e)  { bf_e = e; bf = bal + 0; bf_set = 1 }
+        if (!bl_set || e >= bl_e) { bl_e = e; bl = bal + 0; bl_set = 1 }
+    }
+    next
+}
+END {
+    def_rate = (fallback != "") ? fallback + 0 : ((api_rate != "") ? api_rate + 0 : 0)
+    for (i = 1; i <= nv; i++) {
+        vm = vlist[i]
+        if (!(vm in vprov) && !(vm in vdown)) { vskip[vm] = 1; continue }   # attribution-only vm
+        a = (vm in vprov)  ? vprov[vm] : since; if (a < since) a = since
+        b = (vm in vdown)  ? vdown[vm] : until; if (b > until) b = until
+        vwall[vm] = (b > a) ? (b - a) / 3600.0 : 0
+        vusd[vm]  = vmcost(vm, a, b)
+        vavg[vm]  = (vwall[vm] > 0) ? vusd[vm] / vwall[vm] : 0
+    }
+    printf "== EDM cloud spend  %s → %s ==\n", iso(since), iso(until)
+    if (nm > 0) {
+        printf "\n%-28s %-9s %-16s %5s %8s %9s\n", "campaign", "provider", "vm", "cells", "GPU-h", "USD"
+        for (i = 1; i <= nm; i++) {
+            vm = (mdir[i] in dirvm) ? dirvm[mdir[i]] : "?"
+            if (vm == "?" || vavg[vm] == 0) used_def = 1
+            r  = (vm != "?" && vavg[vm] > 0) ? vavg[vm] : def_rate / 100.0
+            usd = msec[i] / 3600.0 * r
+            csum[vm] += usd; tot_compute += usd
+            printf "%-28s %-9s %-16s %5d %8.2f %9.2f\n", mname[i], (vm == "?") ? "?" : vprovider[vm], vm, mcells[i], msec[i] / 3600.0, usd
+        }
+    }
+    printf "\n%-16s %-9s %8s %9s %12s %13s\n", "vm", "provider", "wall-h", "wall-USD", "compute-USD", "overhead-USD"
+    for (i = 1; i <= nv; i++) {
+        vm = vlist[i]; if (vm in vskip) continue
+        printf "%-16s %-9s %8.2f %9.2f %12.2f %13.2f%s\n", vm, vprovider[vm], vwall[vm], vusd[vm], csum[vm] + 0, vusd[vm] - csum[vm], (vm in vdown) ? "" : "  (still running)"
+        tot_wall += vusd[vm]
+    }
+    printf "\nTOTAL wall-clock spend in window: $%.2f  (manifest-backed compute $%.2f; overhead + in-flight cells $%.2f)\n", tot_wall, tot_compute, tot_wall - tot_compute
+    if (tn > 0) printf "topups in window: $%.2f (%d)\n", tsum, tn
+    if (bf_set && bl_set && bl_e > bf_e)
+        printf "ledger-implied spend ($%.2f @%s + topups − $%.2f @%s): $%.2f\n", bf, iso(bf_e), bl, iso(bl_e), bf + tsum - bl
+    if (def_rate == 0 && used_def) print "[warn] some rows lacked a rate and no fallback was available (priced at $0)"
+    for (i = 1; i <= nn; i++) { if (i == 1) print "\nnotes:"; print "  " notes[i] }
+}'

--- a/orchestration/cube_drain.sh
+++ b/orchestration/cube_drain.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# cube_drain.sh — run ON a cloud VM: continuously push reduced field cubes to the rsync-jailed
+# store, overlapping uploads with the campaign's GPU compute (needs KEEP_CUBE=1 so cubes survive
+# their reduce). Local copies are KEPT (cheap on the VM's NVMe) so a bad upload is never fatal;
+# the store is a staging buffer the workstation later drains at its leisure (no VM billing).
+#
+# A cube is eligible once its <uuid>.reduced marker exists — the reduce read the whole cube, so
+# it is complete and consistent on disk. Verify = a second checksum dry-run pass transfers
+# nothing; only then is the .drained sentinel written. Failures just retry next sweep.
+#
+# Env: DRAIN_STORE (user@host of the jailed store), DRAIN_KEY (default ~/.ssh/depot_key).
+set -u
+STORE="${DRAIN_STORE:?set DRAIN_STORE (user@host of the jailed store)}"
+KEY="${DRAIN_KEY:-$HOME/.ssh/depot_key}"
+RS() { rsync -e "ssh -i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes" "$@"; }
+log() { echo "[drain $(date -u +%FT%TZ)] $*"; }
+
+log "watching $HOME/EDM/runs (store: $STORE)"
+while :; do
+    for cube in "$HOME"/EDM/runs/*/field_*.jls; do
+        [ -e "$cube" ] || continue
+        dir=$(dirname "$cube"); camp=$(basename "$dir"); base=$(basename "$cube")
+        uuid=${base%.jls}; uuid=${uuid##*_}          # field_..._<uuid>.jls
+        [ "$camp" = smoke ] && continue              # smoke cubes are worthless
+        [ -e "$dir/$uuid.reduced" ] || continue      # cube not yet proven complete
+        [ -e "$dir/.drained_$base" ] && continue
+        log "$camp/$base → store ($(du -h "$cube" | cut -f1))"
+        if RS -t --partial "$cube" "$STORE:cubes/$camp/$uuid/"; then
+            # checksum dry-run: -i itemizes ONLY files that would re-transfer ⇒ any mention = mismatch
+            if RS -nci -t "$cube" "$STORE:cubes/$camp/$uuid/" | grep -q "$base"; then
+                log "VERIFY FAILED $base — retrying next sweep"
+            else
+                touch "$dir/.drained_$base"; log "verified $base"
+            fi
+        else
+            log "push failed for $base — retrying next sweep"
+        fi
+    done
+    sleep 60
+done

--- a/orchestration/cube_drain.sh
+++ b/orchestration/cube_drain.sh
@@ -8,11 +8,14 @@
 # it is complete and consistent on disk. Verify = a second checksum dry-run pass transfers
 # nothing; only then is the .drained sentinel written. Failures just retry next sweep.
 #
-# Env: DRAIN_STORE (user@host of the jailed store), DRAIN_KEY (default ~/.ssh/depot_key).
+# Env: DRAIN_STORE (user@host of the jailed store), DRAIN_KEY (default ~/.ssh/depot_key),
+#      DRAIN_PORT (default 22; Hetzner storage-box DIRECT access = port 23 + sub-account —
+#      each machine then gets its own stream instead of sharing the VPS sshfs write pipe).
 set -u
 STORE="${DRAIN_STORE:?set DRAIN_STORE (user@host of the jailed store)}"
 KEY="${DRAIN_KEY:-$HOME/.ssh/depot_key}"
-RS() { rsync -e "ssh -i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes" "$@"; }
+PORT="${DRAIN_PORT:-22}"
+RS() { rsync -e "ssh -p $PORT -i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes" "$@"; }
 log() { echo "[drain $(date -u +%FT%TZ)] $*"; }
 
 log "watching $HOME/EDM/runs (store: $STORE)"

--- a/orchestration/cube_drain.sh
+++ b/orchestration/cube_drain.sh
@@ -25,6 +25,10 @@ while :; do
         [ -e "$dir/$uuid.reduced" ] || continue      # cube not yet proven complete
         [ -e "$dir/.drained_$base" ] && continue
         log "$camp/$base → store ($(du -h "$cube" | cut -f1))"
+        # plain rsync's implicit mkdir is not -p: push a local skeleton first so every
+        # parent of cubes/<camp>/<uuid>/ exists (harmless no-op when it already does)
+        skel=$(mktemp -d); mkdir -p "$skel/cubes/$camp/$uuid"
+        RS -r "$skel/cubes" "$STORE:"; rm -rf "$skel"
         if RS -t --partial "$cube" "$STORE:cubes/$camp/$uuid/"; then
             # checksum dry-run: -i itemizes ONLY files that would re-transfer ⇒ any mention = mismatch
             if RS -nci -t "$cube" "$STORE:cubes/$camp/$uuid/" | grep -q "$base"; then

--- a/orchestration/cube_drain_r2.sh
+++ b/orchestration/cube_drain_r2.sh
@@ -36,7 +36,7 @@ ENVF="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"
 [ -f "$ENVF" ] || { echo "[drain-r2] $ENVF missing — refusing to start (fall back to cube_drain.sh)"; exit 1; }
 . "$ENVF"
 BUCKET="${R2_BUCKET:-simulation-storage}"
-RC() { rclone --s3-upload-concurrency "${R2_CONCURRENCY:-16}" --s3-chunk-size "${R2_CHUNK:-128M}" "$@"; }
+RC() { rclone --s3-no-check-bucket --s3-upload-concurrency "${R2_CONCURRENCY:-16}" --s3-chunk-size "${R2_CHUNK:-128M}" "$@"; }
 log() { echo "[drain-r2 $(date -u +%FT%TZ)] $*"; }
 
 log "watching $HOME/EDM/runs (bucket: $BUCKET)"
@@ -52,7 +52,7 @@ while :; do
         # local hash first (~3 min for 86 GB) — becomes the end-to-end reference the puller checks
         sha=$(sha256sum "$cube" | cut -d' ' -f1) || continue
         if RC copyto "$cube" "r2:$BUCKET/cubes/$camp/$uuid/$base" &&
-           echo "$sha  $base" | rclone rcat "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256"; then
+           echo "$sha  $base" | rclone rcat --s3-no-check-bucket "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256"; then
             touch "$dir/.drained_$base"; log "uploaded $base (sha256 $sha)"
         else
             log "upload failed for $base — retrying next sweep"

--- a/orchestration/cube_drain_r2.sh
+++ b/orchestration/cube_drain_r2.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# cube_drain_r2.sh — R2 (object storage) successor to cube_drain.sh. Run ON a cloud VM with
+# KEEP_CUBE=1: pushes reduced cubes to a Cloudflare R2 bucket with multipart-parallel uploads.
+#
+# WHY R2 over the rsync store: every ssh-based path from a GPU VM is pinned to ~12–16 MB/s per
+# stream (OpenSSH's ~2 MB channel window × 116 ms RTT — measured 2026-07-17, provider-agnostic),
+# so an 86 GB cube costs ~2.4 h and campaigns pay an upload tail after compute ends. Multipart
+# HTTPS sidesteps the window entirely: 16 concurrent 128 MB parts exercise the real NIC.
+# R2 specifics: zero egress fees (cubes leave the buffer again!), ~$0.015/GB-month prorated
+# (a 1 TB campaign parked 3 days ≈ $1.50), S3-compatible API.
+#
+# Integrity: a <cube>.sha256 sidecar object is uploaded alongside; the puller verifies AFTER
+# download and only then frees the bucket slot — end-to-end VM-disk→archive verification,
+# replacing the old full re-read verify pass (~30 min/cube).
+#
+# Same eligibility contract as cube_drain.sh: a cube drains once its <uuid>.reduced marker
+# exists; .drained_<basename> sentinels make the two drainers interchangeable.
+#
+# Setup (once per account — user steps in the Cloudflare dashboard):
+#   1. R2 → create bucket (default name: simulation-storage); add a lifecycle rule (e.g. delete after
+#      14 days) as a cost safety-net for forgotten objects.
+#   2. R2 API token scoped to THAT bucket, Object Read & Write → gives access key id + secret.
+#   3. Write ~/.config/edm-r2.env (the warm step ships it to VMs like the depot key):
+#        export RCLONE_CONFIG_R2_TYPE=s3
+#        export RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+#        export RCLONE_CONFIG_R2_ACCESS_KEY_ID=...
+#        export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=...
+#        export RCLONE_CONFIG_R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
+#   4. rclone on the VM: curl https://rclone.org/install.sh | sudo bash   (or unzip the static
+#      binary into ~/bin — no root needed).
+#
+# Env: CUBE_R2_ENV (default ~/.config/edm-r2.env), R2_BUCKET (default simulation-storage),
+#      R2_CONCURRENCY (default 16), R2_CHUNK (default 128M).
+set -u
+ENVF="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"
+[ -f "$ENVF" ] || { echo "[drain-r2] $ENVF missing — refusing to start (fall back to cube_drain.sh)"; exit 1; }
+. "$ENVF"
+BUCKET="${R2_BUCKET:-simulation-storage}"
+RC() { rclone --s3-upload-concurrency "${R2_CONCURRENCY:-16}" --s3-chunk-size "${R2_CHUNK:-128M}" "$@"; }
+log() { echo "[drain-r2 $(date -u +%FT%TZ)] $*"; }
+
+log "watching $HOME/EDM/runs (bucket: $BUCKET)"
+while :; do
+    for cube in "$HOME"/EDM/runs/*/field_*.jls; do
+        [ -e "$cube" ] || continue
+        dir=$(dirname "$cube"); camp=$(basename "$dir"); base=$(basename "$cube")
+        uuid=${base%.jls}; uuid=${uuid##*_}
+        [ "$camp" = smoke ] && continue
+        [ -e "$dir/$uuid.reduced" ] || continue
+        [ -e "$dir/.drained_$base" ] && continue
+        log "$camp/$base → r2 ($(du -h "$cube" | cut -f1))"
+        # local hash first (~3 min for 86 GB) — becomes the end-to-end reference the puller checks
+        sha=$(sha256sum "$cube" | cut -d' ' -f1) || continue
+        if RC copyto "$cube" "r2:$BUCKET/cubes/$camp/$uuid/$base" &&
+           echo "$sha  $base" | rclone rcat "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256"; then
+            touch "$dir/.drained_$base"; log "uploaded $base (sha256 $sha)"
+        else
+            log "upload failed for $base — retrying next sweep"
+        fi
+    done
+    sleep 60
+done

--- a/orchestration/cube_pull.sh
+++ b/orchestration/cube_pull.sh
@@ -5,12 +5,14 @@
 # cube_drain.sh (on the VMs) fills it while campaigns run; this empties it with no VM billing.
 #
 # Env: PULL_STORE (user@host of the jailed store), PULL_DEST (archive dir),
-#      PULL_KEY (default ~/.ssh/id_ed25519_depot; must be jailed to the store).
+#      PULL_KEY (default ~/.ssh/id_ed25519_depot; must be jailed to the store),
+#      PULL_PORT (default 22; 23 + sub-account for direct Hetzner storage-box access).
 set -u
 STORE="${PULL_STORE:?set PULL_STORE (user@host of the jailed store)}"
 DEST="${PULL_DEST:?set PULL_DEST (archive dir on this machine)}"
 KEY="${PULL_KEY:-$HOME/.ssh/id_ed25519_depot}"
-RS() { rsync -e "ssh -i $KEY -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$@"; }
+PORT="${PULL_PORT:-22}"
+RS() { rsync -e "ssh -p $PORT -i $KEY -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$@"; }
 log() { echo "[pull $(date -u +%FT%TZ)] $*"; }
 EMPTY=$(mktemp -d)
 mkdir -p "$DEST"

--- a/orchestration/cube_pull.sh
+++ b/orchestration/cube_pull.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# cube_pull.sh — run on the archive machine (workstation): pull drained cubes out of the
+# rsync-jailed store into the pool, verify (checksum dry-run transfers nothing), then free the
+# store slot — the store is a ~1 TB BUFFER between the paid VMs and the archive, not a warehouse:
+# cube_drain.sh (on the VMs) fills it while campaigns run; this empties it with no VM billing.
+#
+# Env: PULL_STORE (user@host of the jailed store), PULL_DEST (archive dir),
+#      PULL_KEY (default ~/.ssh/id_ed25519_depot; must be jailed to the store).
+set -u
+STORE="${PULL_STORE:?set PULL_STORE (user@host of the jailed store)}"
+DEST="${PULL_DEST:?set PULL_DEST (archive dir on this machine)}"
+KEY="${PULL_KEY:-$HOME/.ssh/id_ed25519_depot}"
+RS() { rsync -e "ssh -i $KEY -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$@"; }
+log() { echo "[pull $(date -u +%FT%TZ)] $*"; }
+EMPTY=$(mktemp -d)
+mkdir -p "$DEST"
+
+while :; do
+    # store layout (written by cube_drain.sh): cubes/<campaign>/<uuid>/field_*.jls
+    RS -r --list-only "$STORE:cubes/" 2>/dev/null | awk 'NF>=5 && $NF ~ /\.jls$/ {print $NF}' |
+    while IFS= read -r rel; do
+        camp=${rel%%/*}; rest=${rel#*/}; uuid=${rest%%/*}; base=${rest#*/}
+        [ -e "$DEST/$camp/.verified_$base" ] && continue
+        mkdir -p "$DEST/$camp"
+        log "$camp/$base ← store ($uuid)"
+        RS -t --partial "$STORE:cubes/$rel" "$DEST/$camp/" || { log "pull failed $base — next sweep"; continue; }
+        # checksum dry-run against the store copy: -i itemizes only mismatches ⇒ silence = verified
+        if RS -nci -t "$DEST/$camp/$base" "$STORE:cubes/$camp/$uuid/" | grep -q "$base"; then
+            log "VERIFY FAILED $base — keeping store copy, retrying next sweep"
+        else
+            touch "$DEST/$camp/.verified_$base"
+            RS -r --delete "$EMPTY/" "$STORE:cubes/$camp/$uuid/" && log "verified + freed store slot: $camp/$base"
+        fi
+    done
+    sleep 300
+done

--- a/orchestration/cube_pull_r2.sh
+++ b/orchestration/cube_pull_r2.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# cube_pull_r2.sh — archive-machine side of the R2 cube pipeline (see cube_drain_r2.sh).
+# Runs on the workstation: lists the bucket, downloads each cube with multi-thread streams,
+# verifies END-TO-END against the sha256 the VM computed from its own disk, and only then
+# frees the bucket slot. R2 egress is free, so failed verifies re-pull at zero cost.
+#
+# Run from the archive box (institute line) — residential ISPs may block neither R2 (443)
+# nor anything here, unlike the storage box's port 23; R2 needs only HTTPS.
+#
+# Env: CUBE_R2_ENV (default ~/.config/edm-r2.env — same file as the drain side),
+#      R2_BUCKET (default simulation-storage), PULL_DEST (archive dir),
+#      R2_PULL_STREAMS (default 8 multi-thread download streams).
+set -u
+ENVF="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"
+[ -f "$ENVF" ] || { echo "[pull-r2] $ENVF missing — refusing to start"; exit 1; }
+. "$ENVF"
+BUCKET="${R2_BUCKET:-simulation-storage}"
+DEST="${PULL_DEST:?set PULL_DEST (archive dir on this machine)}"
+log() { echo "[pull-r2 $(date -u +%FT%TZ)] $*"; }
+mkdir -p "$DEST"
+
+while :; do
+    rclone lsf -R --files-only "r2:$BUCKET/cubes/" 2>/dev/null | grep '\.jls$' |
+    while IFS= read -r rel; do   # rel = <campaign>/<uuid>/<file>.jls
+        camp=${rel%%/*}; rest=${rel#*/}; uuid=${rest%%/*}; base=${rest#*/}
+        [ -e "$DEST/$camp/.verified_$base" ] && continue
+        mkdir -p "$DEST/$camp"
+        log "$camp/$base ← r2"
+        rclone copyto --multi-thread-streams "${R2_PULL_STREAMS:-8}" \
+            "r2:$BUCKET/cubes/$rel" "$DEST/$camp/$base" || { log "download failed $base — next sweep"; continue; }
+        want=$(rclone cat "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256" 2>/dev/null | cut -d' ' -f1)
+        have=$(sha256sum "$DEST/$camp/$base" | cut -d' ' -f1)
+        if [ -n "$want" ] && [ "$want" = "$have" ]; then
+            touch "$DEST/$camp/.verified_$base"
+            rclone purge "r2:$BUCKET/cubes/$camp/$uuid" && log "verified end-to-end + freed: $camp/$base"
+        else
+            log "VERIFY FAILED $base (want=${want:-none} have=$have) — keeping bucket copy"
+        fi
+    done
+    sleep 300
+done

--- a/scripts/compare_kernels.jl
+++ b/scripts/compare_kernels.jl
@@ -1,0 +1,237 @@
+# Numeric A/B of two retarded-time GPU kernels (GPUKernelNewton vs GPUKernelRK4) run on
+# IDENTICAL physics — same laser, screen, electrons, tolerances; the ONLY thing that differs
+# is how the retarded time is solved on the GPU. Any disagreement is therefore purely
+# numeric: the maps rendered here characterise each kernel's numerical floor, not physics.
+# Per harmonic it renders |Δ| difference maps for B and E (total field and, when both runs
+# saved the split, far field alone), normalized two ways — raw |Δ| and |Δ|/rms(ref) — so the
+# SPATIAL STRUCTURE of the disagreement (smooth vs speckly, ring-following vs uniform) is
+# visible. B is the featured field: E is known to carry the DC-shelf spectral-leakage floor
+# (see the smalla0-floor notes), so its large-n harmonics don't resolve the kernel gap.
+#
+#   julia +release --project=scripts scripts/compare_kernels.jl RUN_A.toml RUN_REF.toml [RUN_ALT.toml]
+#
+# RUN_A = the kernel under test (Newton), RUN_REF = the reference kernel (RK4, the
+# denominator of every relative number). The optional RUN_ALT is a same-kernel sibling of
+# RUN_A differing only in iteration count (e.g. newton_iters=1 vs 2); its gap vs RUN_A is
+# reported in the sidecars as the iteration-convergence floor.
+
+using TOML, Serialization, LinearAlgebra, Statistics, Printf
+using RunManifests: check_schema_version, write_derived, write_comparison
+using CairoMakie
+include(joinpath(@__DIR__, "plot_theme.jl"))   # LaTeX (Computer Modern) fonts
+
+const newt_toml, ref_toml = ARGS[1], ARGS[2]
+const alt_toml = length(ARGS) >= 3 ? ARGS[3] : nothing
+const OUTDIR = get(ENV, "EDM_OUTDIR", ".")
+
+Na = TOML.parsefile(newt_toml)
+Ra = TOML.parsefile(ref_toml)
+Aa = alt_toml === nothing ? nothing : TOML.parsefile(alt_toml)
+
+check_schema_version(Na; source = "kernel-under-test manifest")
+check_schema_version(Ra; source = "reference-kernel manifest")
+Aa === nothing || check_schema_version(Aa; source = "alt-iterations manifest")
+
+run_id(m, path) = get(
+    get(m, "provenance", Dict()), "run_id",
+    replace(basename(path), r"^run_" => "", r"\.toml$" => "")
+)
+script_of(m) = basename(get(get(m, "provenance", Dict()), "script", ""))
+kernel_of(m) = string(get(m["config"], "accumulation_alg", "GPUKernelRK4"))
+
+# Resolve the reduced hmaps .jls relative to the manifest: prefer [outputs].harmonic_maps,
+# else the conventional hmaps_<run_id>.jls beside the toml.
+function resolve_hmaps(m, path)
+    dir = dirname(abspath(path))
+    out = get(m, "outputs", Dict())
+    haskey(out, "harmonic_maps") && return joinpath(dir, out["harmonic_maps"])
+    cand = joinpath(dir, "hmaps_$(run_id(m, path)).jls")
+    isfile(cand) && return cand
+    error("$(basename(path)): no [outputs].harmonic_maps and no $(basename(cand)) beside it")
+end
+
+# Identical physics is the whole premise — refuse any pair that differs in anything except
+# the kernel knobs. Unlike the LPWA comparison there is no convention gap to tolerate:
+# both runs come from the same script, so pol/phi0/everything must match EXACTLY.
+function check_compatible(a, b; expect_kernel_diff::Bool)
+    laser_params = ("wavelength", "w0", "p", "m", "pol", "profile", "a0", "phi0",
+        "temporal_width", "focus_position")
+    config_params = ("samples_per_period", "Nx", "Ny", "N", "N_samples", "initial_phase",
+        "mode", "observable", "reltol", "interp_saveat", "sync_per_electron")
+    setup_params = ("τi", "τf", "Rmax", "Z")
+    for (sec, keys) in (("laser", laser_params), ("config", config_params), ("setup", setup_params))
+        for k in keys
+            (haskey(a[sec], k) || haskey(b[sec], k)) || continue   # absent on both: older schema
+            a[sec][k] == b[sec][k] || error("[$sec].$k differs: $(a[sec][k]) vs $(b[sec][k])")
+        end
+    end
+    if expect_kernel_diff
+        kernel_of(a) != kernel_of(b) ||
+            @warn "both runs use the same retarded-time kernel — this compares iteration counts, not kernels" kernel = kernel_of(a)
+    else
+        kernel_of(a) == kernel_of(b) ||
+            error("alt-iterations run uses a different kernel: $(kernel_of(a)) vs $(kernel_of(b))")
+    end
+    return nothing
+end
+
+check_compatible(Na, Ra; expect_kernel_diff = true)
+Aa === nothing || check_compatible(Aa, Na; expect_kernel_diff = false)
+
+N = deserialize(resolve_hmaps(Na, newt_toml))   # (; fields_h, fields_far_h, harmonics, ffund, x_grid, y_grid, w₀, …)
+R = deserialize(resolve_hmaps(Ra, ref_toml))
+A = Aa === nothing ? nothing : deserialize(resolve_hmaps(Aa, alt_toml))
+
+@assert collect(N.x_grid) ≈ collect(R.x_grid) "x grids differ — screens not co-located"
+@assert collect(N.y_grid) ≈ collect(R.y_grid) "y grids differ — screens not co-located"
+@assert size(N.fields_h)[2:end] == size(R.fields_h)[2:end] "fields_h non-harmonic dims differ"
+
+common_harmonics = A === nothing ? intersect(N.harmonics, R.harmonics) :
+    intersect(N.harmonics, R.harmonics, A.harmonics)
+isempty(common_harmonics) && error("no shared harmonics: $(N.harmonics) vs $(R.harmonics)")
+k_of(H, n) = findfirst(==(n), H.harmonics)
+
+newt_id, ref_id = run_id(Na, newt_toml), run_id(Ra, ref_toml)
+const a0 = Na["laser"]["a0"]
+@printf("comparing %s %s  vs  %s %s (reference)\n", kernel_of(Na), newt_id, kernel_of(Ra), ref_id)
+Aa === nothing || @printf(
+    "  iteration floor vs %s (newton_iters=%s)\n", run_id(Aa, alt_toml), Aa["config"]["newton_iters"]
+)
+@printf("  a0 = %s,  harmonics = %s\n", a0, Tuple(common_harmonics))
+
+const complabels = ("Eˣ", "Eʸ", "Eᶻ", "Bˣ", "Bʸ", "Bᶻ")
+
+xw, yw = collect(N.x_grid) ./ N.w₀, collect(N.y_grid) ./ N.w₀
+
+# Per-harmonic |Δ| maps of one field's 3 components between the two kernels. Top row: raw
+# |Δ| (each panel's own colorbar — the fields span decades between components). Bottom row:
+# |Δ|/rms(ref component) — one dimensionless texture scale, so the structure of the floor is
+# comparable across components/harmonics. `Amaps` (optional) only feeds the iteration-floor
+# scalar in the sidecar. One parametrized chip (harmonic selector) bound to BOTH parents.
+function diff_maps(Nmaps, Rmaps, Amaps; comps, field, kind, label, file_tag, variant)
+    for n in common_harmonics
+        kN, kR = k_of(N, n), k_of(R, n)
+        gN, gR = Nmaps[kN, comps, :, :], Rmaps[kR, comps, :, :]
+        rel_group = norm(gN .- gR) / norm(gR)
+        max_ratio = maximum(abs, gN .- gR) / maximum(abs, gR)
+        # |Δ| vs |ref| pixel correlation: ≈1 → the disagreement rides ON the physical rings
+        # (amplitude-proportional); ≈0 → a structureless (speckle/floor) pattern.
+        ring_corr = cor(vec(abs.(gN .- gR)), vec(abs.(gR)))
+        it_floor = Amaps === nothing ? nothing :
+            norm(Amaps[k_of(A, n), comps, :, :] .- gN) / norm(gN)
+
+        fig = Figure(size = (1150, 680))
+        Label(
+            fig[0, 1:3],
+            @sprintf("|%s̃_Newton − %s̃_RK4| at %dω₁ (a0=%s, %s)", field, field, n, a0, variant);
+            fontsize = 18
+        )
+        rels = Float64[]
+        for (j, comp) in enumerate(comps)
+            a = Nmaps[kN, comp, :, :]
+            b = Rmaps[kR, comp, :, :]
+            d = abs.(a .- b)
+            nrm = norm(b)
+            rel = nrm == 0 ? 0.0 : norm(a .- b) / nrm
+            push!(rels, rel)
+            rms = nrm / sqrt(length(b))
+            ax1 = Axis(
+                fig[1, j][1, 1]; title = @sprintf("%s   ‖Δ‖/‖ref‖=%.2e", complabels[comp], rel),
+                xlabel = "x/w₀", ylabel = "y/w₀", aspect = DataAspect()
+            )
+            hm1 = heatmap!(ax1, xw, yw, d; colormap = :inferno)
+            Colorbar(fig[1, j][1, 2], hm1; label = "|Δ|")
+            ax2 = Axis(fig[2, j][1, 1]; xlabel = "x/w₀", ylabel = "y/w₀", aspect = DataAspect())
+            hm2 = heatmap!(ax2, xw, yw, d ./ rms; colormap = :inferno)
+            Colorbar(fig[2, j][1, 2], hm2; label = "|Δ| / rms(ref)")
+        end
+        out = joinpath(OUTDIR, @sprintf("compare_kernel_%s_h%d_%s-%s.png", file_tag, n, first(newt_id, 8), first(ref_id, 8)))
+        save(out, fig)
+        println("saved → ", out)
+        @printf(
+            "h=%dω₁  %s %-11s  relL2 = %.3e   max|Δ|/max|ref| = %.3e   corr(|Δ|,|ref|) = %+.2f%s\n",
+            n, field, "($variant)", rel_group, max_ratio, ring_corr,
+            it_floor === nothing ? "" : @sprintf("   it-floor = %.3e", it_floor)
+        )
+        pp = Dict{String, Any}(
+            "relL2 ‖Δ‖/‖ref‖" => round(rel_group; sigdigits = 3),
+            "relL2 per comp" => round.(rels; sigdigits = 3),
+            "max|Δ|/max|ref|" => round(max_ratio; sigdigits = 3),
+            "corr(|Δ|,|ref|)" => round(ring_corr; sigdigits = 3),
+        )
+        it_floor === nothing || (pp["relL2 it-pair (Newton $(Aa["config"]["newton_iters"]) vs $(Na["config"]["newton_iters"]) iters)"] =
+            round(it_floor; sigdigits = 3))
+        trust = comps == 4:6 ?
+            "$field is the trusted field for floor comparisons (E carries the DC-shelf spectral-leakage floor)." :
+            "Caveat: E carries the known DC-shelf spectral-leakage floor, so its high harmonics saturate on leakage, not on the kernel gap."
+        write_derived(
+            OUTDIR; kind, label,
+            run_id = [newt_id, ref_id], plot = basename(out), setup = Dict("harmonic" => n),
+            plot_params = pp,
+            description = "|$(field)̃_Newton − $(field)̃_RK4| at $(n)ω₁ (a0=$a0, $variant): identical physics, " *
+                "only the retarded-time GPU kernel differs, so this map IS the kernels' numeric disagreement. " *
+                "Top row raw |Δ|; bottom row |Δ|/rms(ref component) (one dimensionless texture scale). " *
+                @sprintf("rel-L2 = %.2e, max|Δ|/max|ref| = %.2e; corr(|Δ|,|ref|) = %.2f ", rel_group, max_ratio, ring_corr) *
+                "(≈1 → the gap rides on the physical rings, ≈0 → structureless floor). " *
+                (it_floor === nothing ? "" :
+                @sprintf("Newton iteration-convergence floor (it%s vs it%s): rel-L2 = %.2e. ",
+                    Aa["config"]["newton_iters"], Na["config"]["newton_iters"], it_floor)) * trust,
+        )
+        println("derived → $kind h$n  (parents $newt_id, $ref_id)")
+    end
+    return nothing
+end
+
+# B first — the featured, trusted field — then E; total field, then the far-field split.
+diff_maps(N.fields_h, R.fields_h, A === nothing ? nothing : A.fields_h;
+    comps = 4:6, field = "B", kind = "kernel_diff_B", label = "Newton vs RK4 |ΔB|",
+    file_tag = "dB", variant = "total field")
+diff_maps(N.fields_h, R.fields_h, A === nothing ? nothing : A.fields_h;
+    comps = 1:3, field = "E", kind = "kernel_diff_E", label = "Newton vs RK4 |ΔE|",
+    file_tag = "dE", variant = "total field")
+
+Nfar = hasproperty(N, :fields_far_h) ? N.fields_far_h : nothing
+Rfar = hasproperty(R, :fields_far_h) ? R.fields_far_h : nothing
+Afar = (A !== nothing && hasproperty(A, :fields_far_h)) ? A.fields_far_h : nothing
+if Nfar !== nothing && Rfar !== nothing
+    @assert size(Nfar)[2:end] == size(Rfar)[2:end] "far-field non-harmonic dims differ"
+    diff_maps(Nfar, Rfar, Afar;
+        comps = 4:6, field = "B", kind = "kernel_diff_B_far", label = "Newton vs RK4 |ΔB| (far field)",
+        file_tag = "dB_far", variant = "far field")
+    diff_maps(Nfar, Rfar, Afar;
+        comps = 1:3, field = "E", kind = "kernel_diff_E_far", label = "Newton vs RK4 |ΔE| (far field)",
+        file_tag = "dE_far", variant = "far field")
+else
+    println("far-field maps absent on one/both runs — skipping far comparison")
+end
+
+# ── Comparison declaration: the first-class A-vs-B relationship the dashboard reads. ──
+# Both sides live in ONE campaign dir (the kernel is a sweep axis there, not a dir split),
+# so each side carries a `where` filter of canonical-param constraints selecting its runs —
+# the builder pairs the two filtered sides cell-by-cell along the shared a0 axis. Idempotent:
+# every a0-pair re-emits the SAME declaration under one fixed filename.
+let
+    function side_spec(m, path)
+        alg = kernel_of(m)
+        w = Dict{String, Any}("accumulation_alg" => alg)
+        lbl = alg
+        if alg == "GPUKernelNewton"
+            w["newton_iters"] = m["config"]["newton_iters"]
+            lbl = "Newton ($(m["config"]["newton_iters"]) iters)"
+        elseif alg == "GPUKernelRK4"
+            w["n_substeps"] = m["config"]["n_substeps"]
+            lbl = "RK4 ($(m["config"]["n_substeps"]) substep)"
+        end
+        return Dict{String, Any}(
+            "label" => lbl, "dir" => basename(dirname(abspath(path))),
+            "script" => script_of(m), "where" => w,
+        )
+    end
+    sides = [side_spec(Na, newt_toml), side_spec(Ra, ref_toml)]
+    out = write_comparison(
+        OUTDIR; label = "kernel numerics: Newton vs RK4", differs = "retarded-time kernel",
+        along = "a0", sides,
+        filename = "comparison_$(sides[1]["dir"])_kernels.toml",
+    )
+    println("comparison → ", basename(out), "  (", sides[1]["label"], "  vs  ", sides[2]["label"], ")")
+end

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -53,9 +53,13 @@ const NELEC = parse(Int, get(ENV, "EDM_N", "10000"))
 const NSAMPLES = parse(Int, get(ENV, "EDM_NSAMPLES", "8000"))
 const SPP = parse(Int, get(ENV, "EDM_SPP", "16"))
 const NSUBSTEPS = parse(Int, get(ENV, "EDM_NSUBSTEPS", "1"))
-const GPU_SOLVER = lowercase(get(ENV, "EDM_GPU_SOLVER", "rk4"))  # retarded-time kernel: rk4 (ODE march, EDM_NSUBSTEPS) | newton (light-cone root solve, EDM_NEWTON_ITERS)
+# Retarded-time kernel: rk4 (ODE march, EDM_NSUBSTEPS) | newton (light-cone root solve,
+# EDM_NEWTON_ITERS). EDM_ACCUM_ALG is the canonical knob (matches the manifest/dashboard
+# accumulation_alg key + inverse_thomson_scattering.jl); EDM_GPU_SOLVER is the legacy alias
+# from the first newton campaigns' manifests — kept so their replay keeps working.
+const GPU_SOLVER = lowercase(get(ENV, "EDM_ACCUM_ALG", get(ENV, "EDM_GPU_SOLVER", "rk4")))
 GPU_SOLVER in ("rk4", "newton") ||
-    error("EDM_GPU_SOLVER must be \"rk4\" or \"newton\", got $(repr(GPU_SOLVER))")
+    error("EDM_ACCUM_ALG must be \"rk4\" or \"newton\", got $(repr(GPU_SOLVER))")
 const NEWTON_ITERS = parse(Int, get(ENV, "EDM_NEWTON_ITERS", "2"))  # ≥3 for strongly-relativistic forward scattering
 const RELTOL = parse(Float64, get(ENV, "EDM_RELTOL", "1e-12"))   # ODE-solve rel tolerance (Vern9)
 const ABSTOL_ENV = get(ENV, "EDM_ABSTOL", "")                    # "" ⇒ abserr(a0); else this Float64

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -6,6 +6,7 @@
 #
 # ENV knobs (defaults = full production): EDM_GPU_BACKEND (rocm|cuda), EDM_A0,
 # EDM_INITIAL_PHASE, EDM_NX, EDM_N, EDM_NSAMPLES, EDM_SPP, EDM_NSUBSTEPS,
+# EDM_GPU_SOLVER (rk4|newton) + EDM_NEWTON_ITERS,
 # EDM_POL (linear|circular[_plus]|circular_minus),
 # EDM_SYNC_PER_ELECTRON, EDM_OUTDIR. Writes the field .jls + per-harmonic PNGs +
 # run_<uuid>.toml manifest.
@@ -52,6 +53,10 @@ const NELEC = parse(Int, get(ENV, "EDM_N", "10000"))
 const NSAMPLES = parse(Int, get(ENV, "EDM_NSAMPLES", "8000"))
 const SPP = parse(Int, get(ENV, "EDM_SPP", "16"))
 const NSUBSTEPS = parse(Int, get(ENV, "EDM_NSUBSTEPS", "1"))
+const GPU_SOLVER = lowercase(get(ENV, "EDM_GPU_SOLVER", "rk4"))  # retarded-time kernel: rk4 (ODE march, EDM_NSUBSTEPS) | newton (light-cone root solve, EDM_NEWTON_ITERS)
+GPU_SOLVER in ("rk4", "newton") ||
+    error("EDM_GPU_SOLVER must be \"rk4\" or \"newton\", got $(repr(GPU_SOLVER))")
+const NEWTON_ITERS = parse(Int, get(ENV, "EDM_NEWTON_ITERS", "2"))  # ≥3 for strongly-relativistic forward scattering
 const RELTOL = parse(Float64, get(ENV, "EDM_RELTOL", "1e-12"))   # ODE-solve rel tolerance (Vern9)
 const ABSTOL_ENV = get(ENV, "EDM_ABSTOL", "")                    # "" ⇒ abserr(a0); else this Float64
 const INTERP_SAVEAT = get(ENV, "EDM_INTERP_SAVEAT", "")          # trajectory-spline knots/laser-period;
@@ -64,7 +69,7 @@ FIELD_MODE in (:split, :total) || error("EDM_FIELD_MODE must be \"split\" or \"t
 const SKIP_POST = get(ENV, "EDM_SKIP_POSTPROCESS", "0") == "1"   # field-only: serialize cube + manifest, defer the (CPU/IO) reduction to an async step
 const RUN_TAG = get(ENV, "EDM_RUN_TAG", string(uuid4()))   # launcher may pin via EDM_RUN_TAG so .jls/log/manifest share one id
 mkpath(OUTDIR)
-@info "Thomson (field) run config" RUN_TAG GPU_BACKEND ϕ₀ A0 SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS
+@info "Thomson (field) run config" RUN_TAG GPU_BACKEND GPU_SOLVER ϕ₀ A0 SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS NEWTON_ITERS
 const T_START = time()   # wall-clock start → [timing].total in the manifest
 
 # Laser parameters
@@ -200,6 +205,10 @@ screen = ObserverScreen(
 # Multi-GPU: when >1 device is visible (e.g. SLURM --gres=gpu:h200:2) shard the electrons across
 # them — linear superposition ⇒ the summed partials are exact; one device ⇒ the plain path.
 ndev = gpu_device_count(gpu_backend)
+# Retarded-time solver: sentinel alg + its accuracy kwarg (rk4 marches between slots with
+# n_substeps; newton root-solves each slot with n_iters warm-started corrections).
+solver_alg = GPU_SOLVER == "newton" ? GPUKernelNewton() : GPUKernelRK4()
+solver_kw = GPU_SOLVER == "newton" ? (; n_iters = NEWTON_ITERS) : (; n_substeps = NSUBSTEPS)
 # Sample GPU power/util/VRAM across the accumulate_field window on all sharded devices
 # (→ manifest [gpu] stats + the gputrace TSV time series; see gpu_telemetry.jl).
 gputracefile = joinpath(OUTDIR, "gputrace_$(RUN_TAG).tsv")
@@ -209,13 +218,13 @@ t_field = @elapsed begin
         if ndev > 1
             @info "sharding electrons across $ndev devices"
             accumulate_field_sharded(
-                trajs, screen, GPUKernelRK4(), gpu_backend;
-                n_substeps = NSUBSTEPS, mode = Val(FIELD_MODE), sync_per_electron = SYNC
+                trajs, screen, solver_alg, gpu_backend;
+                solver_kw..., mode = Val(FIELD_MODE), sync_per_electron = SYNC
             )
         else
             accumulate_field(
-                trajs, screen, GPUKernelRK4(), gpu_backend;
-                n_substeps = NSUBSTEPS, mode = Val(FIELD_MODE), sync_per_electron = SYNC
+                trajs, screen, solver_alg, gpu_backend;
+                solver_kw..., mode = Val(FIELD_MODE), sync_per_electron = SYNC
             )
         end
     end
@@ -264,6 +273,10 @@ config = Dict{String, Any}(
     "N_samples" => N_samples,
     "samples_per_period" => samples_per_period,
     "n_substeps" => NSUBSTEPS,
+    # dashboard-canonical kernel name (the builder's accumulation_alg param; defaults to
+    # GPUKernelRK4 for manifests that predate the knob)
+    "accumulation_alg" => GPU_SOLVER == "newton" ? "GPUKernelNewton" : "GPUKernelRK4",
+    "newton_iters" => NEWTON_ITERS,    # Newton corrections/slot (active when the Newton kernel is selected)
     "reltol" => RELTOL,                # ODE-solve tolerances (replay + small-a0 floor study)
     "abstol" => ABSTOL,
     "interp_saveat" => isempty(INTERP_SAVEAT) ? "adaptive" : INTERP_SAVEAT,  # trajectory-spline knots/period

--- a/src/ElectronDynamicsModels.jl
+++ b/src/ElectronDynamicsModels.jl
@@ -66,17 +66,16 @@ include("field_evaluator.jl")
 include("gpu/interp.jl")
 include("gpu/accumulate.jl")
 include("gpu/kernel_rk4.jl")
+include("gpu/kernel_newton.jl")
 include("gpu_api.jl")   # vendor GPU API (device mgmt + telemetry); impls in ext/EDM{CUDA,AMDGPU}Ext.jl
 include("rpr_api.jl")   # RPR rendering plumbing; impls in ext/EDMRPRMakieExt.jl + EDMIsoMeshExt.jl
 include("gpu/multidevice.jl")   # accumulate_field_sharded: electron sharding across GPUs
 
-# Experimental: batched/Tsit5 GPU path and the Newton light-cone retarded-time
-# solve — production staging, under active development.
+# Experimental: batched/Tsit5 GPU path — production staging, under active development.
 module Experimental
     include("gpu/experimental.jl")
-    include("gpu/kernel_newton.jl")
 end
 
-using .Experimental: GPUKernelTsit5, GPUKernelNewton
+using .Experimental: GPUKernelTsit5
 
 end

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -1,10 +1,7 @@
 # ── Newton light-cone GPU kernel: per-slot root solve + LW accumulation ──
-# Lives in the `Experimental` submodule (production staging, like the batched
-# Tsit5 path) and extends the parent `accumulate_potential`/`accumulate_field`.
-#
-# Alternative to the GPUKernelRK4 march (kernel_rk4.jl): instead of
-# integrating dτ_r/dx⁰ = 1/(u⁰ − u⃗·n̂) between saveat slots, solve the light-cone
-# condition
+# Extends `accumulate_potential`/`accumulate_field` as the alternative to the
+# GPUKernelRK4 march (kernel_rk4.jl): instead of integrating
+# dτ_r/dx⁰ = 1/(u⁰ − u⃗·n̂) between saveat slots, solve the light-cone condition
 #     f(τ) = x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)|  =  0
 # at each slot with warm-started Newton corrections.  f is strictly monotone
 # decreasing — f′(τ) = −(u⁰ − u⃗·n̂) < 0 since u⁰ ≥ |u⃗| on a timelike worldline —
@@ -12,15 +9,18 @@
 # spline eval that provides the residual.  Unlike the RK4 march, the per-slot
 # error does not accumulate along the observer-time grid.
 #
-# Measured on the W7900 (a₀ = 0.1 production setup, see
-# reports/newton_lightcone_retarded_time.typ): n_iters = 1 sits at the accuracy
-# floor (9.4e-11 vs tight reference; RK4 n_substeps = 1 is 9.5e-10) and runs
-# 1.5–2.0× faster than RK4 n_substeps = 1 on the potential path, time-neutral
-# to ~1.3× faster on the field path.  Strongly-relativistic forward-scattering
-# geometries need n_iters = 3 (the analog of RK4 needing n_substeps = 8 there).
-
-using ..ElectronDynamicsModels: to_gpu, lienard_wiechert_F_split, extract_EB
-import ..ElectronDynamicsModels: accumulate_field
+# Which kernel when (newton_a0_{low,high} production campaigns, MI300X 2026-07;
+# W7900 potential-path numbers in reports/newton_lightcone_retarded_time.typ):
+#   - Boosted forward scattering (γ ≫ 1): Newton. At γ = 10, n_iters = 1 is
+#     ~10× more accurate than RK4 n_substeps = 1 and 4.3× cheaper than
+#     matched-accuracy RK4 n_substeps = 8; converged by n_iters = 2.
+#   - Rest-electron field maps (a₀ ≲ 0.1): RK4. Accuracy is identical in norm
+#     (n_iters = 1 already at the 9.4e-11 floor; ≡ n_iters = 2 to 1e-13) but
+#     RK4 runs 1.3–1.4× faster there, and its error is smooth/correlated along
+#     observer time, so deep-floor harmonic B maps keep coherent ring structure
+#     where Newton's white per-slot error raises the floor (h4 B ~129×).
+# Per-slot error character is the differentiator near numerical floors:
+# norms decide convergence, error spectra decide what survives the FFT.
 
 """
     GPUKernelNewton
@@ -30,6 +30,13 @@ retarded proper time at each saveat slot is obtained by solving the light-cone
 condition `x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)| = 0` with `n_iters` warm-started
 Newton corrections, instead of marching the retarded-time ODE as
 [`GPUKernelRK4`](@ref) does.
+
+Per-slot errors are independent across observer-time slots (no accumulation).
+Prefer this kernel for boosted forward-scattering geometries (γ ≫ 1), where
+`n_iters = 1–2` beats matched-accuracy RK4 by ~4× in cost; prefer
+[`GPUKernelRK4`](@ref) for rest-electron field maps and deep-floor harmonic
+B-map studies, where its smoother error spectrum preserves near-floor ring
+structure. Measured campaign numbers in the header of `gpu/kernel_newton.jl`.
 """
 struct GPUKernelNewton end
 


### PR DESCRIPTION
First production use of the Newton light-cone kernel (#31): make the retarded-time solver selectable, record it in the run manifest, and add the two Hot Aisle campaigns that shake it out.

## Solver knob
- `EDM_GPU_SOLVER` (`rk4` default | `newton`) + `EDM_NEWTON_ITERS` (default 2) in `thomson_scattering.jl`; the alg and its accuracy kwarg (`n_substeps` vs `n_iters`) flow through both the single-device and sharded paths.
- Manifest `[config]` records the dashboard-canonical `accumulation_alg` (`GPUKernelRK4` | `GPUKernelNewton`) + `newton_iters`. `newton_iters` is written on **every** run, including rk4 — the dashboard's axis detection indexes axis keys directly, so heterogeneous key sets within a pool would crash it.
- `run_spec_from_manifest` replays both (guarded `haskey` — pre-Newton manifests keep defaulting to rk4, no schema bump).

## Campaigns
- **newton_a0_low** (6 cells): a0 ∈ {1e-3, 0.1} × n_iters ∈ {2, 1} + RK4 controls at both a0 — a fully self-contained same-hardware solver A/B (no reliance on old cross-hardware runs).
- **newton_a0_high** (6 cells): a0 = 0.2 … 10 at n_iters=3, uniform SPP=32 / NSAMPLES=12160 (Nyquist h16, 380-period window) so the sweep stays 1-D on the dashboard and the harmonic maps are spectrally comparable across a0.

Also rides along: runpod capacity camper now sends an ntfy ping at pod grab (billing starts there, not at campaign launch).

Companion PR: `newton_iters` in the dashboard builder's PARAM_SPEC (must land on the publish box before this campaign publishes).

## Promotion: GPUKernelNewton is out of Experimental (f57663d)

The campaigns above (+ the SPP=48 requeue and a γ=10 kernel A/B) delivered the promotion evidence; verdict: **keep both kernels, regime-guided** — neither is uniformly better.

| regime | winner | receipts |
|---|---|---|
| boosted forward scattering (γ≫1) | **Newton** | n_iters=1: ~10× more accurate than rk4_ns1, 4.3× cheaper than matched-accuracy rk4_ns8 (145 s vs 628 s); converged by n_iters=2 |
| rest-electron field maps (a₀ ≲ 0.1) | **RK4** | identical norm accuracy (h1 to 1.9e-7), 1.3–1.4× faster; smooth correlated error keeps deep-floor B-map ring structure where Newton's white per-slot error raises the floor (h4 B ~129×) |

The error-character asymmetry (norms decide convergence, error spectra decide what survives the FFT near the floor) is written into the kernel header + docstring, with the stale "γ≫1 needs n_iters=3" claim replaced by the measured numbers. `test/gpu_radiation.jl` (28 tests) passes on the moved kernel; no call-site changes — the name was already exported.

Evidence on the dashboard: `newton_a0_low` 3-D card, `newton_a0_high(+_spp48)`, and the "kernel numerics: Newton vs RK4" comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
