### PR TITLE
Productionize the R2 cube pipeline (auto-drain, teardown gate, puller service)

### DIFF
--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -1,0 +1,43 @@
+# orchestration/
+
+Portable campaign framework: a campaign is pure data (`campaigns/*.sh`), `run_cell.sh` is the
+shared core, `backends/` decides where cells run (local GPU / SLURM / Hot Aisle / RunPod).
+Machine infra lives in the gitignored `config.env`; secrets stay under `~/.config`.
+
+## R2 cube pipeline
+
+Field cubes (`field_*.jls`, ~86 GB each) are too big for any ssh path off a cloud VM
+(OpenSSH's channel window pins every stream at ~12–16 MB/s). Instead they ride a Cloudflare
+R2 bucket (`simulation-storage`, multipart HTTPS at NIC speed) with end-to-end sha256
+verification:
+
+- **VM side** — `cube_drain_r2.sh`: watches `~/EDM/runs/*/field_*.jls`, uploads each cube
+  (+ `.sha256` sidecar) once its `<uuid>.reduced` marker exists, drops `.drained_<basename>`
+  sentinels. The hotaisle/runpod backends auto-start it on campaign launch when the campaign
+  sets `KEEP_CUBE=1` (copied to the VM's `$HOME` first, so a branch sync can't yank it).
+- **Teardown gate** — both cloud backends refuse `teardown` while any drain-eligible cube
+  lacks its `.drained_` sentinel (the VM disk is the only copy). `FORCE_TEARDOWN=1` overrides.
+- **Archive side** — `cube_pull_r2.sh`: downloads each cube, verifies against the VM-computed
+  sha256, and only then frees the bucket slot (`purge`). R2 egress is free, so a failed
+  verify re-pulls at zero cost.
+
+### Archive-box setup (once)
+
+1. Credentials: write `~/.config/edm-r2.env` (same file the drain side ships to VMs) with the
+   `RCLONE_CONFIG_R2_*` exports for a bucket-scoped R2 API token — see the header of
+   `cube_drain_r2.sh` for the exact variables. Bucket-scoped tokens can't `ListBuckets`,
+   which is why every rclone call in these scripts carries `--s3-no-check-bucket`.
+2. rclone: any install works; `~/bin/rclone` is found even from non-interactive shells, or
+   point `RCLONE=/path/to/rclone` at it.
+3. Destination: pick `PULL_DEST` (e.g. `/storage/pool/smc/edm_cubes`).
+4. Run the puller as a systemd user service:
+
+   ```sh
+   mkdir -p ~/.config/systemd/user
+   cp orchestration/cube_pull_r2.service ~/.config/systemd/user/
+   systemctl --user daemon-reload
+   systemctl --user edit cube_pull_r2      # override PULL_DEST / ExecStart repo path if needed
+   systemctl --user enable --now cube_pull_r2
+   loginctl enable-linger "$USER"          # keep it running with no login session
+   journalctl --user -u cube_pull_r2 -f    # watch it work
+   ```

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -124,6 +124,56 @@ download_verify() {
     return 1
 }
 
+# Cube drainer (R2): when the campaign keeps cubes, run cube_drain_r2.sh ON the VM so uploads
+# overlap the remaining compute. Script + creds are copied OUT of the repo clone — a later branch
+# sync on a reused VM must not yank a running drainer. Idempotent (pgrep guard); rc>0 ⇒ caller
+# alerts, but a missing drainer never blocks the campaign (the teardown gate still holds cubes).
+start_drainer() {
+    [ "${KEEP_CUBE:-0}" = 1 ] || return 0
+    local envf="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"
+    [ -f "$envf" ] || { log "[drain] $envf missing — no R2 creds to ship"; return 1; }
+    ssh_vm 'mkdir -p ~/.config && cat > ~/.config/edm-r2.env && chmod 600 ~/.config/edm-r2.env' < "$envf" || return 1
+    ssh_vm 'cat > ~/cube_drain_r2.sh' < "$ORCH/cube_drain_r2.sh" || return 1
+    # guard is its OWN ssh call: bundled with the nohup start, the remote shell's cmdline would
+    # contain the plain script name and pgrep would always self-match (drainer never starts)
+    if ! ssh_vm "pgrep -f '[c]ube_drain_r2.sh' >/dev/null" 2>/dev/null; then
+        ssh_vm 'nohup bash ~/cube_drain_r2.sh >> ~/drain_r2.log 2>&1 < /dev/null &' || return 1
+    fi
+    log "[drain] cube_drain_r2.sh running on the VM (log: ~/drain_r2.log)"
+}
+
+# Cube-safety gate: teardown deletes the VM's disk — the ONLY copy of an undrained cube. Refuse
+# while any drain-eligible cube (has its <uuid>.reduced marker, the drainer's own contract; smoke
+# excluded likewise) lacks a .drained_ sentinel. FORCE_TEARDOWN=1 overrides.
+cube_gate() {
+    local pending rc=0
+    pending=$(ssh_vm 'bash -s' 2>/dev/null <<'GATE'
+for cube in "$HOME"/EDM/runs/*/field_*.jls; do
+    [ -e "$cube" ] || continue
+    dir=$(dirname "$cube"); camp=$(basename "$dir"); base=$(basename "$cube")
+    uuid=${base%.jls}; uuid=${uuid##*_}
+    [ "$camp" = smoke ] && continue
+    [ -e "$dir/$uuid.reduced" ] || continue
+    [ -e "$dir/.drained_$base" ] || echo "$camp/$base"
+done
+GATE
+    ) || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        log "[gate] cube check failed (ssh rc=$rc) — cannot verify drains; proceeding (nothing to save over dead ssh)"
+        return 0
+    fi
+    [ -z "$pending" ] && return 0
+    if [ "${FORCE_TEARDOWN:-0}" = 1 ]; then
+        log "[gate] FORCE_TEARDOWN=1 — destroying despite undrained cubes:"; echo "$pending" | sed 's/^/  /'
+        return 0
+    fi
+    log "[gate] REFUSING teardown — undrained cubes on $NAME (the VM holds the only copy):"
+    echo "$pending" | sed 's/^/  /'
+    log "[gate] wait for the drainer (tail ~/drain_r2.log on the VM), or override: FORCE_TEARDOWN=1 $0 teardown"
+    notify rotating_light urgent "EDM teardown BLOCKED" "$NAME: undrained cubes — $(echo "$pending" | tr '\n' ' '); drainer still working? FORCE_TEARDOWN=1 to override."
+    exit 1
+}
+
 run_campaign() {
     local cf="${1:?usage: hotaisle.sh run <campaign.sh>}" cname; cname=$(basename "$cf")
     . "$cf"   # CAMPAIGN (for product paths); the same file is re-read on the VM
@@ -153,6 +203,7 @@ run_campaign() {
     # it here or every julia invocation dies rc=127. The { …; } grouping keeps the pidfile write INSIDE
     # the cd (a bare `A && B & C` backgrounds A&&B and runs C in the ssh cwd = $HOME).
     ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
+    start_drainer || notify warning high "EDM drainer NOT started" "$CAMPAIGN on $NAME: cubes stay on the VM only; teardown gate will hold them"
     log "polling for completion (DONE marker, or driver-death = crash so we don't poll forever while billing)…"
     until ssh_vm "grep -q '\\] ${CAMPAIGN} DONE' EDM/runs/${CAMPAIGN}.out 2>/dev/null"; do
         if ! ssh_vm "kill -0 \$(cat EDM/runs/${CAMPAIGN}.pid 2>/dev/null) 2>/dev/null"; then
@@ -176,6 +227,7 @@ run_campaign() {
 teardown() {
     [ -f "$STATE" ] || { echo "no kept VM recorded in $STATE"; exit 0; }
     read -r NAME IP PROV_TS MIN_MIN < "$STATE"
+    cube_gate
     local min_s=$(( ${MIN_MIN:-1} * 60 )) el=$(( $(date +%s) - ${PROV_TS:-$(date +%s)} ))
     if [ "$el" -lt "$min_s" ]; then
         log "waiting $(( (min_s - el + 59) / 60 )) min to reach the ${MIN_MIN}-min reservation minimum (billed either way; Ctrl-C to delete now)"

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -220,6 +220,57 @@ download_verify() {   # md5 each non-cube product pod-vs-local (subdirs included
     notify rotating_light high "EDM download CHECK FAILED" "$CAMPAIGN: md5 mismatch/missing → $dst"; return 1
 }
 
+# Cube drainer (R2): mirrors hotaisle.sh — copy script + creds OUT of the repo clone (a branch
+# sync must not yank a running drainer), pgrep-guarded nohup start, only when the campaign sets
+# KEEP_CUBE=1. rc>0 ⇒ caller alerts; a missing drainer never blocks (the teardown gate holds cubes).
+start_drainer() {
+    [ "${KEEP_CUBE:-0}" = 1 ] || return 0
+    local envf="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"
+    [ -f "$envf" ] || { log "[drain] $envf missing — no R2 creds to ship"; return 1; }
+    ssh_vm 'mkdir -p ~/.config && cat > ~/.config/edm-r2.env && chmod 600 ~/.config/edm-r2.env' < "$envf" || return 1
+    ssh_vm 'cat > ~/cube_drain_r2.sh' < "$ORCH/cube_drain_r2.sh" || return 1
+    # guard is its OWN ssh call: bundled with the nohup start, the remote shell's cmdline would
+    # contain the plain script name and pgrep would always self-match (drainer never starts)
+    if ! drainer_active; then
+        ssh_vm 'nohup bash ~/cube_drain_r2.sh >> ~/drain_r2.log 2>&1 < /dev/null &' || return 1
+    fi
+    log "[drain] cube_drain_r2.sh running on the pod (log: ~/drain_r2.log)"
+}
+# check-only remote cmdline carries just the [c]-bracketed pattern — no self-match
+drainer_active() { ssh_vm "pgrep -f '[c]ube_drain_r2.sh' >/dev/null" 2>/dev/null; }
+
+# Cube-safety gate: pod deletion destroys pod-local disk — the ONLY copy of an undrained cube
+# (volume-backed runs are exempt: teardown keeps the volume). Same eligibility contract as the
+# drainer (<uuid>.reduced present, smoke excluded). FORCE_TEARDOWN=1 overrides.
+cube_gate() {
+    local pending rc=0
+    pending=$(ssh_vm 'bash -s' 2>/dev/null <<'GATE'
+for cube in "$HOME"/EDM/runs/*/field_*.jls; do
+    [ -e "$cube" ] || continue
+    dir=$(dirname "$cube"); camp=$(basename "$dir"); base=$(basename "$cube")
+    uuid=${base%.jls}; uuid=${uuid##*_}
+    [ "$camp" = smoke ] && continue
+    [ -e "$dir/$uuid.reduced" ] || continue
+    [ -e "$dir/.drained_$base" ] || echo "$camp/$base"
+done
+GATE
+    ) || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        log "[gate] cube check failed (ssh rc=$rc) — cannot verify drains; proceeding (nothing to save over dead ssh)"
+        return 0
+    fi
+    [ -z "$pending" ] && return 0
+    if [ "${FORCE_TEARDOWN:-0}" = 1 ]; then
+        log "[gate] FORCE_TEARDOWN=1 — deleting despite undrained cubes:"; echo "$pending" | sed 's/^/  /'
+        return 0
+    fi
+    log "[gate] REFUSING teardown — undrained cubes on $POD (the pod holds the only copy):"
+    echo "$pending" | sed 's/^/  /'
+    log "[gate] wait for the drainer (tail ~/drain_r2.log on the pod), or override: FORCE_TEARDOWN=1 $0 teardown"
+    notify rotating_light urgent "EDM teardown BLOCKED" "pod $POD: undrained cubes — $(echo "$pending" | tr '\n' ' '); drainer still working? FORCE_TEARDOWN=1 to override."
+    exit 1
+}
+
 monitor_and_download() {   # poll for DONE (crash = 3 consecutive dead liveness checks), then download+verify
     log "polling for completion (DONE marker; crash = 3 consecutive failed liveness checks)…"
     local misses=0
@@ -246,8 +297,8 @@ monitor_and_download() {   # poll for DONE (crash = 3 consecutive dead liveness 
         log "campaign done; downloading products via rsync…"
         mkdir -p "$OUT/$CAMPAIGN"
         local -a excl=(--exclude='field_*.jls')
-        if [ "${KEEP_CUBE:-0}" = 1 ] && [ -z "${VOLID:-}" ]; then
-            excl=(); log "  KEEP_CUBE=1 with no volume ⇒ cubes included in the download (bulky!)"
+        if [ "${KEEP_CUBE:-0}" = 1 ] && [ -z "${VOLID:-}" ] && ! drainer_active; then
+            excl=(); log "  KEEP_CUBE=1, no volume, no drainer ⇒ cubes included in the download (bulky!)"
         fi
         /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" ${excl[@]+"${excl[@]}"} root@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
         download_verify "$OUT/$CAMPAIGN" || log "[verify] issues — products still on the pod${VOLID:+ and volume /workspace/runs/$CAMPAIGN}"
@@ -294,6 +345,7 @@ run_campaign() {
         log "launching $CAMPAIGN on the pod via the local backend ($BACKEND), detached…"
         ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && rm -f runs/${CAMPAIGN}.out runs/${CAMPAIGN}.pid && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
     fi
+    start_drainer || notify warning high "EDM drainer NOT started" "$CAMPAIGN on $POD: cubes stay on the pod only; teardown gate will hold them"
     monitor_and_download
 }
 
@@ -301,12 +353,18 @@ attach_campaign() {   # resume monitoring+download after a driver-side interrupt
     local cf="${1:?usage: runpod.sh attach <campaign.sh>}"; . "$cf"
     pod_reachable || { log "[ERROR] no reachable kept pod ($STATE)"; exit 1; }
     log "attached to kept pod $POD ($IP:$PORT) for $CAMPAIGN"
+    start_drainer || notify warning high "EDM drainer NOT started" "$CAMPAIGN on $POD: cubes stay on the pod only; teardown gate will hold them"
     monitor_and_download
 }
 
 teardown() {   # delete the pod (stops GPU billing); a volume, if attached, is KEPT (bills ~\$0.07/GB-mo)
     [ -f "$STATE" ] || { echo "no kept pod recorded in $STATE"; exit 0; }
     read -r POD IP PORT VOLID BACKEND < "$STATE"; [ "$VOLID" = "-" ] && VOLID=""
+    if [ -n "${VOLID:-}" ]; then
+        log "[gate] volume $VOLID attached — cubes persist past the pod, gate skipped"
+    else
+        cube_gate
+    fi
     /usr/bin/ssh -O exit -o ControlPath="$CM" root@"$IP" 2>/dev/null || true
     if rp -X DELETE "$API/pods/$POD" >/dev/null 2>&1; then
         rm -f "$STATE"; ledger "$POD" teardown "${VOLID:+volume=$VOLID kept}"

--- a/orchestration/cube_drain_r2.sh
+++ b/orchestration/cube_drain_r2.sh
@@ -29,14 +29,20 @@
 #   4. rclone on the VM: curl https://rclone.org/install.sh | sudo bash   (or unzip the static
 #      binary into ~/bin — no root needed).
 #
+# Auto-start: the hotaisle/runpod backends copy this script to the VM's $HOME (out of the repo
+# clone, so a branch sync can't yank it mid-run) and nohup it when the campaign sets KEEP_CUBE=1.
+#
 # Env: CUBE_R2_ENV (default ~/.config/edm-r2.env), R2_BUCKET (default simulation-storage),
-#      R2_CONCURRENCY (default 16), R2_CHUNK (default 128M).
+#      R2_CONCURRENCY (default 16), R2_CHUNK (default 128M), RCLONE (default rclone from PATH).
 set -u
+PATH="$HOME/bin:$PATH"   # non-interactive shells miss ~/bin, where the ad-hoc rclone lives
+RCLONE="${RCLONE:-rclone}"
+command -v "$RCLONE" >/dev/null 2>&1 || { echo "[drain-r2] $RCLONE not found (PATH=$PATH) — install rclone or set RCLONE=/path/to/rclone"; exit 1; }
 ENVF="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"
 [ -f "$ENVF" ] || { echo "[drain-r2] $ENVF missing — refusing to start (fall back to cube_drain.sh)"; exit 1; }
 . "$ENVF"
 BUCKET="${R2_BUCKET:-simulation-storage}"
-RC() { rclone --s3-no-check-bucket --s3-upload-concurrency "${R2_CONCURRENCY:-16}" --s3-chunk-size "${R2_CHUNK:-128M}" "$@"; }
+RC() { "$RCLONE" --s3-no-check-bucket --s3-upload-concurrency "${R2_CONCURRENCY:-16}" --s3-chunk-size "${R2_CHUNK:-128M}" "$@"; }
 log() { echo "[drain-r2 $(date -u +%FT%TZ)] $*"; }
 
 log "watching $HOME/EDM/runs (bucket: $BUCKET)"
@@ -52,7 +58,7 @@ while :; do
         # local hash first (~3 min for 86 GB) — becomes the end-to-end reference the puller checks
         sha=$(sha256sum "$cube" | cut -d' ' -f1) || continue
         if RC copyto "$cube" "r2:$BUCKET/cubes/$camp/$uuid/$base" &&
-           echo "$sha  $base" | rclone rcat --s3-no-check-bucket "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256"; then
+           echo "$sha  $base" | RC rcat "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256"; then
             touch "$dir/.drained_$base"; log "uploaded $base (sha256 $sha)"
         else
             log "upload failed for $base — retrying next sweep"

--- a/orchestration/cube_pull_r2.service
+++ b/orchestration/cube_pull_r2.service
@@ -1,0 +1,17 @@
+# cube_pull_r2.service — archive-box side of the R2 cube pipeline as a systemd user unit
+# (setup in orchestration/README.md). The script resolves rclone (~/bin fallback, RCLONE=
+# override) and its creds (~/.config/edm-r2.env) itself; only PULL_DEST and the repo path
+# are machine policy — override via `systemctl --user edit cube_pull_r2`.
+[Unit]
+Description=EDM R2 cube puller (download, sha256-verify, free bucket slots)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Environment=PULL_DEST=/storage/pool/smc/edm_cubes
+ExecStart=/usr/bin/env bash %h/.julia/dev/ElectronDynamicsModels/orchestration/cube_pull_r2.sh
+Restart=always
+RestartSec=60
+
+[Install]
+WantedBy=default.target

--- a/orchestration/cube_pull_r2.sh
+++ b/orchestration/cube_pull_r2.sh
@@ -9,30 +9,34 @@
 #
 # Env: CUBE_R2_ENV (default ~/.config/edm-r2.env — same file as the drain side),
 #      R2_BUCKET (default simulation-storage), PULL_DEST (archive dir),
-#      R2_PULL_STREAMS (default 8 multi-thread download streams).
+#      R2_PULL_STREAMS (default 8 multi-thread download streams), RCLONE (default from PATH).
 set -u
+PATH="$HOME/bin:$PATH"   # non-interactive shells (systemd, ssh -c) miss ~/bin
+RCLONE="${RCLONE:-rclone}"
+command -v "$RCLONE" >/dev/null 2>&1 || { echo "[pull-r2] $RCLONE not found (PATH=$PATH) — install rclone or set RCLONE=/path/to/rclone"; exit 1; }
 ENVF="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"
 [ -f "$ENVF" ] || { echo "[pull-r2] $ENVF missing — refusing to start"; exit 1; }
 . "$ENVF"
 BUCKET="${R2_BUCKET:-simulation-storage}"
+RC() { "$RCLONE" --s3-no-check-bucket "$@"; }   # bucket-scoped tokens can't ListBuckets
 DEST="${PULL_DEST:?set PULL_DEST (archive dir on this machine)}"
 log() { echo "[pull-r2 $(date -u +%FT%TZ)] $*"; }
 mkdir -p "$DEST"
 
 while :; do
-    rclone lsf -R --files-only "r2:$BUCKET/cubes/" 2>/dev/null | grep '\.jls$' |
+    RC lsf -R --files-only "r2:$BUCKET/cubes/" 2>/dev/null | grep '\.jls$' |
     while IFS= read -r rel; do   # rel = <campaign>/<uuid>/<file>.jls
         camp=${rel%%/*}; rest=${rel#*/}; uuid=${rest%%/*}; base=${rest#*/}
         [ -e "$DEST/$camp/.verified_$base" ] && continue
         mkdir -p "$DEST/$camp"
         log "$camp/$base ← r2"
-        rclone copyto --multi-thread-streams "${R2_PULL_STREAMS:-8}" \
+        RC copyto --multi-thread-streams "${R2_PULL_STREAMS:-8}" \
             "r2:$BUCKET/cubes/$rel" "$DEST/$camp/$base" || { log "download failed $base — next sweep"; continue; }
-        want=$(rclone cat "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256" 2>/dev/null | cut -d' ' -f1)
+        want=$(RC cat "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256" 2>/dev/null | cut -d' ' -f1)
         have=$(sha256sum "$DEST/$camp/$base" | cut -d' ' -f1)
         if [ -n "$want" ] && [ "$want" = "$have" ]; then
             touch "$DEST/$camp/.verified_$base"
-            rclone purge "r2:$BUCKET/cubes/$camp/$uuid" && log "verified end-to-end + freed: $camp/$base"
+            RC purge "r2:$BUCKET/cubes/$camp/$uuid" && log "verified end-to-end + freed: $camp/$base"
         else
             log "VERIFY FAILED $base (want=${want:-none} have=$have) — keeping bucket copy"
         fi


### PR DESCRIPTION
Productionizes the R2 cube pipeline after this week's campaign ops, turning every manual step (and failure) into code.

## What changed

**`cube_drain_r2.sh` / `cube_pull_r2.sh` — rclone resolution hardening**
- Non-interactive shells miss `~/bin` (where the ad-hoc rclone lives) — the manually ssh-started drainer died with `rclone: command not found`. Both scripts now prepend `~/bin` to PATH, honor an `RCLONE=/path/to/rclone` override, and refuse loudly (printing the searched PATH) when nothing resolves.
- The pull side now routes every rclone call through an `RC()` wrapper carrying `--s3-no-check-bucket` (bucket-scoped tokens can't ListBuckets), matching the drain side.

**`backends/hotaisle.sh` + `backends/runpod.sh` — drainer auto-start**
- After the campaign launches, the driver ships `~/.config/edm-r2.env` + `cube_drain_r2.sh` to the VM's `$HOME` (out of the repo clone, so a branch sync on a reused VM can't yank a running drainer) and nohup-starts it, logging to `~/drain_r2.log`.
- Gated on the campaign setting `KEEP_CUBE=1` (the campaign file is already sourced by `run_campaign`, so no grep needed). Why gated rather than always-on: without `KEEP_CUBE` cubes are deleted after reduce so there's nothing to drain; the drainer refuses to run without R2 creds, so always-on would turn every cube-less campaign into a spurious alert; and there's no reason to ship R2 write creds to VMs that never produce cubes.
- Idempotent via a pgrep guard — as its **own** ssh call. Bundling guard + nohup start in one remote command makes the remote shell's cmdline contain the plain script name, so `pgrep -f '[c]ube_drain_r2.sh'` always self-matches and the drainer never starts (caught and verified locally during this work).
- A failed drainer start alerts via ntfy but never blocks the campaign — the teardown gate below is the backstop.
- RunPod extras: drainer also started on `attach`; the "no volume ⇒ include cubes in the rsync download" fallback now only fires when no drainer is running (rsync at 12–16 MB/s is exactly what R2 replaced).

**Teardown gate (both cloud backends)**
- `teardown` now refuses (before the reservation-minimum wait) while any drain-eligible cube — has its `<uuid>.reduced` marker, `smoke` excluded, i.e. exactly the drainer's contract — lacks its `.drained_` sentinel, since the VM disk holds the only copy. It prints the pending list, pings ntfy, and documents the `FORCE_TEARDOWN=1` override.
- If ssh is unreachable the gate logs and proceeds: nothing can be saved over dead ssh, and blocking would only burn money on a dead VM.
- RunPod skips the gate when a network volume is attached (cubes persist past the pod).

**Puller as a service**
- `orchestration/cube_pull_r2.service`: systemd user unit (`Restart=always`, `PULL_DEST` via drop-in override), plus a new `orchestration/README.md` documenting the pipeline contract and the one-time archive-box setup (creds env file, rclone, `PULL_DEST`, `enable --now`, linger).

## Verification
- `bash -n` + shellcheck on all four scripts (remaining findings are pre-existing patterns or style-only).
- Gate logic exercised against a fake runs tree (eligible-undrained flagged; drained / un-reduced / smoke correctly skipped).
- Drain script exercised end-to-end with a stub rclone: `~/bin` resolution from a bare PATH, upload + sha256 sidecar + sentinel; refusal paths for missing rclone and bad `RCLONE=` override.
- pgrep guard semantics verified (bundled form self-matches; split form starts once and holds).

No VMs were started; nothing touched the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn5htwc8e3JAe2iVhALLXh