### PR TITLE
RayMakie/Hikari renderer experiment: volume-mode animation at 3.5 s/frame

### DIFF
--- a/animation/raymakie/.gitignore
+++ b/animation/raymakie/.gitignore
@@ -1,0 +1,4 @@
+frame_cache/
+ray_frames/
+*.png
+*.mp4

--- a/animation/raymakie/Manifest.toml
+++ b/animation/raymakie/Manifest.toml
@@ -1,0 +1,1967 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.6"
+manifest_format = "2.0"
+project_hash = "55574c2515ffc1b585d687cc4ee6b0068b222cbd"
+
+[[deps.AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.5.0"
+
+    [deps.AbstractFFTs.extensions]
+    AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
+    AbstractFFTsTestExt = "Test"
+
+    [deps.AbstractFFTs.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.AbstractTrees]]
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.4.5"
+
+[[deps.AcceleratedKernels]]
+deps = ["ArgCheck", "GPUArraysCore", "KernelAbstractions", "Markdown", "UnsafeAtomics"]
+git-tree-sha1 = "0de01460ed11e90b42ce666c8ed0265bad59aa6a"
+uuid = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"
+version = "0.4.3"
+
+    [deps.AcceleratedKernels.extensions]
+    AcceleratedKernelsoneAPIExt = "oneAPI"
+
+    [deps.AcceleratedKernels.weakdeps]
+    oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
+
+[[deps.Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
+git-tree-sha1 = "7063ad1083578215c7c4bf410368150abe8d5524"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.45"
+
+    [deps.Accessors.extensions]
+    AxisKeysExt = "AxisKeys"
+    IntervalSetsExt = "IntervalSets"
+    LinearAlgebraExt = "LinearAlgebra"
+    StaticArraysExt = "StaticArrays"
+    StructArraysExt = "StructArrays"
+    TestExt = "Test"
+    UnitfulExt = "Unitful"
+
+    [deps.Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "daa72978cd7a624246e894a4f4f067706d4e17e2"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "4.7.0"
+weakdeps = ["SparseArrays", "StaticArrays"]
+
+    [deps.Adapt.extensions]
+    AdaptSparseArraysExt = "SparseArrays"
+    AdaptStaticArraysExt = "StaticArrays"
+
+[[deps.AdaptivePredicates]]
+git-tree-sha1 = "7e651ea8d262d2d74ce75fdf47c4d63c07dba7a6"
+uuid = "35492f91-a3bd-45ad-95db-fcad7dcfedb7"
+version = "1.2.0"
+
+[[deps.AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
+
+[[deps.Animations]]
+deps = ["Colors"]
+git-tree-sha1 = "e092fa223bf66a3c41f9c022bd074d916dc303e7"
+uuid = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
+version = "0.4.2"
+
+[[deps.ArgCheck]]
+git-tree-sha1 = "f9e9a66c9b7be1ad7372bbd9b062d9230c30c5ce"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.5.0"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Atomix]]
+deps = ["UnsafeAtomics"]
+git-tree-sha1 = "b8651b2eb5796a386b0398a20b519a6a6150f75c"
+uuid = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
+version = "1.1.3"
+
+    [deps.Atomix.extensions]
+    AtomixCUDAExt = "CUDA"
+    AtomixMetalExt = "Metal"
+    AtomixOpenCLExt = "OpenCL"
+    AtomixoneAPIExt = "oneAPI"
+
+    [deps.Atomix.weakdeps]
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    OpenCL = "08131aa3-fb12-5dee-8b74-c09406e224a2"
+    oneAPI = "8f75cd03-7ff8-4ecb-9b8f-daf728133b1b"
+
+[[deps.Automa]]
+deps = ["PrecompileTools", "TranscodingStreams"]
+git-tree-sha1 = "94eab0b3ccdcac361188cc661daf69d4433c1818"
+uuid = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
+version = "1.2.0"
+
+[[deps.AxisAlgorithms]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "WoodburyMatrices"]
+git-tree-sha1 = "01b8ccb13d68535d73d2b0c23e39bd23155fb712"
+uuid = "13072b0f-2c55-5437-9ae7-d433b7a33950"
+version = "1.1.0"
+
+[[deps.AxisArrays]]
+deps = ["Dates", "IntervalSets", "IterTools", "RangeArrays"]
+git-tree-sha1 = "4126b08903b777c88edf1754288144a0492c05ad"
+uuid = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+version = "0.4.8"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BaseDirs]]
+git-tree-sha1 = "8c290a1b223deaeea9aea44b235d24546da8eb98"
+uuid = "18cc8868-cbac-4acf-b575-c8ff214dc66f"
+version = "1.4.0"
+
+[[deps.BitMasks]]
+git-tree-sha1 = "4751ad2b3b58362f1584ff07ddb9d13aed53ef7a"
+uuid = "a3e06817-fd65-4797-8291-16f435bc2529"
+version = "0.1.9"
+
+[[deps.Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1b96ea4a01afe0ea4090c5c8039690672dd13f2e"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.9+0"
+
+[[deps.CEnum]]
+git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.5.0"
+
+[[deps.CRC32c]]
+uuid = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
+version = "1.11.0"
+
+[[deps.CRlibm]]
+deps = ["CRlibm_jll"]
+git-tree-sha1 = "66188d9d103b92b6cd705214242e27f5737a1e5e"
+uuid = "96374032-68de-5a5b-8d9e-752f78720389"
+version = "1.0.2"
+
+[[deps.CRlibm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e329286945d0cfc04456972ea732551869af1cfc"
+uuid = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"
+version = "1.0.1+0"
+
+[[deps.Cairo_jll]]
+deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "1fa950ebc3e37eccd51c6a8fe1f92f7d86263522"
+uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
+version = "1.18.7+0"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "12177ad6b3cad7fd50c8b3825ce24a99ad61c18f"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.26.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.ChainRulesCore.extensions]
+    ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[deps.CodecZstd]]
+deps = ["TranscodingStreams", "Zstd_jll"]
+git-tree-sha1 = "da54a6cd93c54950c15adf1d336cfd7d71f51a56"
+uuid = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
+version = "0.8.7"
+
+[[deps.ColorBrewer]]
+deps = ["Colors", "JSON"]
+git-tree-sha1 = "07da79661b919001e6863b81fc572497daa58349"
+uuid = "a2cac450-b92f-5266-8821-25eda20663c8"
+version = "0.4.2"
+
+[[deps.ColorSchemes]]
+deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
+git-tree-sha1 = "b0fd3f56fa442f81e0a47815c92245acfaaa4e34"
+uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+version = "3.31.0"
+
+[[deps.ColorTypes]]
+deps = ["FixedPointNumbers", "Random"]
+git-tree-sha1 = "67e11ee83a43eb71ddc950302c53bf33f0690dfe"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.12.1"
+weakdeps = ["StyledStrings"]
+
+    [deps.ColorTypes.extensions]
+    StyledStringsExt = "StyledStrings"
+
+[[deps.ColorVectorSpace]]
+deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "Requires", "Statistics", "TensorCore"]
+git-tree-sha1 = "8b3b6f87ce8f65a2b4f857528fd8d70086cd72b1"
+uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+version = "0.11.0"
+weakdeps = ["SpecialFunctions"]
+
+    [deps.ColorVectorSpace.extensions]
+    SpecialFunctionsExt = "SpecialFunctions"
+
+[[deps.Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
+git-tree-sha1 = "37ea44092930b1811e666c3bc38065d7d87fcc74"
+uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
+version = "0.13.1"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "eeaad7cef88554c2fa56b5a3f71cfd5cb708c662"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.11"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [deps.CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[deps.ComputePipeline]]
+deps = ["Observables", "Preferences"]
+git-tree-sha1 = "d4b29609344a6e90678e8695fdd95bdb4a7f432e"
+repo-rev = "sd/lava"
+repo-subdir = "ComputePipeline"
+repo-url = "https://github.com/MakieOrg/Makie.jl.git"
+uuid = "95dc2771-c249-4cd0-9c9f-1f3b4330693c"
+version = "0.1.6"
+
+[[deps.ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+weakdeps = ["IntervalSets", "LinearAlgebra", "StaticArrays"]
+
+    [deps.ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+[[deps.Contour]]
+git-tree-sha1 = "439e35b0b36e2e5881738abc8857bd92ad6ff9a8"
+uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
+version = "0.6.3"
+
+[[deps.CoreMath]]
+deps = ["CoreMath_jll"]
+git-tree-sha1 = "8c0480f92b1b1796239156a1b9b1bfb1b39499b4"
+uuid = "b7a15901-be09-4a0e-87d2-2e66b0e09b5a"
+version = "0.1.0"
+
+[[deps.CoreMath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a692a4c1dc59a4b8bc0b6403876eb3250fde2bc3"
+uuid = "a38c48d9-6df1-5ac9-9223-b6ada3b5572b"
+version = "0.1.0+0"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataStructures]]
+deps = ["OrderedCollections"]
+git-tree-sha1 = "6fb53a69613a0b2b68a0d12671717d307ab8b24e"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.19.5"
+
+[[deps.DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Dbus_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "473e9afc9cf30814eb67ffa5f2db7df82c3ad9fd"
+uuid = "ee1fde0b-3d02-5ea6-8484-8dfef6360eab"
+version = "1.16.2+0"
+
+[[deps.DelaunayTriangulation]]
+deps = ["AdaptivePredicates", "EnumX", "ExactPredicates", "Random"]
+git-tree-sha1 = "c55f5a9fd67bdbc8e089b5a3111fe4292986a8e8"
+uuid = "927a84f5-c5f4-47a5-9785-b46e178433df"
+version = "1.6.6"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
+
+[[deps.Distributions]]
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "cd3c5ac74cd3923c8945c6a81518c46abd0e73a3"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.129"
+
+    [deps.Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DistributionsTestExt = "Test"
+
+    [deps.Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.EarCut_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e3290f2d49e661fbd94046d7e3726ffcb2d41053"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.2.4+0"
+
+[[deps.EnumX]]
+git-tree-sha1 = "c49898e8438c828577f04b92fc9368c388ac783c"
+uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+version = "1.0.7"
+
+[[deps.EpollShim_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8a4be429317c42cfae6a7fc03c31bad1970c310d"
+uuid = "2702e6a9-849d-5ed8-8c21-79e8b8f9ee43"
+version = "0.0.20230411+1"
+
+[[deps.ExactPredicates]]
+deps = ["IntervalArithmetic", "Random", "StaticArrays"]
+git-tree-sha1 = "83231673ea4d3d6008ac74dc5079e77ab2209d8f"
+uuid = "429591f6-91af-11e9-00e2-59fbe8cec110"
+version = "2.2.9"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e6c4a6407a949e79a9d3f249bf49e6987c80e01f"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.8.2+0"
+
+[[deps.ExprTools]]
+git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.10"
+
+[[deps.Extents]]
+git-tree-sha1 = "b309b36a9e02fe7be71270dd8c0fd873625332b4"
+uuid = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
+version = "0.1.6"
+
+[[deps.FFMPEG_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libva_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "7a58e45171b63ed4782f2d36fdee8713a469e6e0"
+uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
+version = "8.1.2+0"
+
+[[deps.FFTA]]
+deps = ["AbstractFFTs", "DocStringExtensions", "LinearAlgebra", "MuladdMacro", "Primes", "Random", "Reexport"]
+git-tree-sha1 = "65e55303b72f4a567a51b174dd2c47496efeb95a"
+uuid = "b86e33f2-c0db-4aa1-a6e0-ab43e668529e"
+version = "0.3.1"
+
+[[deps.FileIO]]
+deps = ["Pkg", "Requires", "UUIDs"]
+git-tree-sha1 = "6621fef488e496356c9c9625d0562c12a6070819"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.20.0"
+
+    [deps.FileIO.extensions]
+    HTTPExt = "HTTP"
+
+    [deps.FileIO.weakdeps]
+    HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+
+[[deps.FilePaths]]
+deps = ["FilePathsBase", "MacroTools", "Reexport"]
+git-tree-sha1 = "a1b2fbfe98503f15b665ed45b3d149e5d8895e4c"
+uuid = "8fc22ac5-c921-52a6-82fd-178b2807b824"
+version = "0.9.0"
+
+    [deps.FilePaths.extensions]
+    FilePathsGlobExt = "Glob"
+    FilePathsURIParserExt = "URIParser"
+    FilePathsURIsExt = "URIs"
+
+    [deps.FilePaths.weakdeps]
+    Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+    URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+    URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+
+[[deps.FilePathsBase]]
+deps = ["Compat", "Dates"]
+git-tree-sha1 = "3bab2c5aa25e7840a4b065805c0cdfc01f3068d2"
+uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
+version = "0.9.24"
+
+    [deps.FilePathsBase.extensions]
+    FilePathsBaseMmapExt = "Mmap"
+    FilePathsBaseTestExt = "Test"
+
+    [deps.FilePathsBase.weakdeps]
+    Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.FillArrays]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "2f979084d1e13948a3352cf64a25df6bd3b4dca3"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "1.16.0"
+weakdeps = ["PDMats", "SparseArrays", "StaticArrays", "Statistics"]
+
+    [deps.FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStaticArraysExt = "StaticArrays"
+    FillArraysStatisticsExt = "Statistics"
+
+[[deps.FixedPointNumbers]]
+deps = ["Random", "Statistics"]
+git-tree-sha1 = "59af96b98217c6ef4ae0dfe065ac7c20831d1a84"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.8.6"
+
+[[deps.Fontconfig_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Zlib_jll"]
+git-tree-sha1 = "f85dac9a96a01087df6e3a749840015a0ca3817d"
+uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
+version = "2.17.1+0"
+
+[[deps.Format]]
+git-tree-sha1 = "9c68794ef81b08086aeb32eeaf33531668d5f5fc"
+uuid = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+version = "1.3.7"
+
+[[deps.FreeType]]
+deps = ["CEnum", "FreeType2_jll"]
+git-tree-sha1 = "907369da0f8e80728ab49c1c7e09327bf0d6d999"
+uuid = "b38be410-82b0-50bf-ab77-7b57e271db43"
+version = "4.1.1"
+
+[[deps.FreeType2_jll]]
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "70329abc09b886fd2c5d94ad2d9527639c421e3e"
+uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
+version = "2.14.3+1"
+
+[[deps.FreeTypeAbstraction]]
+deps = ["BaseDirs", "ColorVectorSpace", "Colors", "FreeType", "GeometryBasics", "Mmap"]
+git-tree-sha1 = "4ebb930ef4a43817991ba35db6317a05e59abd11"
+uuid = "663a7486-cb36-511b-a19d-713bb74d65c9"
+version = "0.10.8"
+
+[[deps.FriBidi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "7a214fdac5ed5f59a22c2d9a885a16da1c74bbc7"
+uuid = "559328eb-81f9-559d-9380-de523a88c83c"
+version = "1.0.17+0"
+
+[[deps.GLFW]]
+deps = ["GLFW_jll"]
+git-tree-sha1 = "af06f66cca2b698ab9c482de55977ff8178d025e"
+uuid = "f7f18e0c-5ee9-5ccd-a5bf-e8befd85ed98"
+version = "3.4.6"
+
+[[deps.GLFW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll", "libdecor_jll", "xkbcommon_jll"]
+git-tree-sha1 = "9e0fb9e54594c47f278d75063980e43066e26e20"
+uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+version = "3.4.1+1"
+
+[[deps.GPUArrays]]
+deps = ["Adapt", "GPUArraysCore", "KernelAbstractions", "LLVM", "LinearAlgebra", "Printf", "Random", "Reexport", "ScopedValues", "Serialization", "SparseArrays", "Statistics"]
+git-tree-sha1 = "4ea5e2aecfd52e595ff6c343410e32f83f5b9bbf"
+uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+version = "11.5.8"
+
+    [deps.GPUArrays.extensions]
+    JLD2Ext = "JLD2"
+
+    [deps.GPUArrays.weakdeps]
+    JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+
+[[deps.GPUArraysCore]]
+deps = ["Adapt"]
+git-tree-sha1 = "83cf05ab16a73219e5f6bd1bdfa9848fa24ac627"
+uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
+version = "0.2.0"
+
+[[deps.GPUCompiler]]
+deps = ["ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "PrecompileTools", "Preferences", "Scratch", "Serialization", "TOML", "Tracy", "UUIDs"]
+git-tree-sha1 = "21f06bc7874e98849ee7d8b382990903bd7661df"
+uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
+version = "1.13.3"
+
+[[deps.GPUSelect]]
+deps = ["Adapt", "KernelAbstractions", "Libdl", "Pkg", "Preferences", "TOML"]
+git-tree-sha1 = "f9b7961ea147833b3784d6deaf1040dec510143e"
+repo-rev = "main"
+repo-url = "https://github.com/SimonDanisch/GPUSelect.jl"
+uuid = "203851ad-5791-4cf9-9fcc-5933b5611f42"
+version = "0.1.1"
+
+[[deps.Gamma]]
+git-tree-sha1 = "86f86b6168a016ed88e4ae4e64577b98c3b59e8e"
+uuid = "a0844989-3bd2-4988-8bea-c9407ab0941b"
+version = "1.1.0"
+
+[[deps.GeometryBasics]]
+deps = ["EarCut_jll", "Extents", "IterTools", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
+git-tree-sha1 = "1f5a80f4ed9f5a4aada88fc2db456e637676414b"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.5.10"
+
+    [deps.GeometryBasics.extensions]
+    GeometryBasicsGeoInterfaceExt = "GeoInterface"
+
+    [deps.GeometryBasics.weakdeps]
+    GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+
+[[deps.GettextRuntime_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll"]
+git-tree-sha1 = "45288942190db7c5f760f59c04495064eedf9340"
+uuid = "b0724c58-0f36-5564-988d-3bb0596ebc4a"
+version = "0.22.4+0"
+
+[[deps.Giflib_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6570366d757b50fabae9f4315ad74d2e40c0560a"
+uuid = "59f7168a-df46-5410-90c8-f2779963d0ec"
+version = "5.2.3+0"
+
+[[deps.Glib_jll]]
+deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "24f6def62397474a297bfcec22384101609142ed"
+uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
+version = "2.86.3+0"
+
+[[deps.Graphite2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "69ffb934a5c5b7e086a0b4fee3427db2556fba6e"
+uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
+version = "1.3.16+0"
+
+[[deps.GridLayoutBase]]
+deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
+git-tree-sha1 = "93d5c27c8de51687a2c70ec0716e6e76f298416f"
+uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
+version = "0.11.2"
+
+[[deps.Grisu]]
+git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
+uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
+version = "1.0.2"
+
+[[deps.HarfBuzz_jll]]
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
+git-tree-sha1 = "f923f9a774fcf3f5cb761bfa43aeadd689714813"
+uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
+version = "8.5.1+0"
+
+[[deps.HashArrayMappedTries]]
+git-tree-sha1 = "2eaa69a7cab70a52b9687c8bf950a5a93ec895ae"
+uuid = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"
+version = "0.2.0"
+
+[[deps.Hikari]]
+deps = ["Adapt", "Atomix", "FileIO", "GPUArraysCore", "GeometryBasics", "ImageCore", "ImageIO", "KernelAbstractions", "Lava", "LinearAlgebra", "ProgressMeter", "Random", "RandomNumbers", "Raycore", "StaticArrays", "StructArrays", "Zlib_jll"]
+git-tree-sha1 = "5cd243bb3674e5514200691bbc0cd5806f97ff80"
+repo-rev = "sd/vk-hw-accel"
+repo-url = "https://github.com/JuliaGraphics/Hikari.jl"
+uuid = "afc56b53-c9a9-482a-a956-d1d800e05558"
+version = "0.1.0"
+
+[[deps.HypergeometricFunctions]]
+deps = ["Gamma", "LinearAlgebra"]
+git-tree-sha1 = "18d7deab5fb0440dc6a7b6993c5c27b25420de10"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.29"
+
+[[deps.ImageAxes]]
+deps = ["AxisArrays", "ImageBase", "ImageCore", "Reexport", "SimpleTraits"]
+git-tree-sha1 = "e12629406c6c4442539436581041d372d69c55ba"
+uuid = "2803e5a7-5153-5ecf-9a86-9b4c37f5f5ac"
+version = "0.6.12"
+
+[[deps.ImageBase]]
+deps = ["ImageCore", "Reexport"]
+git-tree-sha1 = "eb49b82c172811fd2c86759fa0553a2221feb909"
+uuid = "c817782e-172a-44cc-b673-b171935fbb9e"
+version = "0.1.7"
+
+[[deps.ImageCore]]
+deps = ["ColorVectorSpace", "Colors", "FixedPointNumbers", "MappedArrays", "MosaicViews", "OffsetArrays", "PaddedViews", "PrecompileTools", "Reexport"]
+git-tree-sha1 = "8c193230235bbcee22c8066b0374f63b5683c2d3"
+uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+version = "0.10.5"
+
+[[deps.ImageIO]]
+deps = ["FileIO", "IndirectArrays", "JpegTurbo", "LazyModules", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs", "WebP"]
+git-tree-sha1 = "696144904b76e1ca433b886b4e7edd067d76cbf7"
+uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
+version = "0.6.9"
+
+[[deps.ImageMetadata]]
+deps = ["AxisArrays", "ImageAxes", "ImageBase", "ImageCore"]
+git-tree-sha1 = "2a81c3897be6fbcde0802a0ebe6796d0562f63ec"
+uuid = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
+version = "0.9.10"
+
+[[deps.Imath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "dcc8d0cd653e55213df9b75ebc6fe4a8d3254c65"
+uuid = "905a6f67-0a94-5f89-b386-d35d92009cd1"
+version = "3.2.2+0"
+
+[[deps.IndirectArrays]]
+git-tree-sha1 = "012e604e1c7458645cb8b436f8fba789a51b257f"
+uuid = "9b13fd28-a010-5f03-acff-a1bbcff69959"
+version = "1.0.0"
+
+[[deps.Inflate]]
+git-tree-sha1 = "d1b1b796e47d94588b3757fe84fbf65a5ec4a80d"
+uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
+version = "0.1.5"
+
+[[deps.IntegerMathUtils]]
+git-tree-sha1 = "4c1acff2dc6b6967e7e750633c50bc3b8d83e617"
+uuid = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
+version = "0.1.3"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.Interpolations]]
+deps = ["Adapt", "AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
+git-tree-sha1 = "48922d06068130f87e43edef52382e6a94305ae6"
+uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+version = "0.16.3"
+
+    [deps.Interpolations.extensions]
+    InterpolationsForwardDiffExt = "ForwardDiff"
+    InterpolationsUnitfulExt = "Unitful"
+
+    [deps.Interpolations.weakdeps]
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.IntervalArithmetic]]
+deps = ["CRlibm", "CoreMath", "MacroTools", "OpenBLASConsistentFPCSR_jll", "Printf", "Random", "RoundingEmulator"]
+git-tree-sha1 = "c3ee408ae340565f41699e3a3fa1053698c7626e"
+uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+version = "1.0.10"
+
+    [deps.IntervalArithmetic.extensions]
+    IntervalArithmeticArblibExt = "Arblib"
+    IntervalArithmeticDiffRulesExt = "DiffRules"
+    IntervalArithmeticForwardDiffExt = "ForwardDiff"
+    IntervalArithmeticIntervalSetsExt = "IntervalSets"
+    IntervalArithmeticIrrationalConstantsExt = "IrrationalConstants"
+    IntervalArithmeticLinearAlgebraExt = "LinearAlgebra"
+    IntervalArithmeticRecipesBaseExt = "RecipesBase"
+    IntervalArithmeticSparseArraysExt = "SparseArrays"
+
+    [deps.IntervalArithmetic.weakdeps]
+    Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
+    DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.IntervalSets]]
+git-tree-sha1 = "79d6bd28c8d9bccc2229784f1bd637689b256377"
+uuid = "8197267c-284f-5f27-9208-e0e47529a953"
+version = "0.7.14"
+
+    [deps.IntervalSets.extensions]
+    IntervalSetsRandomExt = "Random"
+    IntervalSetsRecipesBaseExt = "RecipesBase"
+    IntervalSetsStatisticsExt = "Statistics"
+
+    [deps.IntervalSets.weakdeps]
+    Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.InverseFunctions]]
+git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.17"
+
+    [deps.InverseFunctions.extensions]
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
+
+    [deps.InverseFunctions.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.Isoband]]
+deps = ["isoband_jll"]
+git-tree-sha1 = "f9b6d97355599074dc867318950adaa6f9946137"
+uuid = "f1662d9f-8043-43de-a69a-05efc1cc6ff4"
+version = "0.1.1"
+
+[[deps.IterTools]]
+git-tree-sha1 = "42d5f897009e7ff2cf88db414a389e5ed1bdd023"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.10.0"
+
+[[deps.IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "c89d196f5ffb64bfbf80985b699ea913b0d2c211"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.6.1"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[[deps.JpegTurbo]]
+deps = ["CEnum", "FileIO", "ImageCore", "JpegTurbo_jll", "TOML"]
+git-tree-sha1 = "9496de8fb52c224a2e3f9ff403947674517317d9"
+uuid = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
+version = "0.1.6"
+
+[[deps.JpegTurbo_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1dae3057da6f2b9c857afef03177bbdc7c4afe92"
+uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
+version = "3.2.0+0"
+
+[[deps.JuliaSyntax]]
+git-tree-sha1 = "0d4b3dab95018bcf3925204475693d9f09dc45b8"
+uuid = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+version = "1.0.2"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.KernelAbstractions]]
+deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs"]
+git-tree-sha1 = "a5b87110fa95d711355af44832497745aa93fb52"
+uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+version = "0.9.42"
+
+    [deps.KernelAbstractions.extensions]
+    EnzymeExt = "EnzymeCore"
+    LinearAlgebraExt = "LinearAlgebra"
+    SparseArraysExt = "SparseArrays"
+
+    [deps.KernelAbstractions.weakdeps]
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.KernelDensity]]
+deps = ["Distributions", "DocStringExtensions", "FFTA", "Interpolations", "StatsBase"]
+git-tree-sha1 = "9eda8292dd3268b3b7ec9df21bbfac24e177ec52"
+uuid = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
+version = "0.6.12"
+
+[[deps.LAME_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "059aabebaa7c82ccb853dd4a0ee9d17796f7e1bc"
+uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
+version = "3.100.3+0"
+
+[[deps.LERC_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "17b94ecafcfa45e8360a4fc9ca6b583b049e4e37"
+uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
+version = "4.1.0+0"
+
+[[deps.LLVM]]
+deps = ["CEnum", "LLVMExtra_jll", "Libdl", "PrecompileTools", "Preferences", "Printf", "Unicode"]
+git-tree-sha1 = "24af42ea221a14a04283e362d83d2cdcb115cd12"
+uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
+version = "9.10.1"
+
+    [deps.LLVM.extensions]
+    BFloat16sExt = "BFloat16s"
+
+    [deps.LLVM.weakdeps]
+    BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+
+[[deps.LLVMExtra_jll]]
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "70c96f133c78c3cdc06234157144fab3744c6b38"
+uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
+version = "0.0.43+1"
+
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "b7970cef8ae1c990ba0c09cd8bdc1145e006632f"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "22.1.7+0"
+
+[[deps.LaTeXStrings]]
+git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.4.0"
+
+[[deps.Lava]]
+deps = ["AcceleratedKernels", "Adapt", "Atomix", "GLFW", "GPUArrays", "GPUArraysCore", "GPUCompiler", "GeometryBasics", "KernelAbstractions", "LLVM", "LinearAlgebra", "PrecompileTools", "Raycore", "SPIRV_LLVM_Backend_jll", "SPIRV_Tools_jll", "Serialization", "StaticArrays", "UnsafeAtomics", "Vulkan"]
+git-tree-sha1 = "90e16289f3ee6b2645e7921b9b1fe12901615008"
+repo-rev = "sd/nvidia"
+repo-url = "https://github.com/SimonDanisch/Lava.jl"
+uuid = "3a680b1f-cb25-4bee-9cf7-bc880b76dc8c"
+version = "0.1.0"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+[[deps.LazyModules]]
+git-tree-sha1 = "a560dd966b386ac9ae60bdd3a3d3a326062d3c3e"
+uuid = "8cdb02fc-e678-4876-92c5-9defec4f444e"
+version = "0.3.1"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.LibTracyClient_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "d4e20500d210247322901841d4eafc7a0c52642d"
+uuid = "ad6e5548-8b26-5c9f-8ef3-ef0ad883f3a5"
+version = "0.13.1+0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libffi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c8da7e6a91781c41a863611c7e966098d783c57a"
+uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
+version = "3.4.7+0"
+
+[[deps.Libglvnd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll", "Xorg_libXext_jll"]
+git-tree-sha1 = "d36c21b9e7c172a44a10484125024495e2625ac0"
+uuid = "7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+version = "1.7.1+1"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
+[[deps.Libmount_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "cc3ad4faf30015a3e8094c9b5b7f19e85bdf2386"
+uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
+version = "2.42.0+0"
+
+[[deps.Libtiff_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "aebd334d06cee9f24cea70bd19a39749daf73881"
+uuid = "89763e89-9b03-5906-acba-b20f662cd828"
+version = "4.7.3+0"
+
+[[deps.Libuuid_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "d620582b1f0cbe2c72dd1d5bd195a9ce73370ab1"
+uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
+version = "2.42.0+0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.29"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.MLStyle]]
+git-tree-sha1 = "bc38dff0548128765760c79eb7388a4b37fae2c8"
+uuid = "d8e11817-5142-5d16-987a-aa16d5891078"
+version = "0.4.17"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
+
+[[deps.Makie]]
+deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "ComputePipeline", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "InverseFunctions", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "PNGFiles", "Packing", "Pkg", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "ProgressMeter", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
+git-tree-sha1 = "423103a951bfd0e28f8a1cbb1f21b31ad385e772"
+repo-rev = "sd/lava"
+repo-subdir = "Makie"
+repo-url = "https://github.com/MakieOrg/Makie.jl.git"
+uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+version = "0.24.8"
+
+    [deps.Makie.extensions]
+    MakieDynamicQuantitiesExt = "DynamicQuantities"
+
+    [deps.Makie.weakdeps]
+    DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
+
+[[deps.MappedArrays]]
+git-tree-sha1 = "0ee4497a4e80dbd29c058fcee6493f5219556f40"
+uuid = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
+version = "0.4.3"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MathTeXEngine]]
+deps = ["AbstractTrees", "Automa", "DataStructures", "FreeTypeAbstraction", "GeometryBasics", "LaTeXStrings", "REPL", "RelocatableFolders", "UnicodeFun"]
+git-tree-sha1 = "aa1078778be5a8e5259ff04fbc3d258b3e78d464"
+uuid = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
+version = "0.6.9"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.2.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.MosaicViews]]
+deps = ["MappedArrays", "OffsetArrays", "PaddedViews", "StackViews"]
+git-tree-sha1 = "7b86a5d4d70a9f5cdf2dacb3cbe6d251d1a61dbe"
+uuid = "e94cdb99-869f-56ef-bcf0-1ae2bcbe0389"
+version = "0.3.4"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
+
+[[deps.MuladdMacro]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "e8dcbeef032ba2f9051a44ac22b4e54e3a1a0099"
+uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+version = "0.2.6"
+
+[[deps.Netpbm]]
+deps = ["FileIO", "ImageCore", "ImageMetadata"]
+git-tree-sha1 = "d92b107dbb887293622df7697a2223f9f8176fcd"
+uuid = "f09324ee-3d7c-5217-9330-fc30815ba969"
+version = "1.1.1"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.Observables]]
+git-tree-sha1 = "7438a59546cf62428fc9d1bc94729146d37a7225"
+uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
+version = "0.5.5"
+
+[[deps.OffsetArrays]]
+git-tree-sha1 = "117432e406b5c023f665fa73dc26e79ec3630151"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.17.0"
+weakdeps = ["Adapt"]
+
+    [deps.OffsetArrays.extensions]
+    OffsetArraysAdaptExt = "Adapt"
+
+[[deps.Ogg_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "b6aa4566bb7ae78498a5e68943863fa8b5231b59"
+uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
+version = "1.3.6+0"
+
+[[deps.OpenBLASConsistentFPCSR_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "dafdaa3ff15f20ff703d909d3a6f574a5b0586f3"
+uuid = "6cdc7f73-28fd-5e50-80fb-958a8875b1af"
+version = "0.3.33+1"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.OpenEXR]]
+deps = ["Colors", "FileIO", "OpenEXR_jll"]
+git-tree-sha1 = "97db9e07fe2091882c765380ef58ec553074e9c7"
+uuid = "52e1d378-f018-4a11-a4be-720524705ac7"
+version = "0.3.3"
+
+[[deps.OpenEXR_jll]]
+deps = ["Artifacts", "Imath_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "0d621a4beb5e48d195f907c3c5b0bea285d9ff9d"
+uuid = "18a262bb-aa17-5467-a713-aee519bc75cb"
+version = "3.4.13+0"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.7+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.Opus_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e2bb57a313a74b8104064b7efd01406c0a50d2ff"
+uuid = "91d4177d-7536-5919-b921-800302f37372"
+version = "1.6.1+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "94ba93778373a53bfd5a0caaf7d809c445292ff4"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.2"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.44.0+1"
+
+[[deps.PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "26766d4b5f1a410c218a19b85a672c6edb693c65"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.40"
+weakdeps = ["StatsBase"]
+
+    [deps.PDMats.extensions]
+    StatsBaseExt = "StatsBase"
+
+[[deps.PNGFiles]]
+deps = ["Base64", "CEnum", "ImageCore", "IndirectArrays", "OffsetArrays", "libpng_jll"]
+git-tree-sha1 = "32b657a0d57c310a1a172bfc8c8cf68c5e674323"
+uuid = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
+version = "0.4.5"
+
+[[deps.Packing]]
+deps = ["GeometryBasics"]
+git-tree-sha1 = "bc5bf2ea3d5351edf285a06b0016788a121ce92c"
+uuid = "19eb6ba3-879d-56ad-ad62-d5c202156566"
+version = "0.5.1"
+
+[[deps.PaddedViews]]
+deps = ["OffsetArrays"]
+git-tree-sha1 = "0fac6313486baae819364c52b4f483450a9d793f"
+uuid = "5432bcbf-9aad-5242-b902-cca2824c8663"
+version = "0.5.12"
+
+[[deps.Pango_jll]]
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58e5ed5e386e156bd93e86b305ebd21ac63d2d04"
+uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
+version = "1.57.1+0"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.6"
+
+[[deps.Pixman_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
+git-tree-sha1 = "e4a6721aa89e62e5d4217c0b21bd714263779dda"
+uuid = "30392449-352a-5448-841d-b1acce4e97dc"
+version = "0.46.4+0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PkgVersion]]
+deps = ["Pkg"]
+git-tree-sha1 = "f9501cc0430a26bc3d156ae1b5b0c1b47af4d6da"
+uuid = "eebad327-c553-4316-9ea0-9fa01ccd7688"
+version = "0.3.3"
+
+[[deps.PlotUtils]]
+deps = ["ColorSchemes", "Colors", "Dates", "PrecompileTools", "Printf", "Random", "Reexport", "StableRNGs", "Statistics"]
+git-tree-sha1 = "26ca162858917496748aad52bb5d3be4d26a228a"
+uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+version = "1.4.4"
+
+[[deps.PolygonOps]]
+git-tree-sha1 = "77b3d3605fc1cd0b42d95eba87dfcd2bf67d5ff6"
+uuid = "647866c9-e3ac-4575-94e7-e3d426903924"
+version = "0.1.2"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Primes]]
+deps = ["IntegerMathUtils"]
+git-tree-sha1 = "25cdd1d20cd005b52fc12cb6be3f75faaf59bb9b"
+uuid = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
+version = "0.5.7"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.ProgressMeter]]
+deps = ["Distributed", "Printf"]
+git-tree-sha1 = "fbb92c6c56b34e1a2c4c36058f68f332bec840e7"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "1.11.0"
+
+[[deps.PtrArrays]]
+git-tree-sha1 = "4fbbafbc6251b883f4d2705356f3641f3652a7fe"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.4.0"
+
+[[deps.QOI]]
+deps = ["ColorTypes", "FileIO", "FixedPointNumbers"]
+git-tree-sha1 = "472daaa816895cb7aee81658d4e7aec901fa1106"
+uuid = "4b34888f-f399-49d4-9bb3-47ed5cae4e65"
+version = "1.0.2"
+
+[[deps.QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "5e8e8b0ab68215d7a2b14b9921a946fee794749e"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.11.3"
+
+    [deps.QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [deps.QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.RandomNumbers]]
+deps = ["Random"]
+git-tree-sha1 = "c6ec94d2aaba1ab2ff983052cf6a606ca5985902"
+uuid = "e6cf234a-135c-5ec9-84dd-332b85af5143"
+version = "1.6.0"
+
+[[deps.RangeArrays]]
+git-tree-sha1 = "b9039e93773ddcfc828f12aadf7115b4b4d225f5"
+uuid = "b3c3ace0-ae52-54e7-9d0b-2c1406fd6b9d"
+version = "0.3.2"
+
+[[deps.Ratios]]
+deps = ["Requires"]
+git-tree-sha1 = "1342a47bf3260ee108163042310d26f2be5ec90b"
+uuid = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
+version = "0.4.5"
+weakdeps = ["FixedPointNumbers"]
+
+    [deps.Ratios.extensions]
+    RatiosFixedPointNumbersExt = "FixedPointNumbers"
+
+[[deps.RayMakie]]
+deps = ["AcceleratedKernels", "Adapt", "Colors", "GLFW", "GeometryBasics", "Hikari", "ImageCore", "KernelAbstractions", "Lava", "LinearAlgebra", "Makie", "Raycore", "StaticArrays"]
+git-tree-sha1 = "ae982f9def563d8c617d551d401a112d2105607e"
+repo-rev = "sd/lava"
+repo-subdir = "RayMakie"
+repo-url = "https://github.com/MakieOrg/Makie.jl.git"
+uuid = "70852e3a-d594-4041-8350-783a02753e02"
+version = "1.0.0-DEV"
+
+[[deps.Raycore]]
+deps = ["AcceleratedKernels", "Adapt", "Atomix", "GPUArraysCore", "GeometryBasics", "KernelAbstractions", "LinearAlgebra", "Random", "StaticArrays", "Statistics"]
+git-tree-sha1 = "5fd0a102adc681faa3e73e1c618a881af29bb366"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaGeometry/Raycore.jl"
+uuid = "afc56b53-c9a9-482a-a956-d1d800e05559"
+version = "0.2.0"
+weakdeps = ["Makie"]
+
+    [deps.Raycore.extensions]
+    RaycoreMakieExt = "Makie"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.RelocatableFolders]]
+deps = ["SHA", "Scratch"]
+git-tree-sha1 = "ffdaf70d81cf6ff22c2b6e733c900c3321cab864"
+uuid = "05181044-ff0b-4ac5-8273-598c1e38db00"
+version = "1.0.1"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.1"
+
+[[deps.ResultTypes]]
+deps = ["JuliaSyntax"]
+git-tree-sha1 = "d5343c5511ad148434a5d0f9f055d1ce0b6104ba"
+uuid = "08a2b407-ddc3-586a-afd6-c784ad1fffe2"
+version = "4.0.2"
+
+[[deps.Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "5b3d50eb374cea306873b371d3f8d3915a018f0b"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.9.0"
+
+[[deps.Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.5.1+0"
+
+[[deps.Roots]]
+deps = ["Accessors", "CommonSolve", "Printf"]
+git-tree-sha1 = "7fb25a964849d90a0446366cdefca822e0e84900"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "3.0.6"
+
+    [deps.Roots.extensions]
+    RootsChainRulesCoreExt = "ChainRulesCore"
+    RootsForwardDiffExt = "ForwardDiff"
+    RootsIntervalRootFindingExt = "IntervalRootFinding"
+    RootsSymPyExt = "SymPy"
+    RootsSymPyPythonCallExt = "SymPyPythonCall"
+    RootsUnitfulExt = "Unitful"
+
+    [deps.Roots.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+    SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
+    SymPyPythonCall = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.RoundingEmulator]]
+git-tree-sha1 = "40b9edad2e5287e05bd413a38f61a8ff55b9557b"
+uuid = "5eaf0fd0-dfba-4ccb-bf02-d820a40db705"
+version = "0.2.1"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.SIMD]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "e24dc23107d426a096d3eae6c165b921e74c18e4"
+uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
+version = "3.7.2"
+
+[[deps.SPIRV_LLVM_Backend_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "1bd51b6f5cc8696556a4db2162e1c83e2144330a"
+uuid = "4376b9bf-cff8-51b6-bb48-39421dff0d0c"
+version = "21.1.4+0"
+
+[[deps.SPIRV_Tools_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "783c358eff59056d7e703a644f5179270c43226a"
+uuid = "6ac6d60f-d740-5983-97d7-a4482c0689f4"
+version = "2025.4.0+0"
+
+[[deps.ScopedValues]]
+deps = ["HashArrayMappedTries", "Logging"]
+git-tree-sha1 = "67a144433c4ce877ee6d1ada69a124d6b1ecf7be"
+uuid = "7e506255-f358-4e82-b7e4-beb19740aa63"
+version = "1.6.2"
+
+[[deps.Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "9b81b8393e50b7d4e6d0a9f14e192294d3b7c109"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.3.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.ShaderAbstractions]]
+deps = ["ColorTypes", "FixedPointNumbers", "GeometryBasics", "LinearAlgebra", "Observables", "StaticArrays"]
+git-tree-sha1 = "818554664a2e01fc3784becb2eb3a82326a604b6"
+uuid = "65257c39-d410-5151-9873-9b3e5be5013e"
+version = "0.5.0"
+
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+version = "1.11.0"
+
+[[deps.Showoff]]
+deps = ["Dates", "Grisu"]
+git-tree-sha1 = "91eddf657aca81df9ae6ceb20b959ae5653ad1de"
+uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
+version = "1.0.3"
+
+[[deps.SignedDistanceFields]]
+deps = ["Statistics"]
+git-tree-sha1 = "3949ad92e1c9d2ff0cd4a1317d5ecbba682f4b92"
+uuid = "73760f76-fbc4-59ce-8f25-708e95d2df96"
+version = "0.4.1"
+
+[[deps.SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "7ddb0b49c109481b046972c0e4ab02b2127d6a75"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.6"
+
+[[deps.Sixel]]
+deps = ["Dates", "FileIO", "ImageCore", "IndirectArrays", "OffsetArrays", "REPL", "libsixel_jll"]
+git-tree-sha1 = "0494aed9501e7fb65daba895fb7fd57cc38bc743"
+uuid = "45858cf5-a6b0-47a3-bbea-62219f50df47"
+version = "0.1.5"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "13cd91cc9be159e3f4d95b857fa2aa383b53772a"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.2.3"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.8.0"
+weakdeps = ["ChainRulesCore"]
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+[[deps.StableRNGs]]
+deps = ["Random"]
+git-tree-sha1 = "4f96c596b8c8258cc7d3b19797854d368f243ddc"
+uuid = "860ef19b-820b-49d6-a774-d7a799459cd3"
+version = "1.0.4"
+
+[[deps.StackViews]]
+deps = ["OffsetArrays"]
+git-tree-sha1 = "be1cf4eb0ac528d96f5115b4ed80c26a8d8ae621"
+uuid = "cae243ae-269e-4f55-b966-ac2d0dc13c15"
+version = "0.1.2"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.9.18"
+weakdeps = ["ChainRulesCore", "Statistics"]
+
+    [deps.StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "178ed29fd5b2a2cfc3bd31c13375ae925623ff36"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.8.0"
+
+[[deps.StatsBase]]
+deps = ["AliasTables", "DataAPI", "DataStructures", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "e4d7a1a0edc20af42689ea6f4f3587a2175d50ee"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.34.12"
+
+[[deps.StatsFuns]]
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "91f091a8716a6bb38417a6e6f274602a19aaa685"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "1.5.2"
+weakdeps = ["ChainRulesCore", "InverseFunctions"]
+
+    [deps.StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+[[deps.StructArrays]]
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "9537ef82c42cdd8c5d443cbc359110cbb36bae10"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.6.21"
+weakdeps = ["Adapt", "GPUArraysCore", "KernelAbstractions", "LinearAlgebra", "SparseArrays", "StaticArrays"]
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = ["GPUArraysCore", "KernelAbstractions"]
+    StructArraysLinearAlgebraExt = "LinearAlgebra"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
+
+[[deps.StructEquality]]
+deps = ["Compat"]
+git-tree-sha1 = "192a9f1de3cfef80ab1a4ba7b150bb0e11ceedcf"
+uuid = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"
+version = "2.1.0"
+
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[deps.Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
+git-tree-sha1 = "0f38a06c83f0007bbab3cf911262841c9a0f07e0"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.13.0"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.TensorCore]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "1feb45f88d133a655e001435632f019a9a1bcdb6"
+uuid = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
+version = "0.1.1"
+
+[[deps.TiffImages]]
+deps = ["CodecZstd", "ColorTypes", "DataStructures", "DocStringExtensions", "FileIO", "FixedPointNumbers", "IndirectArrays", "Inflate", "Mmap", "OffsetArrays", "PkgVersion", "PrecompileTools", "ProgressMeter", "SIMD", "UUIDs"]
+git-tree-sha1 = "9ca5f1f2d42f80df4b8c9f6ab5a64f438bbd9976"
+uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
+version = "0.11.9"
+
+[[deps.Tracy]]
+deps = ["ExprTools", "LibTracyClient_jll", "Libdl"]
+git-tree-sha1 = "73e3ff50fd3990874c59fef0f35d10644a1487bc"
+uuid = "e689c965-62c8-4b79-b2c5-8359227902fd"
+version = "0.1.6"
+
+    [deps.Tracy.extensions]
+    TracyProfilerExt = "TracyProfiler_jll"
+
+    [deps.Tracy.weakdeps]
+    TracyProfiler_jll = "0c351ed6-8a68-550e-8b79-de6f926da83c"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.TriplotBase]]
+git-tree-sha1 = "4d4ed7f294cda19382ff7de4c137d24d16adc89b"
+uuid = "981d1d27-644d-49a2-9326-4793e63143c3"
+version = "0.1.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.UnicodeFun]]
+deps = ["REPL"]
+git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
+uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
+version = "0.4.1"
+
+[[deps.Unitful]]
+deps = ["Dates", "LinearAlgebra", "Random"]
+git-tree-sha1 = "57e1b2c9de4bd6f40ecb9de4ac1797b81970d008"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.28.0"
+
+    [deps.Unitful.extensions]
+    ConstructionBaseUnitfulExt = "ConstructionBase"
+    ForwardDiffExt = "ForwardDiff"
+    InverseFunctionsUnitfulExt = "InverseFunctions"
+    LatexifyExt = ["Latexify", "LaTeXStrings"]
+    NaNMathExt = "NaNMath"
+    PrintfExt = "Printf"
+
+    [deps.Unitful.weakdeps]
+    ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+    LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+    Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+    NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+    Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.UnsafeAtomics]]
+git-tree-sha1 = "0f30765c32d66d58e41f4cb5624d4fc8a82ec13b"
+uuid = "013be700-e6cd-48c3-b4a1-df204f14c38f"
+version = "0.3.1"
+weakdeps = ["LLVM"]
+
+    [deps.UnsafeAtomics.extensions]
+    UnsafeAtomicsLLVM = ["LLVM"]
+
+[[deps.Vulkan]]
+deps = ["Accessors", "BitMasks", "DocStringExtensions", "Libdl", "Logging", "MLStyle", "PrecompileTools", "Preferences", "Reexport", "ResultTypes", "StructEquality", "VulkanCore"]
+git-tree-sha1 = "7c427c83e9f9656748df09954db68a4c9867ff10"
+uuid = "9f14b124-c50e-4008-a7d4-969b3a6cd68a"
+version = "0.6.30"
+
+    [deps.Vulkan.extensions]
+    VulkanColorTypesExt = "ColorTypes"
+    VulkanFixedPointNumbersColorTypesExt = ["ColorTypes", "FixedPointNumbers"]
+    VulkanFixedPointNumbersExt = "FixedPointNumbers"
+    VulkanFixedPointNumbersStaticArraysCoreExt = ["FixedPointNumbers", "StaticArraysCore"]
+    VulkanStaticArraysCoreExt = "StaticArraysCore"
+    VulkanXCBExt = "XCB"
+
+    [deps.Vulkan.weakdeps]
+    ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+    FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    XCB = "16167f82-ea26-5cba-b1de-ed6fd5e30a10"
+
+[[deps.VulkanCore]]
+deps = ["Libdl", "Vulkan_Headers_jll"]
+git-tree-sha1 = "12c41714a3b71816d4b46b57a24f807b944f0a31"
+uuid = "16167f82-ea26-5cba-b1de-ed6fd5e30a11"
+version = "1.3.1"
+
+[[deps.Vulkan_Headers_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a2bfa46393bce7f450ee949273f2ba310d889693"
+uuid = "8d446b21-f3ad-5576-a034-752265b9b6f9"
+version = "1.4.321+0"
+
+[[deps.Wayland_jll]]
+deps = ["Artifacts", "EpollShim_jll", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
+git-tree-sha1 = "96478df35bbc2f3e1e791bc7a3d0eeee559e60e9"
+uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
+version = "1.24.0+0"
+
+[[deps.WebP]]
+deps = ["CEnum", "ColorTypes", "FileIO", "FixedPointNumbers", "ImageCore", "libwebp_jll"]
+git-tree-sha1 = "aa1ca3c47f119fbdae8770c29820e5e6119b83f2"
+uuid = "e3aaa7dc-3e4b-44e0-be63-ffb868ccd7c1"
+version = "0.1.3"
+
+[[deps.WoodburyMatrices]]
+deps = ["LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "248a7031b3da79a127f14e5dc5f417e26f9f6db7"
+uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
+version = "1.1.0"
+
+[[deps.XZ_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "b29c22e245d092b8b4e8d3c09ad7baa586d9f573"
+uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
+version = "5.8.3+0"
+
+[[deps.Xorg_libX11_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
+git-tree-sha1 = "808090ede1d41644447dd5cbafced4731c56bd2f"
+uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
+version = "1.8.13+0"
+
+[[deps.Xorg_libXau_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "aa1261ebbac3ccc8d16558ae6799524c450ed16b"
+uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
+version = "1.0.13+0"
+
+[[deps.Xorg_libXcursor_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXfixes_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "6c74ca84bbabc18c4547014765d194ff0b4dc9da"
+uuid = "935fb764-8cf2-53bf-bb30-45bb1f8bf724"
+version = "1.2.4+0"
+
+[[deps.Xorg_libXdmcp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "52858d64353db33a56e13c341d7bf44cd0d7b309"
+uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
+version = "1.1.6+0"
+
+[[deps.Xorg_libXext_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "1a4a26870bf1e5d26cd585e38038d399d7e65706"
+uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
+version = "1.3.8+0"
+
+[[deps.Xorg_libXfixes_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "75e00946e43621e09d431d9b95818ee751e6b2ef"
+uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
+version = "6.0.2+0"
+
+[[deps.Xorg_libXi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
+git-tree-sha1 = "a376af5c7ae60d29825164db40787f15c80c7c54"
+uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
+version = "1.8.3+0"
+
+[[deps.Xorg_libXinerama_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll"]
+git-tree-sha1 = "0ba01bc7396896a4ace8aab67db31403c71628f4"
+uuid = "d1454406-59df-5ea1-beac-c340f2130bc3"
+version = "1.1.7+0"
+
+[[deps.Xorg_libXrandr_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "6c174ef70c96c76f4c3f4d3cfbe09d018bcd1b53"
+uuid = "ec84b674-ba8e-5d96-8ba1-2a689ba10484"
+version = "1.5.6+0"
+
+[[deps.Xorg_libXrender_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "7ed9347888fac59a618302ee38216dd0379c480d"
+uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
+version = "0.9.12+0"
+
+[[deps.Xorg_libpciaccess_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "58972370b81423fc546c56a60ed1a009450177c3"
+uuid = "a65dc6b1-eb27-53a1-bb3e-dea574b5389e"
+version = "0.19.0+0"
+
+[[deps.Xorg_libxcb_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXau_jll", "Xorg_libXdmcp_jll"]
+git-tree-sha1 = "bfcaf7ec088eaba362093393fe11aa141fa15422"
+uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
+version = "1.17.1+0"
+
+[[deps.Xorg_libxkbfile_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "ed756a03e95fff88d8f738ebc2849431bdd4fd1a"
+uuid = "cc61e674-0454-545c-8b26-ed2c68acab7a"
+version = "1.2.0+0"
+
+[[deps.Xorg_xkbcomp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxkbfile_jll"]
+git-tree-sha1 = "801a858fc9fb90c11ffddee1801bb06a738bda9b"
+uuid = "35661453-b289-5fab-8a00-3d9160c6a3a4"
+version = "1.4.7+0"
+
+[[deps.Xorg_xkeyboard_config_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_xkbcomp_jll"]
+git-tree-sha1 = "2e59214e017a55cb87474a00fa76035c82ac0e17"
+uuid = "33bec58e-1273-512f-9401-5d533626f822"
+version = "2.47.0+2"
+
+[[deps.Xorg_xtrans_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a63799ff68005991f9d9491b6e95bd3478d783cb"
+uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
+version = "1.6.0+0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.Zstd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "446b23e73536f84e8037f5dce465e92275f6a308"
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.7+1"
+
+[[deps.isoband_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "51b5eeb3f98367157a7a12a1fb0aa5328946c03c"
+uuid = "9a68df92-36a6-505f-a73e-abb412b6bfb4"
+version = "0.2.3+0"
+
+[[deps.libaom_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "850b06095ee71f0135d644ffd8a52850699581ed"
+uuid = "a4ae2306-e953-59d6-aa16-d00cac43593b"
+version = "3.13.3+0"
+
+[[deps.libass_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "125eedcb0a4a0bba65b657251ce1d27c8714e9d6"
+uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
+version = "0.17.4+0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"
+
+[[deps.libdecor_jll]]
+deps = ["Artifacts", "Dbus_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pango_jll", "Wayland_jll", "xkbcommon_jll"]
+git-tree-sha1 = "9bf7903af251d2050b467f76bdbe57ce541f7f4f"
+uuid = "1183f4f0-6f2a-5f1a-908b-139f9cdfea6f"
+version = "0.2.2+0"
+
+[[deps.libdrm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "63aac0bcb0b582e11bad965cef4a689905456c03"
+uuid = "8e53e030-5e6c-5a89-a30b-be5b7263a166"
+version = "2.4.125+1"
+
+[[deps.libfdk_aac_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "646634dd19587a56ee2f1199563ec056c5f228df"
+uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
+version = "2.0.4+0"
+
+[[deps.libpng_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "e51150d5ab85cee6fc36726850f0e627ad2e4aba"
+uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
+version = "1.6.58+0"
+
+[[deps.libsixel_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "libpng_jll"]
+git-tree-sha1 = "c1733e347283df07689d71d61e14be986e49e47a"
+uuid = "075b6546-f08a-558a-be8f-8157d0f608a5"
+version = "1.10.5+0"
+
+[[deps.libva_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll", "Xorg_libXext_jll", "Xorg_libXfixes_jll", "libdrm_jll"]
+git-tree-sha1 = "7dbf96baae3310fe2fa0df0ccbb3c6288d5816c9"
+uuid = "9a156e7d-b971-5f62-b2c9-67348b8fb97c"
+version = "2.23.0+0"
+
+[[deps.libvorbis_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll"]
+git-tree-sha1 = "11e1772e7f3cc987e9d3de991dd4f6b2602663a5"
+uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
+version = "1.3.8+0"
+
+[[deps.libwebp_jll]]
+deps = ["Artifacts", "Giflib_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libglvnd_jll", "Libtiff_jll", "libpng_jll"]
+git-tree-sha1 = "4e4282c4d846e11dce56d74fa8040130b7a95cb3"
+uuid = "c5f90fcd-3b7e-5836-afba-fc50a0988cb2"
+version = "1.6.0+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"
+
+[[deps.x264_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "14cc7083fc6dff3cc44f2bc435ee96d06ed79aa7"
+uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
+version = "10164.0.1+0"
+
+[[deps.x265_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e7b67590c14d487e734dcb925924c5dc43ec85f3"
+uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
+version = "4.1.0+0"
+
+[[deps.xkbcommon_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]
+git-tree-sha1 = "a1fc6507a40bf504527d0d4067d718f8e179b2b8"
+uuid = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+version = "1.13.0+0"

--- a/animation/raymakie/NOTES.md
+++ b/animation/raymakie/NOTES.md
@@ -1,0 +1,90 @@
+# RayMakie/Hikari vs RPRMakie/HybridPro — experiment notes
+
+Evaluating `../RayDemo`'s stack (Makie `sd/lava`, Hikari `sd/vk-hw-accel`,
+Lava `sd/nvidia` — Julia-native spectral path tracing over Vulkan) as a
+replacement for the RPRMakie/HybridPro production pipeline
+(`animation/thomson_rpr.jl` + `render_production.sh`).
+
+## Bring-up (W7900, headless)
+
+- GLFW.jl **hardcodes X11 on Linux**; with no X session everything fails at
+  precompile. Recipe: `kwin_wayland --virtual --no-global-shortcuts
+  --socket=wayland-edm &` then `WAYLAND_DISPLAY=wayland-edm
+  JULIA_GLFW_PLATFORM=wayland` (no sudo needed). xkbcommon Compose errors in
+  logs are harmless.
+- Lava sees the W7900 via RADV, `rt_pipeline_properties` present (HW RT
+  available). RayDemo Materials demo: **1.45 s warm** at 600×450×8 spp
+  (~220 s one-time kernel compile per process).
+- **Env split forced**: Hikari pins StructArrays 0.6; SciMLBase 3 needs
+  RecursiveArrayTools 4 → StructArrays 0.7. Physics (setup.jl, MTK + Vern9)
+  cannot share an env with the ray stack. Solution:
+  `precompute_frames.jl` (animation env) → plain-array payloads →
+  `thomson_ray.jl` (this env). Payloads: 13–81 MB/frame, 0.5–9 s/frame to
+  produce.
+
+## First light (3 stills, 1280×960, 64 spp, SW BVH)
+
+Look is close to the RPR reference out of the box — same composition,
+tile room + grid, gold electrons, gold/violet stripes, striped screen.
+Grading differences (walls darker at ambient 1.0/aces; laser ribbons more
+prominent) are lookdev-level. Images: `ray_t-5.00.png`, `ray_t+3.00.png`,
+`ray_t+26.00.png` vs `animation/rpr_frames_v3/rpr_{0071,0151,0380}.png`.
+
+## Performance findings (640×480, 32 spp, flash frame t=+3)
+
+| measurement | mesh style | volume style |
+|---|---|---|
+| `build_scene` | 7.6 s | 0.8 s |
+| first `colorbuffer` (upload + BLAS + trace) | 209 s | 34 s |
+| steady-state `colorbuffer` (nothing changed) | **0.5 s** | **0.6 s** |
+| `colorbuffer` after observable update | **2282 s** (!) | **2.5 s** |
+
+- Tracing itself is *fast* — the scene steady-states at half a second.
+- Mesh style is dominated by SW-BVH build over the ~1.6 M-triangle stripe
+  stacks (209 s), and RayMakie's **observable mesh-swap path is
+  pathological** (2282 s — worse than a full rebuild; this is what the
+  "39-minute frame" actually was). Interface model and path depth are
+  secondary (glass sweep: dielectric d16 175 s → thin/interface d8 ~103 s,
+  all dominated by the same floor).
+- **HW RT `DEVICE_LOST`s** (`rt_indirect`) on the mesh-style scene; fine on
+  the small Materials demo. Untested against the volume-style scene (few
+  triangles) — TODO.
+- Volume style (radiation + pulse as emissive `RGBGridMedium`, the thing RPR
+  cannot do at all): per-frame grid re-upload costs ~2.5 s at test res.
+  First mapping attempt (σ_a = |s| everywhere) rendered as an optically
+  thick fog block — needs a floor cut so only wavefront crests participate
+  (fixed; sweep over floor/sigma/Le in `sweep_volume.jl`).
+
+## Cost model for a 400-frame production render (preliminary)
+
+- RPR HybridPro reference: ~10–15 s/frame + 1.7 GB/frame leak → chunked
+  16-frame processes, two passes (`render_production.sh`).
+- RayMakie mesh style: not viable (≥209 s/frame via rebuild; observable path
+  worse).
+- RayMakie volume style: build once + ~2.5 s/frame updates at test res
+  (full-res × spp scaling TBD) in ONE process — no leak, no chunking.
+  Electron meshscatter updates are cheap (included in the 2.5 s).
+
+## Upstream findings (candidates for issues on Hikari/RayMakie)
+
+1. **`RGBGridMedium(σ_s_grid = nothing)` renders as uniform fog** filling the
+   whole bounding box, drowning the actual grid contents. An explicit
+   zero-valued σ_s grid restores correct emission-only behavior.
+   Minimal reproducer: `mwe_medium.jl` (emitting ball in a box — fog block
+   without the zero grid, clean glowing ball with it).
+2. **A Dielectric volume boundary shadows the box** — shadow rays treat the
+   cube as opaque (documented in RayMakie `plots/volume.jl`); use
+   `MediumInterface(NullMaterial(); inside=medium)`.
+3. **Observable mesh swap is ~10× slower than a full scene rebuild**
+   (2282 s vs 209 s for the same 1.6 M-triangle content, SW BVH) — looks like
+   each updated plot triggers its own full accel rebuild.
+4. **HW RT (`hw_accel=true`) DEVICE_LOSTs** (`rt_indirect`) on the
+   ~1.6 M-triangle mesh scene; fine on the small Materials demo.
+
+## Open items
+
+- [ ] Volume-mode look sweep (floor/sigma/le) → pick production mapping
+- [ ] Full-res volume-mode still + timing
+- [ ] HW RT retry on volume-style scene
+- [ ] Short animation clip (scene reuse) + VRAM stability
+- [ ] Grading pass (ambient/softbox/exposure) to match the locked RPR look

--- a/animation/raymakie/NOTES.md
+++ b/animation/raymakie/NOTES.md
@@ -1,90 +1,96 @@
-# RayMakie/Hikari vs RPRMakie/HybridPro — experiment notes
+# RayMakie/Hikari vs RPRMakie/HybridPro — experiment notes & verdict
 
 Evaluating `../RayDemo`'s stack (Makie `sd/lava`, Hikari `sd/vk-hw-accel`,
 Lava `sd/nvidia` — Julia-native spectral path tracing over Vulkan) as a
 replacement for the RPRMakie/HybridPro production pipeline
 (`animation/thomson_rpr.jl` + `render_production.sh`).
 
-## Bring-up (W7900, headless)
+## Verdict: adopt for the volume look — with a lookdev pass first
 
-- GLFW.jl **hardcodes X11 on Linux**; with no X session everything fails at
-  precompile. Recipe: `kwin_wayland --virtual --no-global-shortcuts
-  --socket=wayland-edm &` then `WAYLAND_DISPLAY=wayland-edm
-  JULIA_GLFW_PLATFORM=wayland` (no sudo needed). xkbcommon Compose errors in
-  logs are harmless.
-- Lava sees the W7900 via RADV, `rt_pipeline_properties` present (HW RT
-  available). RayDemo Materials demo: **1.45 s warm** at 600×450×8 spp
-  (~220 s one-time kernel compile per process).
-- **Env split forced**: Hikari pins StructArrays 0.6; SciMLBase 3 needs
-  RecursiveArrayTools 4 → StructArrays 0.7. Physics (setup.jl, MTK + Vern9)
-  cannot share an env with the ray stack. Solution:
-  `precompute_frames.jl` (animation env) → plain-array payloads →
-  `thomson_ray.jl` (this env). Payloads: 13–81 MB/frame, 0.5–9 s/frame to
-  produce.
+**RayMakie volume mode renders the animation at 3.5 s/frame in one process —
+3–4× faster than RPR HybridPro (10–15 s/frame), with no VRAM-leak chunking,
+no manual tonemap, and a genuinely volumetric look RPR cannot produce at
+all.** The mesh (striped-glass) look, however, is currently blocked by
+upstream performance bugs, so an exact like-for-like port of the locked RPR
+style is not viable today. Recommended path: keep `rpr_frames_v3` as the
+shipped mesh-style render, develop the next animation (and the planned
+inverse-scattering one) on RayMakie volume mode after a proper lookdev
+session, and file the upstream issues below.
 
-## First light (3 stills, 1280×960, 64 spp, SW BVH)
+## Measured numbers (W7900, RADV; 1280×960 unless noted)
 
-Look is close to the RPR reference out of the box — same composition,
-tile room + grid, gold electrons, gold/violet stripes, striped screen.
-Grading differences (walls darker at ambient 1.0/aces; laser ribbons more
-prominent) are lookdev-level. Images: `ray_t-5.00.png`, `ray_t+3.00.png`,
-`ray_t+26.00.png` vs `animation/rpr_frames_v3/rpr_{0071,0151,0380}.png`.
-
-## Performance findings (640×480, 32 spp, flash frame t=+3)
-
-| measurement | mesh style | volume style |
+| configuration | per frame | notes |
 |---|---|---|
-| `build_scene` | 7.6 s | 0.8 s |
-| first `colorbuffer` (upload + BLAS + trace) | 209 s | 34 s |
-| steady-state `colorbuffer` (nothing changed) | **0.5 s** | **0.6 s** |
-| `colorbuffer` after observable update | **2282 s** (!) | **2.5 s** |
+| RPR HybridPro production (700 iter, ultra) | 10–15 s | + 1.7 GB/frame leak → 16-frame chunks, 2 passes |
+| RayMakie **volume style, SW BVH, 64 spp** | **3.5 s** | 61-frame clip, single process, scene reuse |
+| RayMakie volume style, HW RT, 64 spp | 6.3 s | works (small BLAS), but slower — volume cost dominates |
+| RayMakie mesh style, fresh scene | 209 s | SW BLAS build over ~1.6 M stripe triangles |
+| RayMakie mesh style, observable mesh swap | 2282 s | pathological upstream path (see issues) |
+| RayMakie mesh style, steady state (nothing changed) | 0.5 s (640×480×32) | tracing itself is fast |
+| physics payloads (`precompute_frames.jl`, animation env) | 0.3 s/frame (volume) / ~6–9 s (mesh+volume stills) | CPU, runs in parallel with the GPU |
 
-- Tracing itself is *fast* — the scene steady-states at half a second.
-- Mesh style is dominated by SW-BVH build over the ~1.6 M-triangle stripe
-  stacks (209 s), and RayMakie's **observable mesh-swap path is
-  pathological** (2282 s — worse than a full rebuild; this is what the
-  "39-minute frame" actually was). Interface model and path depth are
-  secondary (glass sweep: dielectric d16 175 s → thin/interface d8 ~103 s,
-  all dominated by the same floor).
-- **HW RT `DEVICE_LOST`s** (`rt_indirect`) on the mesh-style scene; fine on
-  the small Materials demo. Untested against the volume-style scene (few
-  triangles) — TODO.
-- Volume style (radiation + pulse as emissive `RGBGridMedium`, the thing RPR
-  cannot do at all): per-frame grid re-upload costs ~2.5 s at test res.
-  First mapping attempt (σ_a = |s| everywhere) rendered as an optically
-  thick fog block — needs a floor cut so only wavefront crests participate
-  (fixed; sweep over floor/sigma/Le in `sweep_volume.jl`).
+One-time costs per render process: ~100 s kernel compile (SW) / ~120 s (HW).
+Clip evidence: `thomson_ray_clip.mp4` (frames 120–180, t = 0→6 T0, flash).
 
-## Cost model for a 400-frame production render (preliminary)
+## What worked well
 
-- RPR HybridPro reference: ~10–15 s/frame + 1.7 GB/frame leak → chunked
-  16-frame processes, two passes (`render_production.sh`).
-- RayMakie mesh style: not viable (≥209 s/frame via rebuild; observable path
-  worse).
-- RayMakie volume style: build once + ~2.5 s/frame updates at test res
-  (full-res × spp scaling TBD) in ONE process — no leak, no chunking.
-  Electron meshscatter updates are cheap (included in the 2.5 s).
+- **First-try look parity was close** for the static port: same room/grid,
+  gold electrons, striped screen, camera path (`ray_t-5.00.png`,
+  `ray_t+3.00.png`, `ray_t+26.00.png` vs `rpr_frames_v3/rpr_{0071,0151,0380}.png`).
+  Materials are typed structs; glassglow is ONE node
+  (`MediumInterface(Dielectric; emission=…)`), `Emissive(two_sided=true)`
+  replaces RPR's DOUBLESIDED mode, capture is just
+  `colorbuffer(...; exposure, tonemap=:aces, gamma)`.
+- **Emissive volumes from raw Julia arrays** (`RGBGridMedium` with per-voxel
+  σ_a/Le): the radiation cube and the analytic pulse render as true glowing
+  media that light the room (floor caustic patterns in the clip) — the
+  original "the flash lights the room" idea, impossible in RPR.
+- **Scene reuse across frames actually works** for volumes + meshscatter:
+  grid re-upload ~2 s, electron position updates cheap, camera via
+  observables. 61 frames, one process, no leak.
 
-## Upstream findings (candidates for issues on Hikari/RayMakie)
+## Bring-up recipe (headless W7900)
+
+- GLFW.jl hardcodes X11 on Linux → run under a virtual compositor:
+  `kwin_wayland --virtual --no-global-shortcuts --socket=wayland-edm &`,
+  then `WAYLAND_DISPLAY=wayland-edm JULIA_GLFW_PLATFORM=wayland`.
+  xkbcommon Compose errors are harmless.
+- **Env split forced**: Hikari pins StructArrays 0.6; SciMLBase 3 needs
+  RecursiveArrayTools 4 → StructArrays 0.7. Physics (setup.jl) runs in
+  `--project=animation` via `precompute_frames.jl` → plain-array payloads
+  (13–81 MB/frame) → `thomson_ray.jl` renders from `--project=animation/raymakie`.
+
+## Upstream findings (file as issues on Hikari/RayMakie)
 
 1. **`RGBGridMedium(σ_s_grid = nothing)` renders as uniform fog** filling the
-   whole bounding box, drowning the actual grid contents. An explicit
-   zero-valued σ_s grid restores correct emission-only behavior.
-   Minimal reproducer: `mwe_medium.jl` (emitting ball in a box — fog block
-   without the zero grid, clean glowing ball with it).
-2. **A Dielectric volume boundary shadows the box** — shadow rays treat the
-   cube as opaque (documented in RayMakie `plots/volume.jl`); use
-   `MediumInterface(NullMaterial(); inside=medium)`.
-3. **Observable mesh swap is ~10× slower than a full scene rebuild**
-   (2282 s vs 209 s for the same 1.6 M-triangle content, SW BVH) — looks like
-   each updated plot triggers its own full accel rebuild.
-4. **HW RT (`hw_accel=true`) DEVICE_LOSTs** (`rt_indirect`) on the
-   ~1.6 M-triangle mesh scene; fine on the small Materials demo.
+   whole bounding box. Explicit zero σ_s grid restores emission-only
+   behavior. Minimal reproducer: `mwe_medium.jl`.
+2. **Observable mesh swap is ~10× slower than a full scene rebuild**
+   (2282 s vs 209 s for the same ~1.6 M-triangle content, SW BVH).
+3. **HW RT (`hw_accel=true`) DEVICE_LOSTs** (`rt_indirect` batch) on the
+   ~1.6 M-triangle mesh scene; fine on small scenes and the volume-style
+   scene (~100 k triangles).
+4. (Documented, not a bug: a Dielectric volume boundary shadows the box —
+   use `MediumInterface(NullMaterial(); inside=medium)`, per RayMakie
+   `plots/volume.jl`.)
 
-## Open items
+## Remaining work before production adoption
 
-- [ ] Volume-mode look sweep (floor/sigma/le) → pick production mapping
-- [ ] Full-res volume-mode still + timing
-- [ ] HW RT retry on volume-style scene
-- [ ] Short animation clip (scene reuse) + VRAM stability
-- [ ] Grading pass (ambient/softbox/exposure) to match the locked RPR look
+- [ ] Volume lookdev with a human eye: current mapping
+  (`EDM_RAY_VOL_FLOOR/GAMMA/LE/SIGMA`, pulse floor 0.45 ≙ the mesh ±0.5
+  isolevel) shows structure but cores still trend white; grading
+  (ambient/softbox/exposure) not yet matched to the locked RPR level.
+- [ ] Screen `develop` sequence + camera pull-back check over the full
+  400-frame window.
+- [ ] spp / denoiser trade (64 spp is grainy; `DenoiseConfig` untested).
+- [ ] Optional: report + track the upstream issues; mesh style becomes
+  viable if the BLAS-rebuild and mesh-update paths are fixed.
+
+## Files
+
+- `Project.toml` — render env (ray stack only, GeometryBasics =0.5.10 pin)
+- `precompute_frames.jl` — physics side (animation env): payloads per frame
+- `thomson_ray.jl` — renderer: EDM_RAY_* knobs, mesh|volume styles, reuse
+- `sweep_glass.jl`, `sweep_buildtrace.jl`, `sweep_volume.jl` — measurements
+- `mwe_medium.jl` — σ_s_grid=nothing reproducer
+- `frame_cache/`, `ray_frames/`, `*.png`, `thomson_ray_clip.mp4` — outputs (untracked)

--- a/animation/raymakie/Project.toml
+++ b/animation/raymakie/Project.toml
@@ -1,0 +1,32 @@
+# RayMakie/Hikari render env for the Thomson-scattering animation experiment.
+# RENDER-ONLY: Hikari pins StructArrays 0.6 while SciMLBase 3 (via
+# RecursiveArrayTools 4) needs StructArrays 0.7, so the physics stack cannot
+# live in the same env. precompute_frames.jl runs in ../ (the animation env)
+# and dumps per-frame payloads; thomson_ray.jl renders them from here.
+# [sources] pins the same dev branches as ../../../RayDemo's known-good env.
+[deps]
+ComputePipeline = "95dc2771-c249-4cd0-9c9f-1f3b4330693c"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GPUSelect = "203851ad-5791-4cf9-9fcc-5933b5611f42"
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+Hikari = "afc56b53-c9a9-482a-a956-d1d800e05558"
+Lava = "3a680b1f-cb25-4bee-9cf7-bc880b76dc8c"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RayMakie = "70852e3a-d594-4041-8350-783a02753e02"
+Raycore = "afc56b53-c9a9-482a-a956-d1d800e05559"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[sources]
+GPUSelect = {url = "https://github.com/SimonDanisch/GPUSelect.jl", rev = "main"}
+Lava = {url = "https://github.com/SimonDanisch/Lava.jl", rev = "sd/nvidia"}
+Hikari = {url = "https://github.com/JuliaGraphics/Hikari.jl", rev = "sd/vk-hw-accel"}
+Raycore = {url = "https://github.com/JuliaGeometry/Raycore.jl", rev = "master"}
+Makie = {url = "https://github.com/MakieOrg/Makie.jl.git", rev = "sd/lava", subdir = "Makie"}
+RayMakie = {url = "https://github.com/MakieOrg/Makie.jl.git", rev = "sd/lava", subdir = "RayMakie"}
+ComputePipeline = {url = "https://github.com/MakieOrg/Makie.jl.git", rev = "sd/lava", subdir = "ComputePipeline"}
+
+[compat]
+# 0.5.11 mis-parses binary-PLY face indices (see RayDemo/Project.toml); same
+# pin as the working RayDemo env
+GeometryBasics = "=0.5.10"

--- a/animation/raymakie/mwe_medium.jl
+++ b/animation/raymakie/mwe_medium.jl
@@ -1,0 +1,41 @@
+# Minimal medium sanity check: a 64³ grid with an emitting ball in the center,
+# inside a NullMaterial MediumInterface box, dark scene, one ambient light.
+# If the whole box renders instead of just the ball, the medium path is broken.
+#   julia --startup=no --project=animation/raymakie animation/raymakie/mwe_medium.jl
+using Makie, RayMakie, Hikari, Lava, GPUSelect
+import GeometryBasics
+using FileIO
+
+DEVICE = GPUSelect.Backend(:Lava)
+integrator = Hikari.VolPath(; samples = 64, max_depth = 8, hw_accel = false,
+    regularize = true, max_component_value = 10.0f0)
+
+n = 64
+σ_a = Array{Hikari.RGBSpectrum, 3}(undef, n, n, n)
+Le = Array{Hikari.RGBSpectrum, 3}(undef, n, n, n)
+for k in 1:n, j in 1:n, i in 1:n
+    r = sqrt((i - n / 2)^2 + (j - n / 2)^2 + (k - n / 2)^2) / (n / 2)
+    w = r < 0.3 ? 1.0f0 : 0.0f0
+    σ_a[i, j, k] = Hikari.RGBSpectrum(w)
+    Le[i, j, k] = Hikari.RGBSpectrum(w * 1.0f0, w * 0.6f0, w * 0.1f0)   # orange ball
+end
+σ_s = fill(Hikari.RGBSpectrum(0.0f0), n, n, n)   # explicit zero-scattering grid:
+# σ_s_grid=nothing appears to be mishandled (uniform fog) — testing that
+med = Hikari.RGBGridMedium(; σ_a_grid = σ_a, σ_s_grid = σ_s, Le_grid = Le,
+    sigma_scale = 6.0f0, Le_scale = 2.0f0, g = 0.0f0,
+    bounds = Hikari.Bounds3(GeometryBasics.Point3f(-2, -2, -2), GeometryBasics.Point3f(2, 2, 2)))
+
+scene = Scene(; size = (480, 360), backgroundcolor = RGBf(0.02, 0.02, 0.03),
+    lights = Makie.AbstractLight[Makie.AmbientLight(RGBf(0.5, 0.5, 0.5))])
+cam3d!(scene)
+# gray floor for reference
+mesh!(scene, Rect3f(Point3f(-8, -8, -2.6), Vec3f(16, 16, 0.1));
+    material = Hikari.Diffuse(Kd = Hikari.RGBSpectrum(0.5f0)))
+mesh!(scene, GeometryBasics.normal_mesh(Rect3f(Point3f(-2, -2, -2), Vec3f(4, 4, 4)));
+    material = Hikari.MediumInterface(Hikari.NullMaterial(); inside = med, outside = nothing))
+update_cam!(scene, Vec3f(6, -8, 4), Vec3f(0, 0, 0), Vec3f(0, 0, 1))
+
+img = Makie.colorbuffer(scene; backend = RayMakie, device = DEVICE, integrator,
+    exposure = 1.0f0, tonemap = :aces, gamma = 2.2f0, update = false)
+save(joinpath(@__DIR__, "mwe_medium.png"), img)
+println("saved mwe_medium.png")

--- a/animation/raymakie/precompute_frames.jl
+++ b/animation/raymakie/precompute_frames.jl
@@ -1,0 +1,362 @@
+# Physics side of the RayMakie experiment: everything thomson_rpr.jl computes
+# per frame (pulse isosurfaces, radiation-cube slices/stripes, screen images,
+# electron positions, camera path) evaluated here and dumped as plain-array
+# payloads for animation/raymakie/thomson_ray.jl to render.
+#
+# Why a separate process: Hikari pins StructArrays 0.6 while SciMLBase 3
+# (RecursiveArrayTools 4) needs StructArrays 0.7 — the SciML physics stack and
+# the ray-tracing stack cannot resolve into one environment. Payloads are
+# plain tuples/arrays (no GeometryBasics/EDM types) so the two envs never need
+# matching package versions. Data/transfer blocks are copied verbatim from
+# animation/thomson_rpr.jl to stay frame-comparable with the RPR renders.
+#
+# Run:  julia -t 8 --startup=no --project=animation \
+#         animation/raymakie/precompute_frames.jl
+# Knobs:
+#   EDM_RAY_T=0.0             single still at t (T0 units) → still_<t>.jls
+#   EDM_RAY_FRAMES=a:b|all    play_times frames a..b → frame_%04d.jls (resumable)
+#   EDM_RAY_CACHE=dir         payload dir (default animation/raymakie/frame_cache)
+#   EDM_RAY_CONTENT=mesh|volume|both   which radiation/pulse representations to
+#                             precompute (default both for stills, mesh for ranges)
+#   EDM_RAY_OVERSAMPLE=2 EDM_RAY_RAD_SLEVEL=0.3 EDM_RAY_RAD_UPSAMPLE=4
+#   EDM_RAY_RAD_TINT=0.5 EDM_RAY_RAD_COLORS  EDM_RAY_SCREEN_STYLE=striped
+#   EDM_RAY_SCREEN_FLOOR=0.12 EDM_RAY_SCREEN_DEVELOP=live EDM_RAY_PULSE_FADE=14,4
+#   EDM_RADIATION_CUBE / EDM_SCREEN_TIMESERIES   data overrides (as everywhere)
+
+include(joinpath(@__DIR__, "..", "setup.jl"))
+
+using MarchingCubes   # triggers EDMIsoMeshExt (with GeometryBasics)
+import GeometryBasics
+using Serialization
+using Printf
+import DataInterpolations
+using ElectronDynamicsModels: iso_mesh
+
+# RGBf without a Makie dep (Colors is in the animation env)
+import Colors
+const RGBf = Colors.RGB{Float32}
+
+# ── Shared look/content knobs (defaults = production render_production.sh) ──
+rad_slevel = parse(Float32, get(ENV, "EDM_RAY_RAD_SLEVEL", "0.3"))
+rad_upsample = parse(Int, get(ENV, "EDM_RAY_RAD_UPSAMPLE", "4"))
+rad_tint = parse(Float32, get(ENV, "EDM_RAY_RAD_TINT", "0.5"))
+rad_colors = let s = get(ENV, "EDM_RAY_RAD_COLORS", "1.0,0.75,0.2;0.55,0.3,0.9")
+    a, b = split(s, ";")
+    (RGBf(parse.(Float32, split(a, ","))...), RGBf(parse.(Float32, split(b, ","))...))
+end
+screen_style = get(ENV, "EDM_RAY_SCREEN_STYLE", "striped")
+r_electron = parse(Float64, get(ENV, "EDM_RAY_RADIUS", "0.14")) * λ
+
+# ── Pulse scalar + sampler (verbatim from thomson_rpr.jl) ──
+pulse_scalar(E, B) = E[1]
+
+function sample_pulse!(buf, fe, xs, ys, zs, t)
+    Threads.@threads for j in eachindex(ys)
+        y = ys[j]
+        for (i, x) in enumerate(xs), (k, z) in enumerate(zs)
+            E, B = fe([t, x, y, z])
+            buf[k, i, j] = Float32(pulse_scalar(E, B))
+        end
+    end
+    return buf
+end
+
+# Densified grids for the isosurface; pulse box reaches the detector (+16λ)
+oversample = parse(Float64, get(ENV, "EDM_RAY_OVERSAMPLE", "2"))
+z_pulse_hi = 16λ
+nxr, nyr = round.(Int, oversample .* (nx, ny))
+nzr = round(Int, oversample * nz * (z_pulse_hi - first(zs)) / (last(zs) - first(zs)))
+xsr = LinRange(first(xs), last(xs), nxr)
+ysr = LinRange(first(ys), last(ys), nyr)
+zsr = LinRange(first(zs), z_pulse_hi, nzr)
+vol_buf = Array{Float32}(undef, nzr, nxr, nyr)
+# native-resolution buffer for the volume-mode pulse
+nzn = round(Int, nz * (z_pulse_hi - first(zs)) / (last(zs) - first(zs)))
+zsn = LinRange(first(zs), z_pulse_hi, nzn)
+vol_buf_n = Array{Float32}(undef, nzn, nx, ny)
+
+# ── Scene units ──
+const SCN = Float64(w₀)
+scn(x) = Float32(x / SCN)
+const sw = 1.0f0
+
+# ── Stage C data: radiation cube + screen (verbatim from thomson_rpr.jl) ──
+default_cube = let p = joinpath(@__DIR__, "..", "radiation_cube.jls")
+    isfile(p) ? p :
+        expanduser("~/.julia/dev/ElectronDynamicsModels/animation/radiation_cube.jls")
+end
+radiation_cube = get(ENV, "EDM_RADIATION_CUBE", default_cube)
+RAD = nothing
+rad_win = nothing
+rad_floor = 0.0f0
+const rad_decades = 3.0f0
+rad_s_ceil = 0.0f0
+if isfile(radiation_cube) && get(ENV, "EDM_RAY_RADIATION", "1") == "1"
+    @info "loading radiation cube $radiation_cube"
+    RAD = deserialize(radiation_cube)
+    _rs = filter(>(0.0f0), vec(@view RAD.rad[1:3:end, 1:5:end, 1:5:end, 1:5:end]))
+    rad_ceil = partialsort!(_rs, max(1, round(Int, 0.005 * length(_rs))); rev = true)
+    rad_floor = rad_ceil / exp10(rad_decades)
+    edgewindow(n, frac = 0.1f0; lo = true, hi = true) = begin
+        m = max(2, round(Int, frac * n))
+        w = ones(Float32, n)
+        for i in 1:m
+            s = Float32(i - 1) / m
+            lo && (w[i] = s * s * (3 - 2s))
+            hi && (w[n + 1 - i] = s * s * (3 - 2s))
+        end
+        w
+    end
+    rad_win = reshape(edgewindow(size(RAD.rad, 2); hi = false), :, 1, 1) .*
+        reshape(edgewindow(size(RAD.rad, 3)), 1, :, 1) .*
+        reshape(edgewindow(size(RAD.rad, 4)), 1, 1, :)
+    if haskey(RAD, :rad_s)
+        _ss = filter(!iszero, vec(@view RAD.rad_s[1:3:end, 1:5:end, 1:5:end, 1:5:end]))
+        map!(abs, _ss, _ss)
+        rad_s_ceil = partialsort!(_ss, max(1, round(Int, 0.005 * length(_ss))); rev = true)
+    end
+end
+function upsample_dim1(v, x, xu)
+    out = Array{Float32}(undef, length(xu), size(v, 2), size(v, 3))
+    Threads.@threads for k in axes(v, 3)
+        for j in axes(v, 2)
+            sp = DataInterpolations.CubicSpline(collect(@view v[:, j, k]), x)
+            @inbounds for (i, xi) in enumerate(xu)
+                out[i, j, k] = Float32(sp(xi))
+            end
+        end
+    end
+    return out
+end
+rad_s_grid() = LinRange(first(RAD.slice_zs), last(RAD.slice_zs),
+    rad_upsample * (length(RAD.slice_zs) - 1) + 1)
+rad_s_slice(t; upsample = true) = begin
+    f = clamp(searchsortedlast(RAD.frame_times, t), 1, length(RAD.frame_times))
+    s = upsample ?
+        upsample_dim1(@view(RAD.rad_s[f, :, :, :]), RAD.slice_zs, rad_s_grid()) :
+        Array{Float32}(@view RAD.rad_s[f, :, :, :])
+    w1 = edgewindow(size(s, 1); hi = false)
+    w2 = edgewindow(size(s, 2))
+    w3 = edgewindow(size(s, 3))
+    @. s = clamp(s / rad_s_ceil, -1.0f0, 1.0f0) *
+        $(reshape(w1, :, 1, 1)) * $(reshape(w2, 1, :, 1)) * $(reshape(w3, 1, 1, :))
+    s
+end
+
+default_scr = let p = joinpath(@__DIR__, "..", "screen_timeseries.jls")
+    isfile(p) ? p :
+        expanduser("~/.julia/dev/ElectronDynamicsModels/animation/screen_timeseries.jls")
+end
+screen_file = get(ENV, "EDM_SCREEN_TIMESERIES", default_scr)
+show_screen = get(ENV, "EDM_RAY_SCREEN", "1") == "1"
+SCR = if show_screen && isfile(screen_file)
+    @info "loading screen time series $screen_file"
+    deserialize(screen_file)
+elseif show_screen && RAD !== nothing
+    @info "no dedicated screen data — using the radiation cube's +X edge slice"
+    (; scr = RAD.rad[:, end, :, :], txs = RAD.txs, tys = RAD.tys,
+        z_screen = last(RAD.slice_zs), frame_times = RAD.frame_times)
+else
+    nothing
+end
+scr_floor = 0.0f0
+if SCR !== nothing
+    _ss = filter(>(0.0f0), vec(@view SCR.scr[1:2:end, 1:3:end, 1:3:end]))
+    scr_ceil = partialsort!(_ss, max(1, round(Int, 0.002 * length(_ss))); rev = true)
+    global scr_floor = scr_ceil / exp10(3.0f0)
+end
+scr_slice(t) = begin
+    f = clamp(searchsortedlast(SCR.frame_times, t), 1, length(SCR.frame_times))
+    @. clamp(log10(max($(@view SCR.scr[f, :, :]), scr_floor) / scr_floor) / 3.0f0, 0.0f0, 1.0f0)
+end
+scr_s_ceil = 0.0f0
+scr_flu = nothing
+scr_flu_ceil = 0.0f0
+if RAD !== nothing && haskey(RAD, :rad_s)
+    _sv = filter(!iszero, vec(@view RAD.rad_s[1:2:end, end, 1:3:end, 1:3:end]))
+    map!(abs, _sv, _sv)
+    isempty(_sv) ||
+        (scr_s_ceil = partialsort!(_sv, max(1, round(Int, 0.002 * length(_sv))); rev = true))
+    scr_flu = cumsum(abs2.(@view RAD.rad_s[:, end, :, :]); dims = 1)
+    _fv = filter(>(0.0f0), vec(@view scr_flu[end, 1:2:end, 1:2:end]))
+    isempty(_fv) ||
+        (scr_flu_ceil = partialsort!(_fv, max(1, round(Int, 0.005 * length(_fv))); rev = true))
+end
+scr_flu_frac = scr_flu === nothing ? nothing :
+    (fs = [sum(@view scr_flu[f, :, :]) for f in axes(scr_flu, 1)]; fs ./ max(fs[end], eps()))
+scr_develop = let s = get(ENV, "EDM_RAY_SCREEN_DEVELOP", "live")
+    isempty(s) || s == "off" ? nothing :
+    s == "live" ? :live : Tuple(parse.(Float64, split(s, ",")))
+end
+dev_w(t) = scr_develop === nothing ? 0.0f0 :
+    scr_develop === :live ?
+    (scr_flu_frac === nothing ? 0.0f0 :
+     Float32(scr_flu_frac[clamp(searchsortedlast(RAD.frame_times, t), 1,
+        length(RAD.frame_times))])) :
+    Float32(clamp((t / T0 - scr_develop[1]) / scr_develop[2], 0, 1)^2 *
+            (3 - 2 * clamp((t / T0 - scr_develop[1]) / scr_develop[2], 0, 1)))
+scr_developed_img(f) = begin
+    flo = scr_flu_ceil / exp10(2.5f0)
+    pos, neg = rad_colors
+    map(@view scr_flu[f, :, :]) do v
+        u = clamp(log10(max(v, flo) / flo) / 2.5f0, 0.0f0, 1.0f0)
+        if u < 0.5f0
+            k = 2u
+            RGBf(k * neg.r, k * neg.g, k * neg.b)
+        elseif u < 0.85f0
+            k = (u - 0.5f0) / 0.35f0
+            RGBf(neg.r + k * (pos.r - neg.r), neg.g + k * (pos.g - neg.g),
+                neg.b + k * (pos.b - neg.b))
+        else
+            k = (u - 0.85f0) / 0.15f0
+            RGBf(pos.r + k * (1 - pos.r), pos.g + k * (1 - pos.g),
+                pos.b + k * (1 - pos.b))
+        end
+    end
+end
+pale(c, tint) = RGBf(1 - tint * (1 - c.r), 1 - tint * (1 - c.g), 1 - tint * (1 - c.b))
+scr_striped_img(t) = begin
+    f = clamp(searchsortedlast(RAD.frame_times, t), 1, length(RAD.frame_times))
+    pos = pale(rad_colors[1], rad_tint)
+    neg = pale(rad_colors[2], rad_tint)
+    flo = parse(Float32, get(ENV, "EDM_RAY_SCREEN_FLOOR", "0.12"))
+    inst = map(@view RAD.rad_s[f, end, :, :]) do s
+        w = clamp((abs(s) / scr_s_ceil - flo) / (1 - flo), 0.0f0, 1.0f0)^0.45f0
+        base = s >= 0 ? pos : neg
+        hot = max(0.0f0, 2.5f0 * (w - 0.75f0))
+        RGBf(clamp(w * base.r + hot, 0, 1), clamp(w * base.g + hot, 0, 1),
+            clamp(w * base.b + hot, 0, 1))
+    end
+    (scr_flu !== nothing && scr_develop !== nothing) || return inst
+    if scr_develop === :live
+        dev = scr_developed_img(f)
+        return map(inst, dev) do a, b
+            RGBf(1 - (1 - a.r) * (1 - b.r), 1 - (1 - a.g) * (1 - b.g),
+                1 - (1 - a.b) * (1 - b.b))
+        end
+    end
+    wd = dev_w(t)
+    wd > 0 || return inst
+    dev = scr_developed_img(f)
+    map(inst, dev) do a, b
+        RGBf(a.r + wd * (b.r - a.r), a.g + wd * (b.g - a.g), a.b + wd * (b.b - a.b))
+    end
+end
+span_scr = SCR === nothing ? 0.0f0 : scn(SCR.z_screen - first(zs))
+
+# ── Camera path (verbatim) ──
+smoothstep(x) = x * x * (3 - 2x)
+function camera_for(t)
+    hero = ((2.5f0 * sw, -8.0f0 * sw, 3.0f0 * sw), (0.0f0, 0.0f0, 0.0f0))
+    SCR === nothing && return hero
+    cx = scn((first(zs) + SCR.z_screen) / 2)
+    wide = ((cx + 0.1f0 * span_scr, -1.2f0 * span_scr, 0.32f0 * span_scr), (cx, 0.0f0, 0.0f0))
+    s = Float32(smoothstep(clamp((t - 5T0) / 9T0, 0, 1)))
+    return ((1 - s) .* hero[1] .+ s .* wide[1], (1 - s) .* hero[2] .+ s .* wide[2])
+end
+
+pulse_fade(t) = let s = get(ENV, "EDM_RAY_PULSE_FADE", "14,4")
+    if isempty(s) || s == "off"
+        0.0f0
+    else
+        f0, fspan = parse.(Float64, split(s, ","))
+        Float32(smoothstep(clamp((t / T0 - f0) / fspan, 0, 1)))
+    end
+end
+
+# ── Plain-array payloads (env-boundary safe: tuples + Arrays only) ──
+plain_mesh(m) = m === nothing ? nothing :
+    (; pts = [Tuple(Float32.(p)) for p in GeometryBasics.coordinates(m)],
+        nrm = [Tuple(Float32.(n)) for n in GeometryBasics.normals(m)],
+        fcs = [Int32.(Tuple(f)) for f in GeometryBasics.faces(m)])
+plain_img(img) = [(c.r, c.g, c.b) for c in img]
+
+content_kind = get(ENV, "EDM_RAY_CONTENT", isempty(get(ENV, "EDM_RAY_FRAMES", "")) ? "both" : "mesh")
+do_mesh = content_kind in ("mesh", "both")
+do_vol = content_kind in ("volume", "both")
+
+function frame_payload(t)
+    pf = pulse_fade(t)
+    pulse_meshes = if do_mesh && pf < 0.995f0
+        sample_pulse!(vol_buf, fe, xsr, ysr, zsr, t)
+        cmax = maximum(abs, vol_buf)
+        (plain_mesh(iso_mesh(vol_buf, scn.(zsr), scn.(xsr), scn.(ysr), +0.5f0 * cmax)),
+            plain_mesh(iso_mesh(vol_buf, scn.(zsr), scn.(xsr), scn.(ysr), -0.5f0 * cmax)))
+    else
+        (nothing, nothing)
+    end
+    pulse_vol = if do_vol && pf < 0.995f0
+        sample_pulse!(vol_buf_n, fe, xs, ys, zsn, t)
+        m = maximum(abs, vol_buf_n)
+        m > 0 ? vol_buf_n ./ m : copy(vol_buf_n)
+    else
+        nothing
+    end
+    rad_meshes = if RAD !== nothing && do_mesh && haskey(RAD, :rad_s)
+        s = rad_s_slice(t)
+        zu = scn.(rad_s_grid())
+        (plain_mesh(iso_mesh(s, zu, scn.(RAD.txs), scn.(RAD.tys), +rad_slevel)),
+            plain_mesh(iso_mesh(s, zu, scn.(RAD.txs), scn.(RAD.tys), -rad_slevel)))
+    else
+        (nothing, nothing)
+    end
+    rad_vol = if RAD !== nothing && do_vol && haskey(RAD, :rad_s)
+        rad_s_slice(t; upsample = false)
+    else
+        nothing
+    end
+    scr_img = if SCR !== nothing
+        if screen_style == "striped" && RAD !== nothing && haskey(RAD, :rad_s) && scr_s_ceil > 0
+            plain_img(scr_striped_img(t))
+        else
+            su = scr_slice(t)
+            [(v, v, v) for v in su]   # gray fallback; production uses striped
+        end
+    else
+        nothing
+    end
+    epos = [Tuple(Float32.(scn.(p))) for p in electron_positions(trajs, t)]
+    return (; t, pf, pulse_meshes, pulse_vol, rad_meshes, rad_vol, scr_img, epos,
+        cam = camera_for(t))
+end
+
+static_payload() = (;
+    T0, sw, span_scr,
+    play_times = collect(Float64, play_times),
+    r_electron_scn = scn(r_electron),
+    screen = SCR === nothing ? nothing : (;
+        x = scn(SCR.z_screen),
+        ylo = scn(first(SCR.txs)), yhi = scn(last(SCR.txs)),
+        zlo = scn(first(SCR.tys)), zhi = scn(last(SCR.tys))),
+    pulse_vol_bounds = ((scn(first(zsn)), scn(first(xs)), scn(first(ys))),
+        (scn(last(zsn)), scn(last(xs)), scn(last(ys)))),
+    rad_vol_bounds = RAD === nothing ? nothing :
+        ((scn(first(RAD.slice_zs)), scn(first(RAD.txs)), scn(first(RAD.tys))),
+        (scn(last(RAD.slice_zs)), scn(last(RAD.txs)), scn(last(RAD.tys)))),
+)
+
+# ── Entry ──
+cache_dir = get(ENV, "EDM_RAY_CACHE", joinpath(@__DIR__, "frame_cache"))
+mkpath(cache_dir)
+serialize(joinpath(cache_dir, "static.jls"), static_payload())
+@info "static payload written to $cache_dir"
+
+frames_spec = get(ENV, "EDM_RAY_FRAMES", "")
+if isempty(frames_spec)
+    ts = parse.(Float64, split(get(ENV, "EDM_RAY_T", "0.0"), ","))
+    for tT in ts
+        out = joinpath(cache_dir, @sprintf("still_t%+.2f.jls", tT))
+        el = @elapsed serialize(out, frame_payload(tT * T0))
+        @info @sprintf("still t = %+.2f T0  %.1f s  → %s", tT, el, out)
+    end
+else
+    rng = frames_spec == "all" ? (1:length(play_times)) :
+        (:)(parse.(Int, split(frames_spec, ":"))...)
+    for i in rng
+        out = joinpath(cache_dir, @sprintf("frame_%04d.jls", i))
+        isfile(out) && continue   # resumable
+        el = @elapsed serialize(out, frame_payload(play_times[i]))
+        @info @sprintf("frame %d/%d  t = %+.2f T0  %.1f s", i, last(rng), play_times[i] / T0, el)
+    end
+end
+@info "precompute done"

--- a/animation/raymakie/sweep_buildtrace.jl
+++ b/animation/raymakie/sweep_buildtrace.jl
@@ -1,0 +1,45 @@
+# Attribute the ~100 s flash-frame floor: BLAS/upload vs trace vs
+# observable-update cost, for mesh style and volume style.
+#   julia --startup=no --project=animation/raymakie animation/raymakie/sweep_buildtrace.jl
+ENV["EDM_RAY_ENTRY"] = "0"
+ENV["EDM_RAY_RES"] = get(ENV, "EDM_RAY_RES", "640x480")
+ENV["EDM_RAY_GLASS"] = "thin"
+include(joinpath(@__DIR__, "thomson_ray.jl"))
+
+fc = load_payload(joinpath(cache_dir, "still_t+3.00.jls"))
+integ() = Hikari.VolPath(; samples = 32, max_depth = 8, hw_accel = false,
+    regularize = true, max_component_value = 10.0f0)
+render(S) = Makie.colorbuffer(S.scene; backend = RayMakie, device = DEVICE,
+    integrator = integrator, exposure, tonemap, gamma, update = false)
+
+global integrator = integ()
+
+println("=== MESH style (stripes as iso-mesh glass) ===")
+global rad_style3d = "mesh"; global pulse_style3d = "mesh"
+tb = @elapsed S = build_scene(fc)
+println("build_scene:            ", round(tb; digits = 1), " s")
+t1 = @elapsed render(S)
+println("colorbuffer #1:         ", round(t1; digits = 1), " s   (upload + BLAS + trace)")
+t2 = @elapsed render(S)
+println("colorbuffer #2:         ", round(t2; digits = 1), " s   (steady state)")
+t3 = @elapsed render(S)
+println("colorbuffer #3:         ", round(t3; digits = 1), " s")
+tu = @elapsed update_scene!(S, fc)
+t4 = @elapsed render(S)
+println("update_scene!:          ", round(tu; digits = 1), " s")
+println("colorbuffer after upd:  ", round(t4; digits = 1), " s   (mesh-swap rebuild cost)")
+
+println("=== VOLUME style (stripes+pulse as emissive media) ===")
+global rad_style3d = "volume"; global pulse_style3d = "volume"
+tbv = @elapsed SV = build_scene(fc)
+println("build_scene:            ", round(tbv; digits = 1), " s")
+v1 = @elapsed render(SV)
+println("colorbuffer #1:         ", round(v1; digits = 1), " s")
+v2 = @elapsed render(SV)
+println("colorbuffer #2:         ", round(v2; digits = 1), " s")
+tuv = @elapsed update_scene!(SV, fc)
+v3 = @elapsed render(SV)
+println("update_scene!:          ", round(tuv; digits = 1), " s")
+println("colorbuffer after upd:  ", round(v3; digits = 1), " s   (grid re-upload cost)")
+save(joinpath(@__DIR__, "sweep_volume_t+3.png"), render(SV))
+println("volume still saved: sweep_volume_t+3.png")

--- a/animation/raymakie/sweep_glass.jl
+++ b/animation/raymakie/sweep_glass.jl
@@ -1,0 +1,25 @@
+# Timing/quality sweep over the ribbon/stripe interface model and path depth —
+# diagnosing the 2327 s flash frame (t=+3, both stripe stacks in scene).
+# One process, one kernel compile; scene rebuilt per config.
+#   julia --startup=no --project=animation/raymakie animation/raymakie/sweep_glass.jl
+ENV["EDM_RAY_ENTRY"] = "0"
+ENV["EDM_RAY_RES"] = get(ENV, "EDM_RAY_RES", "640x480")
+include(joinpath(@__DIR__, "thomson_ray.jl"))
+
+fc = load_payload(joinpath(cache_dir, "still_t+3.00.jls"))
+results = Tuple{String, Int, Float64}[]
+for (kind, depth) in (("dielectric", 16), ("dielectric", 8),
+        ("thin", 16), ("thin", 8), ("interface", 8))
+    global glass_kind = kind
+    global integrator = Hikari.VolPath(; samples = 32, max_depth = depth,
+        hw_accel = false, regularize = true, max_component_value = 10.0f0)
+    SCENE_STATE[] = nothing   # force rebuild so the new materials apply
+    out = joinpath(@__DIR__, "sweep_$(kind)_d$(depth).png")
+    tr = render_frame(fc, out)
+    push!(results, (kind, depth, tr))
+    @info "config $kind depth=$depth → $(round(tr; digits = 1)) s"
+end
+println("\n=== sweep results (640x480, 32 spp, t=+3) ===")
+for (k, d, tr) in results
+    println(rpad(k, 12), " depth=", rpad(d, 3), round(tr; digits = 1), " s")
+end

--- a/animation/raymakie/sweep_volume.jl
+++ b/animation/raymakie/sweep_volume.jl
@@ -1,0 +1,23 @@
+# Volume-mode look sweep: (floor, sigma, le_scale) for the emissive
+# RGBGridMedium mapping, flash frame t=+3, radiation + pulse as media.
+#   julia --startup=no --project=animation/raymakie animation/raymakie/sweep_volume.jl
+ENV["EDM_RAY_ENTRY"] = "0"
+ENV["EDM_RAY_RES"] = get(ENV, "EDM_RAY_RES", "640x480")
+ENV["EDM_RAY_STYLE"] = "volume"
+ENV["EDM_RAY_PULSE_STYLE"] = "volume"
+include(joinpath(@__DIR__, "thomson_ray.jl"))
+
+fc = load_payload(joinpath(cache_dir, "still_t+3.00.jls"))
+global integrator = Hikari.VolPath(; samples = 32, max_depth = 8,
+    hw_accel = false, regularize = true, max_component_value = 10.0f0)
+for le in (0.5f0, 1.0f0, 2.0f0, 4.0f0), sig in (2.0f0, 6.0f0, 15.0f0)
+    global vol_floor = 0.2f0
+    global vol_sigma = sig
+    global vol_le = le
+    global vol_gamma = 1.5f0
+    SCENE_STATE[] = nothing
+    out = joinpath(@__DIR__, "sweep_vol_le$(le)_s$(sig).png")
+    tr = render_frame(fc, out)
+    @info "le=$le sigma=$sig → $(round(tr; digits = 1)) s"
+end
+println("volume sweep done")

--- a/animation/raymakie/thomson_ray.jl
+++ b/animation/raymakie/thomson_ray.jl
@@ -391,18 +391,22 @@ else
     outdir = get(ENV, "EDM_RAY_OUTDIR", joinpath(@__DIR__, "ray_frames"))
     mkpath(outdir)
     @info "rendering frames $(first(rng))..$(last(rng)) into $outdir"
-    total = 0.0
-    done = 0
-    for i in rng
-        outpath = joinpath(outdir, @sprintf("ray_%04d.png", i))
-        isfile(outpath) && continue   # resumable
-        fc = load_payload(joinpath(cache_dir, @sprintf("frame_%04d.jls", i)))
-        tr = render_frame(fc, outpath)
-        done += 1
-        total += tr
-        eta = (length(rng) - (i - first(rng) + 1)) * total / done
-        @info @sprintf("frame %d/%d  t = %+.2f T0  %.1f s  (mean %.1f s, ETA %.0f min)",
-            i, last(rng), fc.t / ST.T0, tr, total / done, eta / 60)
+    function render_range(rng, outdir)
+        total = 0.0
+        n_done = 0
+        for i in rng
+            outpath = joinpath(outdir, @sprintf("ray_%04d.png", i))
+            isfile(outpath) && continue   # resumable
+            fc = load_payload(joinpath(cache_dir, @sprintf("frame_%04d.jls", i)))
+            tr = render_frame(fc, outpath)
+            n_done += 1
+            total += tr
+            eta = (length(rng) - (i - first(rng) + 1)) * total / n_done
+            @info @sprintf("frame %d/%d  t = %+.2f T0  %.1f s  (mean %.1f s, ETA %.0f min)",
+                i, last(rng), fc.t / ST.T0, tr, total / n_done, eta / 60)
+        end
+        return n_done
     end
-    @info "done: $done frames rendered"
+    n = render_range(rng, outdir)
+    @info "done: $n frames rendered"
 end

--- a/animation/raymakie/thomson_ray.jl
+++ b/animation/raymakie/thomson_ray.jl
@@ -1,0 +1,378 @@
+# RayMakie/Hikari (Lava Vulkan) renderer for the Thomson-scattering scene —
+# the experiment answering "does RayMakie beat RPRMakie/HybridPro for the
+# production animation?". Consumes the plain-array frame payloads produced by
+# animation/raymakie/precompute_frames.jl (the physics stack cannot share this
+# env: Hikari pins StructArrays 0.6, SciMLBase 3 needs 0.7 — see Project.toml).
+#
+# What RayMakie changes vs the RPR pipeline:
+#   * observables are wired: the scene is built ONCE and mutated per frame
+#     (EDM_RAY_REUSE=1, default) instead of rebuilt with a fresh context —
+#     EDM_RAY_REUSE=0 rebuilds per frame as a control
+#   * colorbuffer() returns a tonemapped image directly (exposure/tonemap/gamma
+#     kwargs) — no raw-framebuffer capture / manual Reinhard
+#   * materials are typed Hikari structs — glassglow is ONE node: glass BSDF +
+#     area-light emission on the same faces (RPR needed LayerMaterial / a
+#     folded Uber, with different builds per plugin)
+#   * EDM_RAY_STYLE=volume renders the radiation as a true emissive medium
+#     (RGBGridMedium) — the thing RPR could never do on GPU
+#
+# Headless (no X session): GLFW.jl hardcodes X11 on Linux, so run under a
+# virtual compositor —
+#   kwin_wayland --virtual --no-global-shortcuts --socket=wayland-edm &
+#   export WAYLAND_DISPLAY=wayland-edm JULIA_GLFW_PLATFORM=wayland
+#
+# Run:  julia --startup=no --project=animation/raymakie \
+#         animation/raymakie/thomson_ray.jl
+# Knobs:
+#   EDM_RAY_T=0.0             still time (T0) — reads still_<t>.jls from the cache
+#   EDM_RAY_FRAMES=a:b|all    frame range — reads frame_%04d.jls (resumable out)
+#   EDM_RAY_CACHE=dir         payload dir (default animation/raymakie/frame_cache)
+#   EDM_RAY_OUT / EDM_RAY_OUTDIR   output png / frames dir
+#   EDM_RAY_SPP=64 EDM_RAY_MAX_DEPTH=16 EDM_RAY_HW=1 EDM_RAY_RES=1280x960
+#   EDM_RAY_REUSE=1           build scene once + mutate observables per frame
+#   EDM_RAY_STYLE=mesh|volume radiation stripes as glass iso-meshes (production
+#                             look) or as an emissive RGBGridMedium
+#   EDM_RAY_PULSE_STYLE=mesh|volume  same for the laser pulse
+#   EDM_RAY_BG=room|dark      gray corner room (production) or dark backdrop
+#   EDM_RAY_AMBIENT=1.0       room dome intensity (Hikari scale — RPR's 7.0 was
+#                             tuned against its Reinhard capture, do not copy)
+#   EDM_RAY_SOFTBOX=1.5       ceiling panel Le (0 = off)
+#   EDM_RAY_EMIS=1.0 EDM_RAY_EMIS_COOL=0.25 EDM_RAY_GLOW=0.25   glassglow
+#   EDM_RAY_ELECTRON_ROUGH=0.45
+#   EDM_RAY_RAD_TINT=0.5 EDM_RAY_RAD_COLORS="1.0,0.75,0.2;0.55,0.3,0.9"
+#   EDM_RAY_VOL_LE=4.0 EDM_RAY_VOL_SIGMA=8.0   volume-mode emission/absorption
+#   EDM_RAY_EXPOSURE=1.0 EDM_RAY_TONEMAP=aces EDM_RAY_GAMMA=2.2
+
+using Makie
+using RayMakie
+using Hikari
+using Lava
+using GPUSelect
+import GeometryBasics
+using FileIO
+using Serialization
+using Printf
+
+# ── Parameters ──
+spp = parse(Int, get(ENV, "EDM_RAY_SPP", "64"))
+max_depth = parse(Int, get(ENV, "EDM_RAY_MAX_DEPTH", "16"))
+use_hw = get(ENV, "EDM_RAY_HW", "1") == "1"
+res = Tuple(parse.(Int, split(get(ENV, "EDM_RAY_RES", "1280x960"), "x")))
+reuse_scene = get(ENV, "EDM_RAY_REUSE", "1") == "1"
+rad_style3d = get(ENV, "EDM_RAY_STYLE", "mesh")          # mesh | volume
+pulse_style3d = get(ENV, "EDM_RAY_PULSE_STYLE", "mesh")  # mesh | volume
+white_room = get(ENV, "EDM_RAY_BG", "room") == "room"
+ambient_room = parse(Float32, get(ENV, "EDM_RAY_AMBIENT", "1.0"))
+sbox = parse(Float32, get(ENV, "EDM_RAY_SOFTBOX", "1.5"))
+emis_scale = parse(Float32, get(ENV, "EDM_RAY_EMIS", "1.0"))
+emis_cool = parse(Float32, get(ENV, "EDM_RAY_EMIS_COOL", "0.25"))
+glow_w = parse(Float32, get(ENV, "EDM_RAY_GLOW", "0.25"))
+electron_rough = parse(Float32, get(ENV, "EDM_RAY_ELECTRON_ROUGH", "0.45"))
+rad_tint = parse(Float32, get(ENV, "EDM_RAY_RAD_TINT", "0.5"))
+rad_colors = let s = get(ENV, "EDM_RAY_RAD_COLORS", "1.0,0.75,0.2;0.55,0.3,0.9")
+    a, b = split(s, ";")
+    (RGBf(parse.(Float32, split(a, ","))...), RGBf(parse.(Float32, split(b, ","))...))
+end
+vol_le = parse(Float32, get(ENV, "EDM_RAY_VOL_LE", "4.0"))
+vol_sigma = parse(Float32, get(ENV, "EDM_RAY_VOL_SIGMA", "8.0"))
+exposure = parse(Float32, get(ENV, "EDM_RAY_EXPOSURE", "1.0"))
+tonemap = Symbol(get(ENV, "EDM_RAY_TONEMAP", "aces"))
+gamma = parse(Float32, get(ENV, "EDM_RAY_GAMMA", "2.2"))
+
+cache_dir = get(ENV, "EDM_RAY_CACHE", joinpath(@__DIR__, "frame_cache"))
+ST = deserialize(joinpath(cache_dir, "static.jls"))
+const sw = ST.sw
+span_scr = ST.span_scr
+
+DEVICE = GPUSelect.Backend(:Lava)
+hw_accel = use_hw && DEVICE isa Lava.LavaBackend &&
+    Lava.vk_context().rt_pipeline_properties !== nothing
+integrator = Hikari.VolPath(; samples = spp, max_depth, hw_accel,
+    regularize = true, max_component_value = 10.0f0)
+@info "RayMakie" DEVICE hw_accel spp max_depth res reuse_scene rad_style3d pulse_style3d
+
+# ── Payload reconstruction ──
+rebuild_mesh(pm) = pm === nothing ? nothing :
+    GeometryBasics.Mesh(
+        [GeometryBasics.Point3f(p...) for p in pm.pts],
+        [GeometryBasics.GLTriangleFace(f...) for f in pm.fcs];
+        normal = [GeometryBasics.Vec3f(n...) for n in pm.nrm])
+rebuild_img(pi) = [RGBf(c...) for c in pi]
+
+# degenerate stand-in far below the floor: a lobe can vanish (payload nothing),
+# but a live plot needs SOME mesh to keep its observable graph alive
+const NULL_MESH = GeometryBasics.Mesh(
+    [GeometryBasics.Point3f(0, 0, -1e4), GeometryBasics.Point3f(1e-3, 0, -1e4),
+        GeometryBasics.Point3f(0, 1e-3, -1e4)],
+    [GeometryBasics.GLTriangleFace(1, 2, 3)];
+    normal = [GeometryBasics.Vec3f(0, 0, 1) for _ in 1:3])
+mesh_or_null(m) = m === nothing ? NULL_MESH : m
+
+# ── Hikari materials ──
+spec(c::RGBf) = Hikari.RGBSpectrum(c.r, c.g, c.b)
+pale(c, tint) = RGBf(1 - tint * (1 - c.r), 1 - tint * (1 - c.g), 1 - tint * (1 - c.b))
+
+# Emissive() applies pbrt's photometric normalization to scale — route the
+# emission NamedTuple through it so brightness matches Emissive materials
+function emission_info(c; scale = 1.0f0, two_sided = true)
+    em = Hikari.Emissive(Le = (c.r, c.g, c.b), scale = scale, two_sided = two_sided)
+    (Le = em.Le, scale = em.scale, two_sided = em.two_sided)
+end
+emissive_mat(c; scale = 1.0f0, two_sided = true) =
+    Hikari.MediumInterface(Hikari.Emissive(; Le = (c.r, c.g, c.b), scale, two_sided))
+
+# tinted glass: transmission carries the lobe color, reflections lightly tinted
+# (the RPR recipe: reflection_color = 0.3 + 0.7c)
+tinted_glass(c) = Hikari.Dielectric(
+    Kr = spec(RGBf(0.3f0 + 0.7f0 * c.r, 0.3f0 + 0.7f0 * c.g, 0.3f0 + 0.7f0 * c.b)),
+    Kt = spec(c), roughness = 0.0f0, index = 1.5f0)
+
+# glassglow: ONE node — glass BSDF + folded area-light emission
+function glassglow(c; emis = 1.0f0, glow = glow_w, fade = 0.0f0)
+    e = emis * (1 - fade)
+    c.b > c.r && (e *= emis_cool)   # cool lobe glows less (Fresnel depth cues)
+    Hikari.MediumInterface(tinted_glass(c);
+        emission = emission_info(RGBf(e * c.r, e * c.g, e * c.b); scale = glow))
+end
+
+gold_electron() = Hikari.Gold(roughness = electron_rough)
+flat_mat(c) = Hikari.Diffuse(Kd = spec(c))
+satin_mat(c) = Hikari.CoatedDiffuse(reflectance = spec(c), roughness = 0.45f0)
+transparent_boundary() = Hikari.Dielectric(
+    Kr = Hikari.RGBSpectrum(0.0f0), Kt = Hikari.RGBSpectrum(1.0f0), index = 1.0f0)
+
+# signed volume → emissive RGBGridMedium: ± lobes in the given palette,
+# emission and absorption ∝ |s| (pbrt: volumetric Le contributes as σ_a·Le)
+function signed_medium(s, bounds; le_scale = vol_le, sigma = vol_sigma, colors = rad_colors)
+    dims = size(s)
+    σ_a = Array{Hikari.RGBSpectrum, 3}(undef, dims)
+    Le = Array{Hikari.RGBSpectrum, 3}(undef, dims)
+    pos, neg = colors
+    @inbounds for i in eachindex(s)
+        v = s[i]
+        a = abs(v)
+        c = v ≥ 0 ? pos : neg
+        σ_a[i] = Hikari.RGBSpectrum(a)
+        Le[i] = Hikari.RGBSpectrum(a * c.r, a * c.g, a * c.b)
+    end
+    bmin, bmax = bounds
+    Hikari.RGBGridMedium(; σ_a_grid = σ_a, Le_grid = Le,
+        sigma_scale = sigma, Le_scale = le_scale, g = 0.0f0,
+        bounds = Hikari.Bounds3(GeometryBasics.Point3f(bmin...), GeometryBasics.Point3f(bmax...)))
+end
+vol_boundary_mat(s, bounds; kw...) = Hikari.MediumInterface(transparent_boundary();
+    inside = signed_medium(s, bounds; kw...), outside = nothing)
+
+pulse_colors = (RGBf(0.85, 0.25, 0.15), RGBf(0.2, 0.4, 0.95))
+rad_pale = (pale(rad_colors[1], rad_tint), pale(rad_colors[2], rad_tint))
+
+screen_material(img) = Hikari.MediumInterface(
+    Hikari.Diffuse(Kd = spec(RGBf(0.02, 0.02, 0.03)));
+    emission = (Le = Hikari.Texture(img'), scale = emission_info(RGBf(1, 1, 1)).scale,
+        two_sided = true))
+
+load_payload(path) = deserialize(path)
+
+# ── Scene assembly ──
+function build_scene(fc)
+    lights = if white_room
+        Makie.AbstractLight[Makie.AmbientLight(RGBf(ambient_room, ambient_room, 1.022f0 * ambient_room))]
+    else
+        radiance = 30.0f0
+        Makie.AbstractLight[
+            Makie.PointLight(RGBf(0.12radiance, 0.12radiance, 0.14radiance), Point3f(2sw, -9sw, 5sw)),
+            Makie.AmbientLight(RGBf(0.08, 0.08, 0.09))]
+    end
+    scene = Scene(; size = res, backgroundcolor = RGBf(0.055, 0.065, 0.09), lights)
+    cam3d!(scene)
+    cc = Makie.cameracontrols(scene)
+    cc.settings.center[] = false   # bbox re-centering steps when a lobe pops (RPR fix, still applies)
+
+    if white_room
+        C = (-10sw, 8sw, -2sw)
+        th = 0.05sw
+        xhi = max(32sw, (ST.screen === nothing ? 0.0f0 : ST.screen.x) + 0.45f0 * span_scr)
+        ylo_w = min(-16sw, -1.2f0 * span_scr - 3sw)
+        zhi = max(18sw, C[3] + 0.65f0 * span_scr)
+        xlen, ylen, zlen = xhi - C[1], C[2] - ylo_w, zhi - C[3]
+        for (slab, col) in (
+                (Rect3f(Point3f(C[1], ylo_w, C[3] - th), Vec3f(xlen, ylen, th)), RGBf(0.6, 0.6, 0.62)),
+                (Rect3f(Point3f(C[1], C[2], C[3]), Vec3f(xlen, th, zlen)), RGBf(0.72, 0.72, 0.74)),
+                (Rect3f(Point3f(C[1] - th, ylo_w, C[3]), Vec3f(th, ylen, zlen)), RGBf(0.66, 0.66, 0.68)),
+            )
+            mesh!(scene, slab; color = col, material = satin_mat(col))
+        end
+        if sbox > 0
+            panel = Rect3f(Point3f(-4sw, -8sw, 12sw), Vec3f(16sw, 12sw, 0.05sw))
+            mesh!(scene, panel; color = RGBf(1, 1, 1),
+                material = emissive_mat(RGBf(1, 1, 1.03f0); scale = sbox))
+        end
+        s = 0.09sw
+        axis_gray = RGBf(0.32, 0.33, 0.36)
+        for a in (
+                Rect3f(Point3f(C[1], C[2] - s, C[3]), Vec3f(xlen, s, s)),
+                Rect3f(Point3f(C[1], ylo_w, C[3]), Vec3f(s, ylen, s)),
+                Rect3f(Point3f(C[1], C[2] - s, C[3]), Vec3f(s, s, zlen)),
+            )
+            mesh!(scene, a; color = axis_gray, material = flat_mat(axis_gray))
+        end
+        g = 0.02sw
+        grid_gray = RGBf(0.5, 0.5, 0.53)
+        gridmults(lo, hi) = (2 * ceil(Int, lo / 2sw):2:2 * floor(Int, hi / 2sw)) .* sw
+        strips = Rect3f[]
+        for xg in gridmults(C[1], xhi)
+            push!(strips, Rect3f(Point3f(xg - g / 2, ylo_w, C[3]), Vec3f(g, ylen, g)))
+            push!(strips, Rect3f(Point3f(xg - g / 2, C[2] - g, C[3]), Vec3f(g, g, zlen)))
+        end
+        for yg in gridmults(ylo_w, C[2])
+            push!(strips, Rect3f(Point3f(C[1], yg - g / 2, C[3]), Vec3f(xlen, g, g)))
+            push!(strips, Rect3f(Point3f(C[1], yg - g / 2, C[3]), Vec3f(g, g, zlen)))
+        end
+        for zg in gridmults(C[3], zhi)
+            push!(strips, Rect3f(Point3f(C[1], C[2] - g, zg - g / 2), Vec3f(xlen, g, g)))
+            push!(strips, Rect3f(Point3f(C[1], ylo_w, zg - g / 2), Vec3f(g, ylen, g)))
+        end
+        for st in strips
+            mesh!(scene, st; color = grid_gray, material = flat_mat(grid_gray))
+        end
+    end
+
+    # laser wavefront ribbons (± signed pulse isosurfaces, glassglow)
+    pulse_plots = if pulse_style3d == "mesh"
+        map((1, 2)) do i
+            c = pulse_colors[i]
+            mesh!(scene, mesh_or_null(rebuild_mesh(fc.pulse_meshes[i])); color = c,
+                material = glassglow(c; emis = emis_scale, fade = fc.pf))
+        end
+    else
+        nothing
+    end
+    # radiation stripes (± signed Ex_far isosurfaces, pale tinted glass)
+    rad_plots = if rad_style3d == "mesh"
+        map((1, 2)) do i
+            mesh!(scene, mesh_or_null(rebuild_mesh(fc.rad_meshes[i])); color = rad_pale[i],
+                material = tinted_glass(rad_pale[i]))
+        end
+    else
+        nothing
+    end
+    # volume variants: emissive media inside transparent boxes
+    pulse_vol_plot = if pulse_style3d == "volume" && fc.pulse_vol !== nothing
+        bmin, bmax = ST.pulse_vol_bounds
+        mesh!(scene, Rect3f(Point3f(bmin...), Vec3f((bmax .- bmin)...));
+            material = vol_boundary_mat(fc.pulse_vol, ST.pulse_vol_bounds;
+                le_scale = vol_le * emis_scale * (1 - fc.pf), colors = pulse_colors))
+    else
+        nothing
+    end
+    rad_vol_plot = if rad_style3d == "volume" && fc.rad_vol !== nothing
+        bmin, bmax = ST.rad_vol_bounds
+        mesh!(scene, Rect3f(Point3f(bmin...), Vec3f((bmax .- bmin)...));
+            material = vol_boundary_mat(fc.rad_vol, ST.rad_vol_bounds))
+    else
+        nothing
+    end
+
+    # detector plate: textured emissive quad (manual mesh, same as RPR)
+    screen_plot = if ST.screen !== nothing && fc.scr_img !== nothing
+        S = ST.screen
+        pts = GeometryBasics.Point3f[(S.x, S.ylo, S.zlo), (S.x, S.yhi, S.zlo),
+            (S.x, S.yhi, S.zhi), (S.x, S.ylo, S.zhi)]
+        fcs = [GeometryBasics.GLTriangleFace(1, 2, 3), GeometryBasics.GLTriangleFace(1, 3, 4)]
+        uvs = GeometryBasics.Vec2f[(0, 0), (1, 0), (1, 1), (0, 1)]
+        nrm = [GeometryBasics.Vec3f(-1, 0, 0) for _ in 1:4]
+        plate = GeometryBasics.Mesh(pts, fcs; uv = uvs, normal = nrm)
+        mesh!(scene, plate; color = :black, material = screen_material(rebuild_img(fc.scr_img)))
+    else
+        nothing
+    end
+
+    electrons = meshscatter!(scene, [GeometryBasics.Point3f(p...) for p in fc.epos];
+        marker = GeometryBasics.Sphere(GeometryBasics.Point3f(0), 1.0f0),
+        markersize = Vec3f(ST.r_electron_scn), color = :gold, material = gold_electron())
+
+    eye, lookat = fc.cam
+    update_cam!(scene, Vec3f(eye...), Vec3f(lookat...), Vec3f(0, 0, 1))
+
+    return (; scene, pulse_plots, rad_plots, pulse_vol_plot, rad_vol_plot,
+        screen_plot, electrons)
+end
+
+# in-place frame update: mutate plot observables, never rebuild (the RayMakie
+# capability RPRMakie lacks)
+function update_scene!(S, fc)
+    if S.pulse_plots !== nothing
+        for i in (1, 2)
+            S.pulse_plots[i].mesh[] = mesh_or_null(rebuild_mesh(fc.pulse_meshes[i]))
+            S.pulse_plots[i].material[] =
+                glassglow(pulse_colors[i]; emis = emis_scale, fade = fc.pf)
+        end
+    end
+    if S.rad_plots !== nothing
+        for i in (1, 2)
+            S.rad_plots[i].mesh[] = mesh_or_null(rebuild_mesh(fc.rad_meshes[i]))
+        end
+    end
+    S.pulse_vol_plot !== nothing && fc.pulse_vol !== nothing &&
+        (S.pulse_vol_plot.material[] = vol_boundary_mat(fc.pulse_vol, ST.pulse_vol_bounds;
+            le_scale = vol_le * emis_scale * (1 - fc.pf), colors = pulse_colors))
+    S.rad_vol_plot !== nothing && fc.rad_vol !== nothing &&
+        (S.rad_vol_plot.material[] = vol_boundary_mat(fc.rad_vol, ST.rad_vol_bounds))
+    S.screen_plot !== nothing && fc.scr_img !== nothing &&
+        (S.screen_plot.material[] = screen_material(rebuild_img(fc.scr_img)))
+    Makie.update!(S.electrons; arg1 = [GeometryBasics.Point3f(p...) for p in fc.epos])
+    eye, lookat = fc.cam
+    update_cam!(S.scene, Vec3f(eye...), Vec3f(lookat...), Vec3f(0, 0, 1))
+    return S
+end
+
+SCENE_STATE = Ref{Any}(nothing)
+function render_frame(fc, outpath)
+    S = SCENE_STATE[]
+    if S === nothing || !reuse_scene
+        S = build_scene(fc)
+        SCENE_STATE[] = S
+    else
+        update_scene!(S, fc)
+    end
+    t_render = @elapsed img = Makie.colorbuffer(S.scene; backend = RayMakie,
+        device = DEVICE, integrator, exposure, tonemap, gamma, update = false)
+    save(outpath, img)
+    return t_render
+end
+
+# ── Entry: single still (EDM_RAY_T) or frame range (EDM_RAY_FRAMES) ──
+frames_spec = get(ENV, "EDM_RAY_FRAMES", "")
+if get(ENV, "EDM_RAY_ENTRY", "1") == "0"
+    @info "EDM_RAY_ENTRY=0 — loaded as library, no render"
+elseif isempty(frames_spec)
+    for tT in parse.(Float64, split(get(ENV, "EDM_RAY_T", "0.0"), ","))
+        payload = joinpath(cache_dir, @sprintf("still_t%+.2f.jls", tT))
+        outfile = get(ENV, "EDM_RAY_OUT",
+            joinpath(@__DIR__, @sprintf("ray_t%+.2f.png", tT)))
+        @info "rendering still t = $tT T0 from $payload ($spp spp, hw_accel=$hw_accel)"
+        fc = load_payload(payload)
+        tr = render_frame(fc, outfile)
+        @info "rendered in $(round(tr; digits = 1)) s — saved $outfile"
+    end
+else
+    rng = frames_spec == "all" ? (1:length(ST.play_times)) :
+        (:)(parse.(Int, split(frames_spec, ":"))...)
+    outdir = get(ENV, "EDM_RAY_OUTDIR", joinpath(@__DIR__, "ray_frames"))
+    mkpath(outdir)
+    @info "rendering frames $(first(rng))..$(last(rng)) into $outdir"
+    total = 0.0
+    done = 0
+    for i in rng
+        outpath = joinpath(outdir, @sprintf("ray_%04d.png", i))
+        isfile(outpath) && continue   # resumable
+        fc = load_payload(joinpath(cache_dir, @sprintf("frame_%04d.jls", i)))
+        tr = render_frame(fc, outpath)
+        done += 1
+        total += tr
+        eta = (length(rng) - (i - first(rng) + 1)) * total / done
+        @info @sprintf("frame %d/%d  t = %+.2f T0  %.1f s  (mean %.1f s, ETA %.0f min)",
+            i, last(rng), fc.t / ST.T0, tr, total / done, eta / 60)
+    end
+    @info "done: $done frames rendered"
+end

--- a/animation/raymakie/thomson_ray.jl
+++ b/animation/raymakie/thomson_ray.jl
@@ -122,10 +122,21 @@ emissive_mat(c; scale = 1.0f0, two_sided = true) =
     Hikari.MediumInterface(Hikari.Emissive(; Le = (c.r, c.g, c.b), scale, two_sided))
 
 # tinted glass: transmission carries the lobe color, reflections lightly tinted
-# (the RPR recipe: reflection_color = 0.3 + 0.7c)
-tinted_glass(c) = Hikari.Dielectric(
-    Kr = spec(RGBf(0.3f0 + 0.7f0 * c.r, 0.3f0 + 0.7f0 * c.g, 0.3f0 + 0.7f0 * c.b)),
-    Kt = spec(c), roughness = 0.0f0, index = 1.5f0)
+# (the RPR recipe: reflection_color = 0.3 + 0.7c). The iso-surface sheets are
+# OPEN surfaces — a full Dielectric tracks inside/outside and can TIR-loop to
+# the depth budget on every path, so EDM_RAY_GLASS picks the interface model:
+#   dielectric  index-1.5 glass (Fresnel + refraction; slowest, deepest look)
+#   thin        ThinDielectric — pbrt's thin-surface model, RPR's
+#               refraction_thin_surface=true equivalent (untinted)
+#   interface   index-1.0 tinted pass-through (no bend, no TIR; fastest)
+glass_kind = get(ENV, "EDM_RAY_GLASS", "dielectric")
+tinted_glass(c) =
+    glass_kind == "thin" ? Hikari.ThinDielectric(eta = 1.5f0) :
+    glass_kind == "interface" ? Hikari.Dielectric(
+        Kr = Hikari.RGBSpectrum(0.0f0), Kt = spec(c), roughness = 0.0f0, index = 1.0f0) :
+    Hikari.Dielectric(
+        Kr = spec(RGBf(0.3f0 + 0.7f0 * c.r, 0.3f0 + 0.7f0 * c.g, 0.3f0 + 0.7f0 * c.b)),
+        Kt = spec(c), roughness = 0.0f0, index = 1.5f0)
 
 # glassglow: ONE node — glass BSDF + folded area-light emission
 function glassglow(c; emis = 1.0f0, glow = glow_w, fade = 0.0f0)

--- a/animation/raymakie/thomson_ray.jl
+++ b/animation/raymakie/thomson_ray.jl
@@ -73,8 +73,14 @@ rad_colors = let s = get(ENV, "EDM_RAY_RAD_COLORS", "1.0,0.75,0.2;0.55,0.3,0.9")
     a, b = split(s, ";")
     (RGBf(parse.(Float32, split(a, ","))...), RGBf(parse.(Float32, split(b, ","))...))
 end
-vol_le = parse(Float32, get(ENV, "EDM_RAY_VOL_LE", "4.0"))
-vol_sigma = parse(Float32, get(ENV, "EDM_RAY_VOL_SIGMA", "8.0"))
+vol_le = parse(Float32, get(ENV, "EDM_RAY_VOL_LE", "2.0"))
+vol_sigma = parse(Float32, get(ENV, "EDM_RAY_VOL_SIGMA", "6.0"))
+vol_floor = parse(Float32, get(ENV, "EDM_RAY_VOL_FLOOR", "0.2"))
+vol_gamma = parse(Float32, get(ENV, "EDM_RAY_VOL_GAMMA", "1.5"))
+# the pulse envelope core sits at |s|≈1 over a large volume (unlike the thin
+# radiation crests) — cut it at the mesh look's ±0.5 isolevel or it saturates
+pulse_vol_floor = parse(Float32, get(ENV, "EDM_RAY_PULSE_VOL_FLOOR", "0.45"))
+pulse_vol_le = parse(Float32, get(ENV, "EDM_RAY_PULSE_VOL_LE", "1.0"))
 exposure = parse(Float32, get(ENV, "EDM_RAY_EXPOSURE", "1.0"))
 tonemap = Symbol(get(ENV, "EDM_RAY_TONEMAP", "aces"))
 gamma = parse(Float32, get(ENV, "EDM_RAY_GAMMA", "2.2"))
@@ -149,25 +155,34 @@ end
 gold_electron() = Hikari.Gold(roughness = electron_rough)
 flat_mat(c) = Hikari.Diffuse(Kd = spec(c))
 satin_mat(c) = Hikari.CoatedDiffuse(reflectance = spec(c), roughness = 0.45f0)
-transparent_boundary() = Hikari.Dielectric(
-    Kr = Hikari.RGBSpectrum(0.0f0), Kt = Hikari.RGBSpectrum(1.0f0), index = 1.0f0)
+# pbrt "interface" semantics — a Dielectric boundary (even Kr=0/Kt=1/index=1)
+# makes SHADOW rays treat the cube as opaque and paints it as a shadowed block
+# (see RayMakie plots/volume.jl); NullMaterial only fires the medium swap
+transparent_boundary() = Hikari.NullMaterial()
 
-# signed volume → emissive RGBGridMedium: ± lobes in the given palette,
-# emission and absorption ∝ |s| (pbrt: volumetric Le contributes as σ_a·Le)
-function signed_medium(s, bounds; le_scale = vol_le, sigma = vol_sigma, colors = rad_colors)
+# signed volume → emissive RGBGridMedium: ± wavefront crests in the given
+# palette. Only |s| above vol_floor participates — pbrt's volumetric emission
+# contributes as σ_a·Le, and without the cut the box-filling numerical floor
+# goes optically thick over the ~30 sw domain (renders as a white fog block).
+function signed_medium(s, bounds; le_scale = vol_le, sigma = vol_sigma,
+        colors = rad_colors, floor = vol_floor, gamma = vol_gamma)
     dims = size(s)
     σ_a = Array{Hikari.RGBSpectrum, 3}(undef, dims)
     Le = Array{Hikari.RGBSpectrum, 3}(undef, dims)
+    # σ_s_grid=nothing is mishandled upstream (whole box renders as uniform
+    # fog — see mwe_medium.jl); an explicit zero grid restores emission-only
+    σ_s = fill(Hikari.RGBSpectrum(0.0f0), dims)
     pos, neg = colors
     @inbounds for i in eachindex(s)
         v = s[i]
         a = abs(v)
+        w = a <= floor ? 0.0f0 : ((a - floor) / (1 - floor))^gamma
         c = v ≥ 0 ? pos : neg
-        σ_a[i] = Hikari.RGBSpectrum(a)
-        Le[i] = Hikari.RGBSpectrum(a * c.r, a * c.g, a * c.b)
+        σ_a[i] = Hikari.RGBSpectrum(w)
+        Le[i] = Hikari.RGBSpectrum(w * c.r, w * c.g, w * c.b)
     end
     bmin, bmax = bounds
-    Hikari.RGBGridMedium(; σ_a_grid = σ_a, Le_grid = Le,
+    Hikari.RGBGridMedium(; σ_a_grid = σ_a, σ_s_grid = σ_s, Le_grid = Le,
         sigma_scale = sigma, Le_scale = le_scale, g = 0.0f0,
         bounds = Hikari.Bounds3(GeometryBasics.Point3f(bmin...), GeometryBasics.Point3f(bmax...)))
 end
@@ -270,15 +285,18 @@ function build_scene(fc)
     # volume variants: emissive media inside transparent boxes
     pulse_vol_plot = if pulse_style3d == "volume" && fc.pulse_vol !== nothing
         bmin, bmax = ST.pulse_vol_bounds
-        mesh!(scene, Rect3f(Point3f(bmin...), Vec3f((bmax .- bmin)...));
+        mesh!(scene,
+            GeometryBasics.normal_mesh(Rect3f(Point3f(bmin...), Vec3f((bmax .- bmin)...)));
             material = vol_boundary_mat(fc.pulse_vol, ST.pulse_vol_bounds;
-                le_scale = vol_le * emis_scale * (1 - fc.pf), colors = pulse_colors))
+                le_scale = pulse_vol_le * emis_scale * (1 - fc.pf), colors = pulse_colors,
+                floor = pulse_vol_floor, gamma = 2.0f0))
     else
         nothing
     end
     rad_vol_plot = if rad_style3d == "volume" && fc.rad_vol !== nothing
         bmin, bmax = ST.rad_vol_bounds
-        mesh!(scene, Rect3f(Point3f(bmin...), Vec3f((bmax .- bmin)...));
+        mesh!(scene,
+            GeometryBasics.normal_mesh(Rect3f(Point3f(bmin...), Vec3f((bmax .- bmin)...)));
             material = vol_boundary_mat(fc.rad_vol, ST.rad_vol_bounds))
     else
         nothing
@@ -326,7 +344,8 @@ function update_scene!(S, fc)
     end
     S.pulse_vol_plot !== nothing && fc.pulse_vol !== nothing &&
         (S.pulse_vol_plot.material[] = vol_boundary_mat(fc.pulse_vol, ST.pulse_vol_bounds;
-            le_scale = vol_le * emis_scale * (1 - fc.pf), colors = pulse_colors))
+            le_scale = pulse_vol_le * emis_scale * (1 - fc.pf), colors = pulse_colors,
+                floor = pulse_vol_floor, gamma = 2.0f0))
     S.rad_vol_plot !== nothing && fc.rad_vol !== nothing &&
         (S.rad_vol_plot.material[] = vol_boundary_mat(fc.rad_vol, ST.rad_vol_bounds))
     S.screen_plot !== nothing && fc.scr_img !== nothing &&


### PR DESCRIPTION
## What

Evaluates **RayMakie + Hikari** (Julia-native spectral path tracing over Vulkan/Lava, from the RayDemo repo's dev branches) as a replacement for the RPRMakie/HybridPro animation pipeline. Adds `animation/raymakie/`: a render-only env, a physics-side payload precompute (`precompute_frames.jl`, runs in the `animation` env), the renderer (`thomson_ray.jl`, mesh|volume styles, scene reuse via observables, `EDM_RAY_*` knobs), measurement sweeps, and `NOTES.md` with the full verdict.

## Why a two-process split

Hikari pins StructArrays 0.6 while SciMLBase 3 needs StructArrays 0.7 (via RecursiveArrayTools 4) — the physics stack and the ray stack cannot resolve into one env. Payloads cross the boundary as plain tuples/arrays.

## Headline numbers (W7900, RADV, 1280×960)

| configuration | per frame |
|---|---|
| RPR HybridPro production (700 iter) | 10–15 s + 1.7 GB/frame leak → 16-frame chunked processes |
| **RayMakie volume style, SW BVH, 64 spp** | **3.5 s, single process, no leak** (61-frame clip) |
| RayMakie volume style, HW RT | 6.3 s (works, but volume cost dominates) |
| RayMakie mesh style | not viable today: 209 s BLAS build / 2282 s observable mesh swap |

Volume mode renders the radiation cube + analytic pulse as **true emissive media** (`RGBGridMedium` from raw Julia arrays) — the thing RPR segfaults on — and the emission genuinely lights the room. Static mesh-style port reproduces the locked look closely on first try (stills in `animation/raymakie/`, vs `rpr_frames_v3`).

## Upstream bugs found (reproducers included)

1. `RGBGridMedium(σ_s_grid=nothing)` renders the whole bounding box as uniform fog (`mwe_medium.jl`); explicit zero grid fixes it
2. Observable mesh swap ~10× slower than a full scene rebuild (2282 s vs 209 s, ~1.6 M tris)
3. `hw_accel=true` DEVICE_LOSTs on multi-million-triangle BLAS builds (fine on small scenes)

## Verdict

Adopt for the volume look after a human lookdev pass (mapping knobs are in place; cores still trend white and grading isn't matched to the locked RPR level). Keep `rpr_frames_v3` as the shipped mesh-style render. Details + remaining work in `animation/raymakie/NOTES.md`.

Headless recipe (no X session): `kwin_wayland --virtual --socket=wayland-edm` + `WAYLAND_DISPLAY=wayland-edm JULIA_GLFW_PLATFORM=wayland` (GLFW.jl hardcodes X11 on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
