### PR TITLE
Hot Aisle GPU availability watcher + mini dashboard

### DIFF
--- a/orchestration/README-availability.md
+++ b/orchestration/README-availability.md
@@ -1,0 +1,54 @@
+# Hot Aisle availability watcher
+
+Standalone section until `orchestration/README.md` lands on main (PR #42); fold it in there afterwards.
+
+Polls the Hot Aisle offerings list every 5 min and logs which GPU specs are on offer, so
+capacity gaps become visible over time and a returning 1×MI300X fires an ntfy ping.
+`GET /virtual_machines/available/` is read-only and free — polling never provisions anything;
+an absent spec (e.g. no 1×MI300X row) means out of capacity right now.
+
+- `hotaisle_availability.sh` — one poll: appends one TSV row per offering to
+  `${AVAIL_LOG:-~/.local/share/edm-availability/availability.tsv}`
+  (`ts_utc  model  gpu_count  price_cents_h  min_reserve_min`; price = cents per GPU-hour).
+  `model=none` marks a polled-and-empty list (distinct from watcher downtime), `model=error`
+  a failed poll. On a 1×MI300X absent→available transition it notifies via the existing
+  campaign ntfy creds (`$NTFY_ENV`, default `~/.config/ntfy/edm-campaigns.env`) with the
+  price and how long the spec was gone.
+- `availability_report.sh [--log FILE] [--days N] [--html FILE]` — summary table
+  (current state, last seen, availability fraction 24h/7d, median gap) to stdout, or with
+  `--html` a self-contained page: a timeline strip per spec (blank = watcher down), the
+  summary table, and a list-price chart when the price varied.
+
+## Setup (systemd user timer)
+
+```sh
+cp orchestration/hotaisle_availability.sh ~/.local/bin/edm-hotaisle-availability
+chmod +x ~/.local/bin/edm-hotaisle-availability
+cp orchestration/edm-hotaisle-availability.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now edm-hotaisle-availability.timer
+loginctl enable-linger   # or the timer dies on logout
+```
+
+Config (all outside git): the Hot Aisle API token at `~/.config/hotaisle/token` (0600,
+per-machine — mint one in the TUI at `ssh admin.hotaisle.app`); the team handle from
+`$HOTAISLE_TEAM`, `config.env` beside the script, `~/.config/hotaisle/env`
+(`HOTAISLE_TEAM=...`) or `~/.config/hotaisle/team` — the installed copy in `~/.local/bin`
+has no `config.env` beside it, so create one of the latter two. ntfy is optional; without
+creds the watcher only logs.
+
+## Publishing the dashboard
+
+On the machine holding `~/.config/research-publish.env` (do not copy those creds around):
+
+```sh
+bash orchestration/availability_report.sh --html /tmp/availability.html \
+  && (source ~/.config/research-publish.env \
+      && rsync -e /usr/bin/ssh --chmod=F644 --no-owner --no-group \
+           /tmp/availability.html "${VPS_HOST}:${VPS_DATA_DIR}/availability.html")
+```
+
+Same destination convention as `costs.html` in the dashboard repo's `research-publish.sh`.
+Like costs.html, the container Caddy needs an explicit handle route for `/availability.html`
+or the SPA answers instead. If the log lives on another machine, rsync the TSV over and pass
+`--log`.

--- a/orchestration/availability_report.sh
+++ b/orchestration/availability_report.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# availability_report.sh — Hot Aisle GPU availability report from the watcher log.
+#
+#   bash orchestration/availability_report.sh [--log FILE] [--days N] [--html FILE]
+#
+# Reads the TSV appended by hotaisle_availability.sh (ts_utc model gpu_count
+# price_cents_h min_reserve_min; model none = polled-and-empty, error = failed poll).
+# Text output: per-spec current state, last seen, availability fraction over 24h/7d,
+# median closed-gap length. --html FILE writes a self-contained page (mirrors
+# cost_report.sh — inline SVG, no CDNs): a timeline strip per spec over the last
+# --days days (default 7; blank = watcher down, i.e. poll gap > 15 min), the summary
+# table, and a list-price chart when the price varied. Plain bash + GNU awk; no network.
+set -euo pipefail
+
+LOG="${AVAIL_LOG:-$HOME/.local/share/edm-availability/availability.tsv}"
+DAYS=7
+HTML_FILE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --log)     LOG=${2:?}; shift 2 ;;
+        --days)    DAYS=${2:?}; shift 2 ;;
+        --html)    HTML_FILE=${2:?}; shift 2 ;;
+        -h|--help) sed -n '2,13p' "$0"; exit 0 ;;
+        *)         echo "unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+[ -f "$LOG" ] || { echo "no availability log at $LOG (watcher not run yet?)" >&2; exit 1; }
+
+run_report() {
+awk -F'\t' -v days="$DAYS" -v html="${HTML_FILE:+1}" '
+function iso(e)  { return strftime("%Y-%m-%dT%H:%MZ", e, 1) }
+function epoch(ts,   t) { t = ts; gsub(/[-:TZ]/, " ", t); return mktime(t, 1) }   # ISO-8601 Z → UTC epoch (gawk)
+function esc(s)  { gsub(/&/, "\\&amp;", s); gsub(/</, "\\&lt;", s); gsub(/>/, "\\&gt;", s); return s }
+function dur(s)  { return (s < 3600) ? int(s/60) "m" : (s < 86400) ? int(s/3600) "h" int(s%3600/60) "m" : int(s/86400) "d" int(s%86400/3600) "h" }
+function usd(c)  { return sprintf("$%.2f", c / 100.0) }
+function median(j,   i, m, t) {   # median of the closed gaps of spec j (g[] filled in order)
+    m = gn[j]; if (m == 0) return "-"
+    for (i = 1; i <= m; i++) t[i] = g[j, i]
+    asort(t)
+    return dur((m % 2) ? t[(m+1)/2] : (t[m/2] + t[m/2+1]) / 2)
+}
+FNR > 1 && NF >= 2 {
+    e = epoch($1)
+    if (e != cur) { cur = e; np++; pt[np] = e }
+    if ($2 == "error") { perr[np] = 1; nerr++; next }
+    if ($2 == "none") next
+    k = $2 " ×" $3
+    if (!(k in ks)) { ks[k] = ++nk; kn[nk] = k }
+    j = ks[k]
+    pres[np, j] = 1; pprice[np, j] = $4; pmin[np, j] = $5
+}
+END {
+    if (np == 0) { print "log has a header but no polls yet" > "/dev/stderr"; exit 1 }
+    now = systime()
+    CAP = 900   # poll gap beyond this = watcher down (3 × the 5-min cadence)
+    for (i = 1; i <= nk; i++) ord[i] = i   # display order: by name (insertion sort, nk is tiny)
+    for (i = 2; i <= nk; i++) {
+        j = ord[i]; m = i - 1
+        while (m > 0 && kn[ord[m]] > kn[j]) { ord[m+1] = ord[m]; m-- }
+        ord[m+1] = j
+    }
+    # ── per-spec stats: window fractions, last-seen, closed gaps ──
+    for (p = 1; p <= np; p++) {
+        if (perr[p]) continue   # unknown — neither an up- nor a down-observation
+        for (j = 1; j <= nk; j++) {
+            up = ((p, j) in pres) ? 1 : 0
+            if (pt[p] >= now -   86400) { t24[j]++; u24[j] += up }
+            if (pt[p] >= now - 7*86400) { t7[j]++;  u7[j]  += up }
+            if (up) {
+                if (sawdown[j]) g[j, ++gn[j]] = pt[p] - lastup[j]
+                lastup[j] = pt[p]; sawdown[j] = 0
+                lastprice[j] = pprice[p, j]; lastmin[j] = pmin[p, j]
+            } else if (j in lastup) sawdown[j] = 1
+        }
+    }
+    for (p = 1; p < np; p++)   # watcher downtime = gaps between polls beyond CAP
+        if (pt[p+1] - pt[p] > CAP) { wd_n++; wd_s += pt[p+1] - pt[p] }
+    for (j = 1; j <= nk; j++) {   # current state string per spec
+        if      (perr[np])       snow[j] = "error (last poll)"
+        else if ((np, j) in pres) snow[j] = "UP @" pprice[np, j] "¢/GPU-h"
+        else if (j in lastup)    snow[j] = "out " dur(now - lastup[j])
+        else                     snow[j] = "never seen"
+    }
+    if (html) { html_out(); exit }
+    # ── text output ──
+    printf "== Hot Aisle availability  %s → %s  (%d polls, %d errors) ==\n", iso(pt[1]), iso(pt[np]), np, nerr
+    if (now - pt[np] > CAP) printf "[warn] last poll was %s ago — watcher down?\n", dur(now - pt[np])
+    if (wd_n) printf "watcher downtime: %d poll gaps >15m totalling %s\n", wd_n, dur(wd_s)
+    printf "\n%-13s %-20s %-18s %8s %6s %6s %11s %5s\n", "spec", "now", "last seen", "¢/GPU-h", "24h", "7d", "median gap", "gaps"
+    for (i = 1; i <= nk; i++) {
+        j = ord[i]
+        printf "%-13s %-20s %-18s %8s %6s %6s %11s %5d\n", kn[j], snow[j], \
+               (j in lastup) ? iso(lastup[j]) : "never", (j in lastprice) ? lastprice[j] : "-", \
+               t24[j] ? sprintf("%.1f%%", 100.0*u24[j]/t24[j]) : "-", \
+               t7[j]  ? sprintf("%.1f%%", 100.0*u7[j]/t7[j])  : "-", median(j), gn[j] + 0
+    }
+    if (nk == 0) print "\nno offerings seen yet (every poll so far was empty or an error)"
+}
+function seg(j, y, a, b, st,   x, w, fill, lab) {   # one timeline segment, clipped to [T0,T1]
+    if (a < T0) a = T0
+    if (b > T1) b = T1
+    if (b <= a) return
+    x = GUT + (a - T0) / (T1 - T0) * PW; w = (b - a) / (T1 - T0) * PW
+    if (w < 0.5) w = 0.5
+    fill = (st == 1) ? "var(--up)" : (st == 2) ? "var(--err)" : "var(--down)"
+    lab = (st == 1) ? "available" : (st == 2) ? "API error" : "unavailable"
+    printf "<g><title>%s — %s %s → %s (%s)</title><rect x=\"%.2f\" y=\"%d\" width=\"%.2f\" height=\"%d\" fill=\"%s\"/></g>\n", \
+           esc(kn[j]), lab, iso(a), iso(b), dur(b - a), x, y, w, BH, fill
+}
+function html_out(   i, j, p, y, fh, t0f, st, runst, runa, prevend, sege, tick, step, x, \
+                     havep, pmn, pmx, npts, tv, pv, lastt, py, px, d, nvary, ci, cols) {
+    T1 = now; T0 = now - days * 86400
+    if (T0 < pt[1]) T0 = pt[1]
+    GUT = 110; PW = 590; BH = 16; PITCH = 26
+    print "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+    print "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+    print "<title>Hot Aisle GPU availability</title><style>"
+    print ":root{--ink:#1a1d24;--muted:#6a7284;--border:#dee2ea;--border-2:#c5cad6;--accent:#3b6fb3;"
+    print "--up:#0ca30c;--down:#e6e9ef;--err:#fab219;--upink:#006300;"
+    print "--ui:system-ui,-apple-system,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif;"
+    print "--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,\"Liberation Mono\",monospace}"
+    print "html,body{margin:0;padding:0;background:#fff;color:var(--ink);font-family:var(--ui);font-size:14px;line-height:1.5}"
+    print "main{max-width:960px;margin:0 auto;padding:24px 16px}"
+    print "h1{font-size:20px;margin:0 0 4px} h2{font-size:15px;margin:28px 0 8px}"
+    print ".meta{color:var(--muted);font-family:var(--mono);font-size:11px;margin:0 0 16px}"
+    print ".hero{font-size:16px;margin:14px 0} .hero .up{color:var(--upink);font-weight:600} .hero .out{font-weight:600}"
+    print "table{border-collapse:collapse;width:100%;font-size:13px}"
+    print "th,td{padding:4px 10px;border-bottom:1px solid var(--border);text-align:left;white-space:nowrap}"
+    print "th{color:var(--muted);font-weight:600;border-bottom:1px solid var(--border-2)}"
+    print "td.n,th.n{text-align:right;font-family:var(--mono)}"
+    print ".note{color:var(--muted);font-size:12px;margin-top:6px}"
+    print ".viz{margin:6px 0 10px} .viz svg{width:100%;height:auto;display:block;max-width:760px}"
+    print ".viz text{font-family:var(--ui);font-size:12px}"
+    print ".viz .lab{fill:#6a7284} .viz .tick{fill:#6a7284;font-size:11px}"
+    print ".legend{font-size:12px;color:#6a7284;margin:2px 0 4px}"
+    print ".legend span{margin-right:16px}"
+    print ".sw{display:inline-block;width:10px;height:10px;border-radius:2px;margin-right:6px;vertical-align:-1px}"
+    print "</style></head><body><main>"
+    print "<h1>Hot Aisle GPU availability</h1>"
+    printf "<p class=\"meta\">updated %s &middot; log %s → %s &middot; %d polls (%d errors) every ~5 min &middot; read-only offerings endpoint — absent spec = out of capacity</p>\n", \
+           iso(now), iso(pt[1]), iso(pt[np]), np, nerr
+    # ── headline: the spec campaigns actually provision ──
+    j = ("MI300X ×1" in ks) ? ks["MI300X ×1"] : 0
+    if (j) {
+        if ((np, j) in pres) printf "<p class=\"hero\">1&times;MI300X: <span class=\"up\">AVAILABLE @ %s/GPU-h</span></p>\n", usd(pprice[np, j])
+        else if (j in lastup) printf "<p class=\"hero\">1&times;MI300X: <span class=\"out\">out of capacity for %s</span> (last seen %s)</p>\n", dur(now - lastup[j]), iso(lastup[j])
+    } else print "<p class=\"hero\">1&times;MI300X: <span class=\"out\">never seen in this log</span></p>"
+    # ── timeline strips ──
+    if (nk > 0) {
+        fh = nk * PITCH + 28
+        printf "<h2>Timeline %s → %s</h2>\n", iso(T0), iso(T1)
+        print "<p class=\"legend\"><span><span class=\"sw\" style=\"background:var(--up)\"></span>available</span>" \
+              "<span><span class=\"sw\" style=\"background:var(--down)\"></span>unavailable</span>" \
+              "<span><span class=\"sw\" style=\"background:var(--err)\"></span>API error</span>" \
+              "<span><span class=\"sw\" style=\"background:#fff;border:1px solid var(--border-2)\"></span>blank = watcher down</span></p>"
+        printf "<div class=\"viz\"><svg viewBox=\"0 0 720 %d\" role=\"img\" aria-label=\"Availability timeline per GPU spec\">\n", fh
+        step = (days >= 3) ? 86400 : 21600   # day ticks; 6-hourly for short windows
+        for (tick = int(T0 / step + 1) * step; tick < T1; tick += step) {
+            x = GUT + (tick - T0) / (T1 - T0) * PW
+            printf "<line x1=\"%.1f\" y1=\"4\" x2=\"%.1f\" y2=\"%d\" stroke=\"#eceef3\" stroke-width=\"1\"/>\n", x, x, nk * PITCH + 4
+            printf "<text x=\"%.1f\" y=\"%d\" text-anchor=\"middle\" class=\"tick\">%s</text>\n", x, nk * PITCH + 18, \
+                   (tick % 86400 == 0) ? strftime("%m-%d", tick, 1) : strftime("%Hh", tick, 1)
+        }
+        for (i = 1; i <= nk; i++) {
+            j = ord[i]; y = 4 + (i - 1) * PITCH
+            printf "<text x=\"%d\" y=\"%d\" text-anchor=\"end\" class=\"lab\">%s</text>\n", GUT - 8, y + 12, esc(kn[j])
+            runst = -1; runa = 0; prevend = -1
+            for (p = 1; p <= np; p++) {   # merge contiguous same-state polls into segments
+                if (pt[p] > T1) break
+                sege = (p < np) ? ((pt[p+1] - pt[p] <= CAP) ? pt[p+1] : pt[p] + CAP) \
+                                : ((now - pt[np] <= CAP) ? now : pt[np] + CAP)
+                if (sege < T0) continue
+                st = perr[p] ? 2 : (((p, j) in pres) ? 1 : 0)
+                if (st != runst || pt[p] > prevend) {
+                    if (runst >= 0) seg(j, y, runa, prevend, runst)
+                    runst = st; runa = pt[p]
+                }
+                prevend = sege
+            }
+            if (runst >= 0) seg(j, y, runa, prevend, runst)
+        }
+        print "</svg></div>"
+    } else print "<p class=\"note\">no offerings seen yet — every poll so far returned an empty list or an error.</p>"
+    # ── summary table ──
+    if (nk > 0) {
+        print "<h2>Summary</h2><table><tr><th>spec</th><th>now</th><th>last seen</th><th class=\"n\">$/GPU-h</th><th class=\"n\">min reserve</th><th class=\"n\">avail 24h</th><th class=\"n\">avail 7d</th><th class=\"n\">median gap</th><th class=\"n\">gaps</th></tr>"
+        for (i = 1; i <= nk; i++) {
+            j = ord[i]
+            printf "<tr><td>%s</td><td>%s</td><td class=\"n\">%s</td><td class=\"n\">%s</td><td class=\"n\">%s</td><td class=\"n\">%s</td><td class=\"n\">%s</td><td class=\"n\">%s</td><td class=\"n\">%d</td></tr>\n", \
+                   esc(kn[j]), \
+                   ((np, j) in pres) ? "<span style=\"color:var(--upink);font-weight:600\">available</span>" : (perr[np] ? "unknown (error)" : "out"), \
+                   (j in lastup) ? iso(lastup[j]) : "never", \
+                   ((j in lastprice) && lastprice[j] + 0 > 0) ? usd(lastprice[j]) : "&mdash;", \
+                   ((j in lastmin) && lastmin[j] != "-") ? lastmin[j] " min" : "&mdash;", \
+                   t24[j] ? sprintf("%.1f%%", 100.0*u24[j]/t24[j]) : "&mdash;", \
+                   t7[j]  ? sprintf("%.1f%%", 100.0*u7[j]/t7[j])  : "&mdash;", median(j), gn[j] + 0
+        }
+        print "</table>"
+        print "<p class=\"note\">availability fraction = polls listing the spec / non-error polls in the window; gap = closed unavailable stretch between two sightings; price = OnDemandPrice per GPU-hour.</p>"
+        if (wd_n) printf "<p class=\"note\">watcher downtime: %d poll gaps &gt;15&thinsp;min totalling %s (blank in the timeline).</p>\n", wd_n, dur(wd_s)
+    }
+    # ── list price over time (only if it ever varied) ──
+    pmn = 1e12; pmx = -1
+    for (p = 1; p <= np; p++) for (j = 1; j <= nk; j++)
+        if (((p, j) in pres) && pprice[p, j] + 0 > 0) { d = pprice[p, j] + 0; if (d < pmn) pmn = d; if (d > pmx) pmx = d }
+    if (pmx > pmn) {
+        split("#2a78d6 #008300 #e87ba4 #eda100 #1baf7a #eb6834", cols, " ")   # fixed categorical order (validated palette)
+        PH = 110
+        print "<h2>List price</h2>"
+        printf "<p class=\"legend\">"
+        ci = 0
+        for (i = 1; i <= nk; i++) { j = ord[i]; if (j in lastprice) printf "<span><span class=\"sw\" style=\"background:%s\"></span>%s</span>", cols[(ci++ % 6) + 1], esc(kn[j]) }
+        print "</p>"
+        printf "<div class=\"viz\"><svg viewBox=\"0 0 720 %d\" role=\"img\" aria-label=\"List price per GPU-hour over time\">\n", PH + 30
+        printf "<text x=\"%d\" y=\"14\" text-anchor=\"end\" class=\"tick\">%s</text>\n", GUT - 8, usd(pmx)
+        printf "<text x=\"%d\" y=\"%d\" text-anchor=\"end\" class=\"tick\">%s</text>\n", GUT - 8, PH + 4, usd(pmn)
+        printf "<line x1=\"%d\" y1=\"10\" x2=\"%d\" y2=\"10\" stroke=\"#eceef3\"/>\n", GUT, GUT + PW
+        printf "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"#eceef3\"/>\n", GUT, PH, GUT + PW, PH
+        ci = 0
+        for (i = 1; i <= nk; i++) {   # step line per spec, vertices only where the price changes
+            j = ord[i]; if (!(j in lastprice)) continue
+            npts = 0; pv = ""; lastt = 0
+            printf "<path fill=\"none\" stroke=\"%s\" stroke-width=\"2\" d=\"", cols[(ci++ % 6) + 1]
+            for (p = 1; p <= np; p++) {
+                if (!((p, j) in pres) || pprice[p, j] + 0 <= 0) continue
+                d = pprice[p, j] + 0
+                px = GUT + (pt[p] - pt[1]) / (now - pt[1] + 1) * PW
+                py = PH - (d - pmn) / (pmx - pmn) * (PH - 10)
+                if (npts == 0) printf "M%.1f %.1f", px, py
+                else if (d != pv) printf " H%.1f V%.1f", px, py
+                pv = d; lastt = px; npts++
+            }
+            if (npts > 0) printf " H%.1f", lastt
+            print "\"/>"
+        }
+        printf "<text x=\"%d\" y=\"%d\" class=\"tick\">%s</text><text x=\"%d\" y=\"%d\" text-anchor=\"end\" class=\"tick\">%s</text>\n", \
+               GUT, PH + 16, iso(pt[1]), GUT + PW, PH + 16, iso(now)
+        print "</svg></div>"
+        print "<p class=\"note\">sampled while the spec was offered; flat stretches between sightings are interpolated.</p>"
+    }
+    print "</main></body></html>"
+}' "$LOG"
+}
+
+if [ -n "$HTML_FILE" ]; then
+    tmp="${HTML_FILE}.tmp.$$"
+    run_report > "$tmp" && mv "$tmp" "$HTML_FILE"
+    echo "wrote $HTML_FILE" >&2
+else
+    run_report
+fi

--- a/orchestration/edm-hotaisle-availability.service
+++ b/orchestration/edm-hotaisle-availability.service
@@ -1,0 +1,8 @@
+# EDM Hot Aisle availability poll — installed copy of orchestration/hotaisle_availability.sh
+# (see orchestration/README-availability.md for setup)
+[Unit]
+Description=EDM Hot Aisle GPU availability poll
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/bin/edm-hotaisle-availability

--- a/orchestration/edm-hotaisle-availability.timer
+++ b/orchestration/edm-hotaisle-availability.timer
@@ -1,0 +1,11 @@
+# Poll Hot Aisle offerings every 5 min (see orchestration/README-availability.md)
+[Unit]
+Description=EDM Hot Aisle GPU availability poll timer
+
+[Timer]
+OnCalendar=*:0/5
+RandomizedDelaySec=30
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/orchestration/hotaisle_availability.sh
+++ b/orchestration/hotaisle_availability.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# hotaisle_availability.sh — one Hot Aisle offerings poll → availability TSV (+ ntfy when 1×MI300X returns).
+#
+#   bash orchestration/hotaisle_availability.sh     # driven every 5 min by edm-hotaisle-availability.timer
+#
+# GET /virtual_machines/available/ is READ-ONLY — a free offerings list; polling never provisions.
+# Appends one row per offering to $AVAIL_LOG (default ~/.local/share/edm-availability/availability.tsv):
+#   ts_utc  model  gpu_count  price_cents_h  min_reserve_min      (price = cents per GPU-hour)
+# model=none  → poll OK, list empty (capacity exhausted — distinct from watcher downtime);
+# model=error → poll failed (curl / bad JSON), so error stretches stay visible in the data.
+# A 1×MI300X absent→available transition (vs the previous poll) fires ntfy through the existing
+# campaign creds ($NTFY_ENV): price + how long the spec was gone. Otherwise silent on failures.
+# Team handle stays out of git: $HOTAISLE_TEAM, else config.env beside this script, else
+# ~/.config/hotaisle/env, else ~/.config/hotaisle/team. The token reaches curl only via a -K
+# header file (never argv). Render the log with orchestration/availability_report.sh.
+set -euo pipefail
+
+LOG="${AVAIL_LOG:-$HOME/.local/share/edm-availability/availability.tsv}"
+TOKF="${HOTAISLE_TOKEN_FILE:-$HOME/.config/hotaisle/token}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+[ -z "${HOTAISLE_TEAM:-}" ] && [ -f "$HERE/config.env" ] && . "$HERE/config.env"
+# shellcheck disable=SC1091
+[ -z "${HOTAISLE_TEAM:-}" ] && [ -f "$HOME/.config/hotaisle/env" ] && . "$HOME/.config/hotaisle/env"
+TEAM="${HOTAISLE_TEAM:-$(cat "$HOME/.config/hotaisle/team" 2>/dev/null || true)}"
+[ -n "$TEAM" ] || { echo "no team handle (HOTAISLE_TEAM / config.env / ~/.config/hotaisle/{env,team})" >&2; exit 1; }
+URL="${HOTAISLE_API:-https://admin.hotaisle.app/api/teams}/$TEAM/virtual_machines/available/"
+
+NTFY_ENV="${NTFY_ENV:-$HOME/.config/ntfy/edm-campaigns.env}"
+notify() {   # notify <tags> <priority> <title> <message> — no-op without creds
+    [ -f "$NTFY_ENV" ] || return 0
+    # shellcheck disable=SC1090
+    . "$NTFY_ENV"
+    [ -n "${NTFY_URL:-}" ] || return 0
+    curl -sS --max-time 10 ${NTFY_CERT:+--cert "$NTFY_CERT"} ${NTFY_KEY:+--key "$NTFY_KEY"} \
+        ${NTFY_TOKEN:+-H "Authorization: Bearer $NTFY_TOKEN"} \
+        -H "Tags: $1" -H "Priority: $2" -H "Title: $3" -d "$4" "$NTFY_URL" >/dev/null 2>&1 \
+        || echo "[warn] ntfy post failed: $3" >&2
+}
+fmt_dur() {   # seconds → 47m / 3h12m / 2d5h
+    local s=$1
+    if [ "$s" -lt 3600 ]; then echo "$((s / 60))m"
+    elif [ "$s" -lt 86400 ]; then echo "$((s / 3600))h$(((s % 3600) / 60))m"
+    else echo "$((s / 86400))d$(((s % 86400) / 3600))h"; fi
+}
+
+mkdir -p "$(dirname "$LOG")"
+[ -f "$LOG" ] || printf 'ts_utc\tmodel\tgpu_count\tprice_cents_h\tmin_reserve_min\n' > "$LOG"
+exec 9>>"$LOG"
+flock -n 9 || exit 0   # previous poll still running
+
+# previous-poll state, read BEFORE appending
+prev_up=$(awk -F'\t' 'FNR>1 { if ($1 != ts) { ts = $1; up = 0 }; if ($2 == "MI300X" && $3 == 1) up = 1 }
+                      END { print up + 0 }' "$LOG")
+last_up_ts=$(awk -F'\t' 'FNR>1 && $2 == "MI300X" && $3 == 1 { ts = $1 } END { print ts }' "$LOG")
+
+umask 077
+hk=$(mktemp); trap 'rm -f "$hk"' EXIT
+{ printf 'header = "Authorization: Token '; tr -d '\n' < "$TOKF"; printf '"\n'; } > "$hk"
+
+TS=$(date -u +%FT%TZ)
+rows=""
+if json=$(curl -fsS --max-time 25 -K "$hk" "$URL" 2>/dev/null) \
+   && jq -e 'type == "array"' <<<"$json" >/dev/null 2>&1; then
+    rows=$(jq -r '.[] | [(.Specs.gpus[0].model // "unknown"), (.Specs.gpus[0].count // 0),
+                         (.OnDemandPrice // "-"), (.MinimumReservationMinutes // "-")] | @tsv' \
+               <<<"$json" | sort)
+    if [ -n "$rows" ]; then
+        while IFS= read -r r; do printf '%s\t%s\n' "$TS" "$r" >&9; done <<<"$rows"
+    else
+        printf '%s\tnone\t-\t-\t-\n' "$TS" >&9
+    fi
+else
+    printf '%s\terror\t-\t-\t-\n' "$TS" >&9
+    exit 0
+fi
+
+now_row=$(awk -F'\t' '$1 == "MI300X" && $2 == 1 { print; exit }' <<<"$rows")
+if [ -n "$now_row" ] && [ "$prev_up" != 1 ]; then
+    price=$(cut -f3 <<<"$now_row")
+    if [ -n "$last_up_ts" ]; then
+        gap="was gone $(fmt_dur $(($(date -u -d "$TS" +%s) - $(date -u -d "$last_up_ts" +%s))))"
+    else
+        gap="first sighting in this log"
+    fi
+    notify "rocket" "high" "Hot Aisle 1×MI300X available" "${price}¢/GPU-h — ${gap}"
+fi


### PR DESCRIPTION
Adds a Hot Aisle capacity watcher to `orchestration/`, so MI300X droughts become visible data and a returning 1×MI300X pings ntfy.

- **`hotaisle_availability.sh`** — one poll of the read-only offerings endpoint (`GET /virtual_machines/available/` — never provisions). Appends one TSV row per offering (`ts_utc model gpu_count price_cents_h min_reserve_min`) to `~/.local/share/edm-availability/availability.tsv`; `none` marks a polled-and-empty list (out of capacity ≠ watcher downtime), `error` a failed poll. On a 1×MI300X absent→available transition it notifies via the existing campaign ntfy creds (price + how long the spec was gone). Token only ever reaches curl via a `-K` header file; team handle resolves from `HOTAISLE_TEAM` / `config.env` / `~/.config/hotaisle/{env,team}` — nothing infra-specific in git.
- **`availability_report.sh`** — text summary (current state, last seen, availability fraction 24h/7d, median closed-gap length) or `--html` self-contained page mirroring `cost_report.sh`: timeline strip per spec (available / unavailable / API error; blank = watcher down), summary table, and a list-price chart when the price varied. Plain bash + gawk, no CDNs.
- **systemd user units** (5-min timer) + setup/publish notes in `README-availability.md` (standalone since the orchestration README from #42 isn't on main yet; fold it in once it lands).

Tested: real poll (currently returns `none` — capacity exhausted), shimmed transition tests (notify fires once with price+gap, no re-notify while up, silent `error` row on curl failure), synthetic 2-day log rendered and eyeballed, `bash -n` + `systemd-analyze verify` clean. Deployed on the workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn5htwc8e3JAe2iVhALLXh