### PR TITLE
GPUKernelNewton hardening: light-front residual + bracketed step + LL-regime ladder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@
 /scripts/hotaisle_campaign.sh
 /scripts/balance_monitor.sh
 /scripts/*.sbatch
-animation/rpr_frames/
+animation/rpr_frames*/
+animation/lookdev/
+# RadeonProRender compiled-shader cache (regenerated on first RPR run)
+/cache/

--- a/scripts/v2_newton_kernel_check.jl
+++ b/scripts/v2_newton_kernel_check.jl
@@ -2,7 +2,8 @@
 # Vern9 CPU reference, in both analytic regimes of test/gpu_radiation.jl,
 # alongside GPUKernelRK4 for context. A-level (accumulated potential) errors.
 #
-# Run from the worktree root: julia --project=scripts scripts/v2_newton_kernel_check.jl
+# Run from the repo root: julia --project=test scripts/v2_newton_kernel_check.jl
+# (needs KernelAbstractions for the CPU backend — the test env has it, scripts does not)
 
 using ElectronDynamicsModels
 using ElectronDynamicsModels: TrajectoryInterpolant, ObserverScreen

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -230,6 +230,8 @@ function accumulate_potential(
     )
     n_iters ≥ 1 || throw(ArgumentError(
         "n_iters must be ≥ 1 — n_iters = 0 degrades to an unchecked Euler march"))
+    step(screen.x⁰_samples) > 0 || throw(ArgumentError(
+        "screen.x⁰_samples must be strictly increasing (got step = $(step(screen.x⁰_samples)))"))
     Nx, Ny = length(screen.x_grid), length(screen.y_grid)
     N_samples = length(screen.x⁰_samples)
 
@@ -355,6 +357,8 @@ function accumulate_field(
     )
     n_iters ≥ 1 || throw(ArgumentError(
         "n_iters must be ≥ 1 — n_iters = 0 degrades to an unchecked Euler march"))
+    step(screen.x⁰_samples) > 0 || throw(ArgumentError(
+        "screen.x⁰_samples must be strictly increasing (got step = $(step(screen.x⁰_samples)))"))
     Nx, Ny = length(screen.x_grid), length(screen.y_grid)
     N_samples = length(screen.x⁰_samples)
     c = screen.c

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -45,24 +45,36 @@ struct GPUKernelNewton end
 # τ ← τ + f·rhs with rhs = 1/(u⁰ − u⃗·n̂) = r_norm/xr_dot_u > 0, and the final
 # (converged) eval doubles as the accumulation eval: `v` carries the full
 # [xμ; uμ] state and K/xr_dot_u = K·rhs/r_norm.
-@inline function _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+@inline function _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
     v = gpu_traj.itp(τ)
     x⁰ = v[gpu_traj.x_idxs[1]] # x⁰(τ)
+    x³ = v[gpu_traj.x_idxs[4]] # x³(τ)
     d¹ = r_obs[1] - v[gpu_traj.x_idxs[2]]
     d² = r_obs[2] - v[gpu_traj.x_idxs[3]]
     d³ = r_obs[3] - v[gpu_traj.x_idxs[4]]
+    # ρ = x⊥ - R = [d¹, d²]
+    # R - d³ = ρ²/(||R||+d³)
+    # screen_dist (regrouped) = ρ²/(||R||+d³)
+    # The terms are regrouped for better conditioning
+    # assumes z_screen > x³(τ)
+    ρ² = d¹*d¹ + d²*d²
     r_norm = sqrt(d¹ * d¹ + d² * d² + d³ * d³)
-    # x⁰_target - x⁰(τ) = ||r_obs - x(τ)|| = ||R||
+    screen_dist = ρ² / (r_norm + d³)
+    # x⁰_k - x⁰(τ) = ||r_obs - x(τ)|| = ||R||
+    # x⁰_k = Z + tₖ
+    # ψₖ(τ) = x⁰(τ) - x³(τ)
+    ψₖ = x⁰ - x³
     u⁰ = v[gpu_traj.u_idxs[1]]
     u¹ = v[gpu_traj.u_idxs[2]]
     u² = v[gpu_traj.u_idxs[3]]
     u³ = v[gpu_traj.u_idxs[4]]
-    # X^μ = x^μ - x^μ(τ) = (x⁰_target - x⁰(τ), R)
+    # X^μ = x^μ - x^μ(τ) = (x⁰_k - x⁰(τ), R)
     # m_dot(xr, uμ) with xr = (r_norm, d¹, d², d³)
     xr_dot_u = r_norm * u⁰ - (d¹ * u¹ + d² * u² + d³ * u³)
     # n̂ = R/||R|| => X ⋅ u = r_norm * (u⁰ - n̂ ⋅ u⃗)
     rhs = r_norm / xr_dot_u
-    f = x⁰_target - x⁰ - r_norm
+    # f = tₖ - ψₖ(τ) - ρ²/(||R||+d³)
+    f = tₖ - ψₖ - screen_dist
     return v, f, rhs, r_norm, d¹, d², d³
 end
 
@@ -74,7 +86,7 @@ end
 function _gpu_newton_one_electron!(
         A_buf, gpu_traj,
         x_grid, y_grid, z_screen,
-        x⁰_first, δx⁰, N_samples, Nx, Ny,
+        t_first, δx⁰, N_samples, Nx, Ny,
         τi, τf, pixel_iter, backend, n_iters
     )
     K = gpu_traj.K
@@ -86,28 +98,39 @@ function _gpu_newton_one_electron!(
 
         # Pixel-specific advanced-time window x⁰_i, x⁰_f
         v_i = gpu_traj.itp(τi)
+        x_i⁰ = v_i[gpu_traj.x_idxs[1]] # x⁰(τi)
+        x_i³ = v_i[gpu_traj.x_idxs[4]] # x³(τi)
         d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
         d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]
         d_i³ = r_obs[3] - v_i[gpu_traj.x_idxs[4]]
         R_i = sqrt(d_i¹^2 + d_i²^2 + d_i³^2)
-        x⁰_i_px = v_i[gpu_traj.x_idxs[1]] + R_i
+        # light-front coordinate reformulation
+        ψ_i = x_i⁰ - x_i³
+        ρ_i² = d_i¹^2 + d_i²^2
+        t_i_px = ψ_i + ρ_i²/(R_i + d_i³)
 
         v_f = gpu_traj.itp(τf)
+        x_f⁰ = v_f[gpu_traj.x_idxs[1]] # x⁰(τf)
+        x_f³ = v_f[gpu_traj.x_idxs[4]] # x³(τf)
         d_f¹ = r_obs[1] - v_f[gpu_traj.x_idxs[2]]
         d_f² = r_obs[2] - v_f[gpu_traj.x_idxs[3]]
         d_f³ = r_obs[3] - v_f[gpu_traj.x_idxs[4]]
-        x⁰_f_px = v_f[gpu_traj.x_idxs[1]] + sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
+        # light-front coordinate reformulation
+        ψ_f = x_f⁰ - x_f³
+        ρ_f² = d_f¹^2 + d_f²^2
+        R_f = sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
+        t_f_px = ψ_f + ρ_f²/(R_f + d_f³)
 
         inv_δ = inv(δx⁰)
         # Strict-interior slot range matching Tsit5 with save_start/save_end=false.
-        k_start = max(1, floor(Int, (x⁰_i_px - x⁰_first) * inv_δ) + 2)
-        k_end = min(N_samples, ceil(Int, (x⁰_f_px - x⁰_first) * inv_δ))
+        k_start = max(1, floor(Int, (t_i_px - t_first) * inv_δ) + 2)
+        k_end = min(N_samples, ceil(Int, (t_f_px - t_first) * inv_δ))
 
         if k_start > k_end
             return
         end
 
-        # Warm start at the window edge: τ(x⁰_i_px) = τi exactly, and the v_i
+        # Warm start at the window edge: τ(t_i_px) = τi exactly, and the v_i
         # eval above already provides rhs(τi) for the first predictor stride —
         # no RK4 bridge needed.
         u⁰_i = v_i[gpu_traj.u_idxs[1]]
@@ -116,17 +139,18 @@ function _gpu_newton_one_electron!(
         u³_i = v_i[gpu_traj.u_idxs[4]]
         rhs = R_i / (R_i * u⁰_i - (d_i¹ * u¹_i + d_i² * u²_i + d_i³ * u³_i))
         τ = τi
-        x⁰_target = x⁰_first + (k_start - 1) * δx⁰
-        Δ = x⁰_target - x⁰_i_px   # ∈ (0, δx⁰] unless k_start clamped to 1
+
+        tₖ = t_first + (k_start - 1) * δx⁰
+        Δ = tₖ - t_i_px   # ∈ (0, δx⁰] unless k_start clamped to 1
 
         for k in k_start:k_end
             # Euler predictor from the previous slot's converged state, then
             # fixed-count Newton corrections on the light-cone residual.
             τ = clamp(τ + Δ * rhs, τi, τf)
-            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
             for _ in 1:n_iters
                 τ = clamp(τ + f * rhs, τi, τf)
-                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
             end
 
             # Accumulate from the last residual eval — zero extra spline evals.
@@ -136,7 +160,7 @@ function _gpu_newton_one_electron!(
             @inbounds A_buf[ix, iy, 3, k] += coeff * v[gpu_traj.u_idxs[3]]
             @inbounds A_buf[ix, iy, 4, k] += coeff * v[gpu_traj.u_idxs[4]]
 
-            x⁰_target += δx⁰
+            tₖ += δx⁰
             Δ = δx⁰
         end
     end
@@ -175,6 +199,8 @@ function accumulate_potential(
     A_buf = Adapt.adapt(backend, zeros(Nx, Ny, 4, N_samples))
 
     x⁰_first = first(screen.x⁰_samples)
+    # light-front coordinate reformulation
+    t_first = x⁰_first - screen.z
     δx⁰ = step(screen.x⁰_samples)
 
     # Iteration target: one element per pixel. Sentinel array; never read.
@@ -187,7 +213,7 @@ function accumulate_potential(
         _gpu_newton_one_electron!(
             A_buf, gpu_traj,
             screen.x_grid, screen.y_grid, screen.z,
-            x⁰_first, δx⁰, N_samples, Nx, Ny,
+            t_first, δx⁰, N_samples, Nx, Ny,
             τi, τf, pixel_iter, backend, n_iters,
         )
         sync_per_electron && KernelAbstractions.synchronize(backend)
@@ -209,7 +235,7 @@ end
 function _gpu_newton_field_one_electron!(
         mode::Val, E1_buf, B1_buf, E2_buf, B2_buf, gpu_traj, c,
         x_grid, y_grid, z_screen,
-        x⁰_first, δx⁰, N_samples, Nx, Ny,
+        t_first, δx⁰, N_samples, Nx, Ny,
         τi, τf, pixel_iter, backend, n_iters
     )
     K = gpu_traj.K
@@ -221,22 +247,33 @@ function _gpu_newton_field_one_electron!(
 
         # Pixel-specific advanced-time window x⁰_i, x⁰_f
         v_i = gpu_traj.itp(τi)
+        x_i⁰ = v_i[gpu_traj.x_idxs[1]] # x⁰(τi)
+        x_i³ = v_i[gpu_traj.x_idxs[4]] # x³(τi)
         d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
         d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]
         d_i³ = r_obs[3] - v_i[gpu_traj.x_idxs[4]]
         R_i = sqrt(d_i¹^2 + d_i²^2 + d_i³^2)
-        x⁰_i_px = v_i[gpu_traj.x_idxs[1]] + R_i
+        # light-front coordinate reformulation
+        ψ_i = x_i⁰ - x_i³
+        ρ_i² = d_i¹^2 + d_i²^2
+        t_i_px = ψ_i + ρ_i²/(R_i + d_i³)
 
         v_f = gpu_traj.itp(τf)
+        x_f⁰ = v_f[gpu_traj.x_idxs[1]] # x⁰(τf)
+        x_f³ = v_f[gpu_traj.x_idxs[4]] # x³(τf)
         d_f¹ = r_obs[1] - v_f[gpu_traj.x_idxs[2]]
         d_f² = r_obs[2] - v_f[gpu_traj.x_idxs[3]]
         d_f³ = r_obs[3] - v_f[gpu_traj.x_idxs[4]]
-        x⁰_f_px = v_f[gpu_traj.x_idxs[1]] + sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
+        # light-front coordinate reformulation
+        ψ_f = x_f⁰ - x_f³
+        ρ_f² = d_f¹^2 + d_f²^2
+        R_f = sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
+        t_f_px = ψ_f + ρ_f²/(R_f + d_f³)
 
         inv_δ = inv(δx⁰)
         # Strict-interior slot range matching Tsit5 with save_start/save_end=false.
-        k_start = max(1, floor(Int, (x⁰_i_px - x⁰_first) * inv_δ) + 2)
-        k_end = min(N_samples, ceil(Int, (x⁰_f_px - x⁰_first) * inv_δ))
+        k_start = max(1, floor(Int, (t_i_px - t_first) * inv_δ) + 2)
+        k_end = min(N_samples, ceil(Int, (t_f_px - t_first) * inv_δ))
 
         if k_start > k_end
             return
@@ -248,15 +285,15 @@ function _gpu_newton_field_one_electron!(
         u³_i = v_i[gpu_traj.u_idxs[4]]
         rhs = R_i / (R_i * u⁰_i - (d_i¹ * u¹_i + d_i² * u²_i + d_i³ * u³_i))
         τ = τi
-        x⁰_target = x⁰_first + (k_start - 1) * δx⁰
-        Δ = x⁰_target - x⁰_i_px
+        tₖ = t_first + (k_start - 1) * δx⁰
+        Δ = tₖ - t_i_px
 
         for k in k_start:k_end
             τ = clamp(τ + Δ * rhs, τi, τf)
-            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
             for _ in 1:n_iters
                 τ = clamp(τ + f * rhs, τi, τf)
-                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, x⁰_target)
+                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
             end
 
             # Field write from the converged eval (X reuses r_norm and d).
@@ -279,7 +316,7 @@ function _gpu_newton_field_one_electron!(
                 end
             end
 
-            x⁰_target += δx⁰
+            tₖ += δx⁰
             Δ = δx⁰
         end
     end
@@ -318,6 +355,8 @@ function accumulate_field(
     end
 
     x⁰_first = first(screen.x⁰_samples)
+    # light-front coordinate reformulation
+    t_first = x⁰_first - screen.z
     δx⁰ = step(screen.x⁰_samples)
 
     pixel_iter = Adapt.adapt(backend, zeros(Int8, Nx, Ny))
@@ -329,7 +368,7 @@ function accumulate_field(
         _gpu_newton_field_one_electron!(
             mode, E1_buf, B1_buf, E2_buf, B2_buf, gpu_traj, c,
             screen.x_grid, screen.y_grid, screen.z,
-            x⁰_first, δx⁰, N_samples, Nx, Ny,
+            t_first, δx⁰, N_samples, Nx, Ny,
             τi, τf, pixel_iter, backend, n_iters,
         )
         sync_per_electron && KernelAbstractions.synchronize(backend)

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -2,8 +2,19 @@
 # Extends `accumulate_potential`/`accumulate_field` as the alternative to the
 # GPUKernelRK4 march (kernel_rk4.jl): instead of integrating
 # dτ_r/dx⁰ = 1/(u⁰ − u⃗·n̂) between saveat slots, solve the light-cone condition
-#     f(τ) = x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)|  =  0
-# at each slot with warm-started Newton corrections.  f is strictly monotone
+# at each slot with warm-started Newton corrections.  The residual is spelled
+# in screen-relative (light-front) form,
+#     f(τ) = tₖ − ψ(τ) − ρ²/(R + d³)  =  0
+#     tₖ = x⁰_target − z_screen   (offset sample grid, built small)
+#     ψ  = x⁰(τ) − x³(τ)          (light-front coordinate of the emission event)
+#     ρ⃗  = (d¹, d²),  d³ = z_screen − x³(τ),  R = |r_obs − x⃗(τ)|
+# — algebraically identical to x⁰_target − x⁰(τ) − R (difference-of-squares
+# regrouping, R − d³ = ρ²/(R + d³)), but every stored term is interaction-scale,
+# which removes the ε·Z cancellation floor of the absolute spelling (τ noise
+# ~5e-9 at the production Z ≈ 3e9 a.u., growing ∝ γ² against the sample
+# spacing).  Assumes the screen is downstream (z_screen > x³(τ)) and
+# trajectories are interaction-centered (|xμ| ≪ Z) — true for all EDM setups.
+# f is strictly monotone
 # decreasing — f′(τ) = −(u⁰ − u⃗·n̂) < 0 since u⁰ ≥ |u⃗| on a timelike worldline —
 # so the root is unique and the Newton derivative comes for free from the same
 # spline eval that provides the residual.  Unlike the RK4 march, the per-slot
@@ -29,7 +40,10 @@ Sentinel solver type selecting the Newton light-cone GPU kernel path: the
 retarded proper time at each saveat slot is obtained by solving the light-cone
 condition `x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)| = 0` with `n_iters` warm-started
 Newton corrections, instead of marching the retarded-time ODE as
-[`GPUKernelRK4`](@ref) does.
+[`GPUKernelRK4`](@ref) does.  The residual is evaluated in the equivalent
+screen-relative light-front spelling `f = tₖ − ψ(τ) − ρ²/(R + d³)` (see the
+file header), which keeps Float64 rounding at the interaction scale instead of
+the ε·Z floor of the absolute coordinates.
 
 Per-slot errors are independent across observer-time slots (no accumulation).
 Prefer this kernel for boosted forward-scattering geometries (γ ≫ 1), where
@@ -52,18 +66,16 @@ struct GPUKernelNewton end
     d¹ = r_obs[1] - v[gpu_traj.x_idxs[2]]
     d² = r_obs[2] - v[gpu_traj.x_idxs[3]]
     d³ = r_obs[3] - v[gpu_traj.x_idxs[4]]
-    # ρ = x⊥ - R = [d¹, d²]
-    # R - d³ = ρ²/(||R||+d³)
-    # screen_dist (regrouped) = ρ²/(||R||+d³)
-    # The terms are regrouped for better conditioning
-    # assumes z_screen > x³(τ)
-    ρ² = d¹*d¹ + d²*d²
-    r_norm = sqrt(d¹ * d¹ + d² * d² + d³ * d³)
+    # ρ⃗ = x⊥ − r⊥(τ) = (d¹, d²): the transverse pixel offsets are already the
+    # subtract-first small differences.  R − d³ = ρ²/(R + d³) exactly
+    # (difference of squares); the regrouped form has no O(Z) cancellation left
+    # in it.  Conditioning assumes z_screen > x³(τ) (screen downstream).
+    ρ² = d¹ * d¹ + d² * d²
+    r_norm = sqrt(ρ² + d³ * d³)
     screen_dist = ρ² / (r_norm + d³)
-    # x⁰_k - x⁰(τ) = ||r_obs - x(τ)|| = ||R||
-    # x⁰_k = Z + tₖ
-    # ψₖ(τ) = x⁰(τ) - x³(τ)
-    ψₖ = x⁰ - x³
+    # ψ(τ) = x⁰(τ) − x³(τ): light-front coordinate of the emission event,
+    # small and slowly varying for forward motion (dψ/dτ = u⁰ − u³).
+    ψ = x⁰ - x³
     u⁰ = v[gpu_traj.u_idxs[1]]
     u¹ = v[gpu_traj.u_idxs[2]]
     u² = v[gpu_traj.u_idxs[3]]
@@ -73,16 +85,67 @@ struct GPUKernelNewton end
     xr_dot_u = r_norm * u⁰ - (d¹ * u¹ + d² * u² + d³ * u³)
     # n̂ = R/||R|| => X ⋅ u = r_norm * (u⁰ - n̂ ⋅ u⃗)
     rhs = r_norm / xr_dot_u
-    # f = tₖ - ψₖ(τ) - ρ²/(||R||+d³)
-    f = tₖ - ψₖ - screen_dist
+    # f = tₖ − ψ(τ) − ρ²/(R + d³)  ≡  x⁰_k − x⁰(τ) − R  with  x⁰_k = z_screen + tₖ
+    f = tₖ - ψ - screen_dist
     return v, f, rhs, r_norm, d¹, d², d³
+end
+
+# Pixel arrival-window edge in screen-relative offsets — the light-front
+# spelling of x⁰(τ) + R − z_screen — plus the Doppler factor 1/(u⁰ − n̂·u⃗)
+# there (used for the warm-start predictor stride).  Shared by the potential
+# and field kernels.
+@inline function _window_edge(gpu_traj, r_obs, τ)
+    v = gpu_traj.itp(τ)
+    x⁰ = v[gpu_traj.x_idxs[1]]
+    x³ = v[gpu_traj.x_idxs[4]]
+    d¹ = r_obs[1] - v[gpu_traj.x_idxs[2]]
+    d² = r_obs[2] - v[gpu_traj.x_idxs[3]]
+    d³ = r_obs[3] - v[gpu_traj.x_idxs[4]]
+    ρ² = d¹ * d¹ + d² * d²
+    R = sqrt(ρ² + d³ * d³)
+    t_px = (x⁰ - x³) + ρ² / (R + d³)
+    u⁰ = v[gpu_traj.u_idxs[1]]
+    u¹ = v[gpu_traj.u_idxs[2]]
+    u² = v[gpu_traj.u_idxs[3]]
+    u³ = v[gpu_traj.u_idxs[4]]
+    rhs = R / (R * u⁰ - (d¹ * u¹ + d² * u² + d³ * u³))
+    return t_px, rhs
+end
+
+# One slot of the per-pixel march, shared by the potential and field kernels:
+# Euler predictor from the previous slot's converged state, then `n_iters`
+# bracketed Newton corrections on the light-cone residual.  Every eval
+# tightens the enclosure [lo, hi] by one sign test (f is strictly decreasing:
+# f > 0 ⇒ τ left of the root).  The safeguarded step trusts the Newton
+# proposal iff it stays inside the OPEN interval — strict inequalities,
+# because at convergence prop == τ may sit exactly on the boundary it just
+# became, and must be accepted — and takes the bisection midpoint otherwise
+# (guaranteed progress: the enclosure halves).  Fixed trip count + branchless
+# select keep warp lockstep.  Returns the converged eval so the caller's
+# payload (potential or field write) reuses it with zero extra spline evals.
+@inline function _bracketed_slot_solve(τ, Δ, rhs, lo, gpu_traj, r_obs, tₖ, τi, τf, n_iters)
+    hi = τf   # the upper bound does not survive the target moving up: rebuilt per slot
+    τ = clamp(τ + Δ * rhs, τi, τf)
+    v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
+    f > 0 ? (lo = max(lo, τ)) : (hi = min(hi, τ))
+    for _ in 1:n_iters
+        prop = τ + f * rhs   # Newton proposal (tangent zero-crossing)
+        τ = ifelse((prop < lo) | (prop > hi), (lo + hi) / 2, prop)
+        v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
+        f > 0 ? (lo = max(lo, τ)) : (hi = min(hi, τ))
+    end
+    return τ, lo, v, f, rhs, r_norm, d¹, d², d³
 end
 
 # Per-electron AK.foreachindex pass over (Nx × Ny) pixels; same closure pattern
 # as _gpu_unified_one_electron! (see the @kernel note at the top of
-# kernel_rk4.jl).  Window computation copied verbatim from the RK4 kernel; the
-# RK4 bridge+march is replaced by an Euler predictor + fixed-count Newton
-# corrections per slot (uniform trip count → no warp divergence).
+# kernel_rk4.jl).  The window block computes the same arrival-time edges as the
+# RK4 kernel but in screen-relative offsets (t_px = ψ + ρ²/(R + d³) instead of
+# x⁰_px = x⁰ + R) — an intentional divergence from kernel_rk4.jl, accepted so
+# the light-front conditioning also covers the slot range and the warm-start
+# stride.  The RK4 bridge+march is replaced by an Euler predictor +
+# fixed-count Newton corrections per slot (uniform trip count → no warp
+# divergence).
 function _gpu_newton_one_electron!(
         A_buf, gpu_traj,
         x_grid, y_grid, z_screen,
@@ -96,30 +159,10 @@ function _gpu_newton_one_electron!(
         iy = ((i_lin - 1) ÷ Nx) + 1
         r_obs = SVector{3}(x_grid[ix], y_grid[iy], z_screen)
 
-        # Pixel-specific advanced-time window x⁰_i, x⁰_f
-        v_i = gpu_traj.itp(τi)
-        x_i⁰ = v_i[gpu_traj.x_idxs[1]] # x⁰(τi)
-        x_i³ = v_i[gpu_traj.x_idxs[4]] # x³(τi)
-        d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
-        d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]
-        d_i³ = r_obs[3] - v_i[gpu_traj.x_idxs[4]]
-        R_i = sqrt(d_i¹^2 + d_i²^2 + d_i³^2)
-        # light-front coordinate reformulation
-        ψ_i = x_i⁰ - x_i³
-        ρ_i² = d_i¹^2 + d_i²^2
-        t_i_px = ψ_i + ρ_i²/(R_i + d_i³)
-
-        v_f = gpu_traj.itp(τf)
-        x_f⁰ = v_f[gpu_traj.x_idxs[1]] # x⁰(τf)
-        x_f³ = v_f[gpu_traj.x_idxs[4]] # x³(τf)
-        d_f¹ = r_obs[1] - v_f[gpu_traj.x_idxs[2]]
-        d_f² = r_obs[2] - v_f[gpu_traj.x_idxs[3]]
-        d_f³ = r_obs[3] - v_f[gpu_traj.x_idxs[4]]
-        # light-front coordinate reformulation
-        ψ_f = x_f⁰ - x_f³
-        ρ_f² = d_f¹^2 + d_f²^2
-        R_f = sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
-        t_f_px = ψ_f + ρ_f²/(R_f + d_f³)
+        # Arrival-window edges in screen-relative offsets (shared helper); the
+        # τi eval also provides rhs(τi) for the warm-start predictor stride.
+        t_i_px, rhs = _window_edge(gpu_traj, r_obs, τi)
+        t_f_px, _ = _window_edge(gpu_traj, r_obs, τf)
 
         inv_δ = inv(δx⁰)
         # Strict-interior slot range matching Tsit5 with save_start/save_end=false.
@@ -130,28 +173,20 @@ function _gpu_newton_one_electron!(
             return
         end
 
-        # Warm start at the window edge: τ(t_i_px) = τi exactly, and the v_i
-        # eval above already provides rhs(τi) for the first predictor stride —
-        # no RK4 bridge needed.
-        u⁰_i = v_i[gpu_traj.u_idxs[1]]
-        u¹_i = v_i[gpu_traj.u_idxs[2]]
-        u²_i = v_i[gpu_traj.u_idxs[3]]
-        u³_i = v_i[gpu_traj.u_idxs[4]]
-        rhs = R_i / (R_i * u⁰_i - (d_i¹ * u¹_i + d_i² * u²_i + d_i³ * u³_i))
+        # Warm start at the window edge: τ(t_i_px) = τi exactly — no RK4 bridge.
         τ = τi
 
         tₖ = t_first + (k_start - 1) * δx⁰
         Δ = tₖ - t_i_px   # ∈ (0, δx⁰] unless k_start clamped to 1
 
+        # Bracket lower bound: raised only at sign-verified points (f > 0), so
+        # it lower-bounds every later root too (targets increase along k) —
+        # carried across slots, the one extra live register.
+        lo = τi
+
         for k in k_start:k_end
-            # Euler predictor from the previous slot's converged state, then
-            # fixed-count Newton corrections on the light-cone residual.
-            τ = clamp(τ + Δ * rhs, τi, τf)
-            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
-            for _ in 1:n_iters
-                τ = clamp(τ + f * rhs, τi, τf)
-                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
-            end
+            τ, lo, v, f, rhs, r_norm, d¹, d², d³ =
+                _bracketed_slot_solve(τ, Δ, rhs, lo, gpu_traj, r_obs, tₖ, τi, τf, n_iters)
 
             # Accumulate from the last residual eval — zero extra spline evals.
             coeff = K * rhs / r_norm   # = K / m_dot(xr, uμ)
@@ -172,9 +207,11 @@ end
 
 Newton light-cone GPU path: like the [`GPUKernelRK4`](@ref) unified kernel, but
 the retarded proper time at each saveat slot is found by solving the light-cone
-condition `x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)| = 0` directly (`n_iters`
-warm-started Newton corrections per slot) instead of integrating the
-retarded-time ODE between slots.
+condition directly (`n_iters` warm-started Newton corrections per slot) instead
+of integrating the retarded-time ODE between slots.  The condition is evaluated
+in the screen-relative light-front spelling `f = tₖ − ψ(τ) − ρ²/(R + d³)`
+(algebraically identical to `x⁰_target − x⁰(τ) − |r_obs − x⃗(τ)| = 0`; see the
+file header), with the sample grid carried as offsets `tₖ = x⁰_k − z_screen`.
 
 Spline-eval budget per slot is `n_iters + 1` (the final residual eval doubles
 as the accumulation eval), vs `4·n_substeps + 1` for the RK4 march; and the
@@ -191,6 +228,8 @@ function accumulate_potential(
         n_iters::Int = 2,
         sync_per_electron::Bool = true,
     )
+    n_iters ≥ 1 || throw(ArgumentError(
+        "n_iters must be ≥ 1 — n_iters = 0 degrades to an unchecked Euler march"))
     Nx, Ny = length(screen.x_grid), length(screen.y_grid)
     N_samples = length(screen.x⁰_samples)
 
@@ -245,30 +284,10 @@ function _gpu_newton_field_one_electron!(
         iy = ((i_lin - 1) ÷ Nx) + 1
         r_obs = SVector{3}(x_grid[ix], y_grid[iy], z_screen)
 
-        # Pixel-specific advanced-time window x⁰_i, x⁰_f
-        v_i = gpu_traj.itp(τi)
-        x_i⁰ = v_i[gpu_traj.x_idxs[1]] # x⁰(τi)
-        x_i³ = v_i[gpu_traj.x_idxs[4]] # x³(τi)
-        d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
-        d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]
-        d_i³ = r_obs[3] - v_i[gpu_traj.x_idxs[4]]
-        R_i = sqrt(d_i¹^2 + d_i²^2 + d_i³^2)
-        # light-front coordinate reformulation
-        ψ_i = x_i⁰ - x_i³
-        ρ_i² = d_i¹^2 + d_i²^2
-        t_i_px = ψ_i + ρ_i²/(R_i + d_i³)
-
-        v_f = gpu_traj.itp(τf)
-        x_f⁰ = v_f[gpu_traj.x_idxs[1]] # x⁰(τf)
-        x_f³ = v_f[gpu_traj.x_idxs[4]] # x³(τf)
-        d_f¹ = r_obs[1] - v_f[gpu_traj.x_idxs[2]]
-        d_f² = r_obs[2] - v_f[gpu_traj.x_idxs[3]]
-        d_f³ = r_obs[3] - v_f[gpu_traj.x_idxs[4]]
-        # light-front coordinate reformulation
-        ψ_f = x_f⁰ - x_f³
-        ρ_f² = d_f¹^2 + d_f²^2
-        R_f = sqrt(d_f¹^2 + d_f²^2 + d_f³^2)
-        t_f_px = ψ_f + ρ_f²/(R_f + d_f³)
+        # Arrival-window edges in screen-relative offsets (shared helper); the
+        # τi eval also provides rhs(τi) for the warm-start predictor stride.
+        t_i_px, rhs = _window_edge(gpu_traj, r_obs, τi)
+        t_f_px, _ = _window_edge(gpu_traj, r_obs, τf)
 
         inv_δ = inv(δx⁰)
         # Strict-interior slot range matching Tsit5 with save_start/save_end=false.
@@ -279,22 +298,16 @@ function _gpu_newton_field_one_electron!(
             return
         end
 
-        u⁰_i = v_i[gpu_traj.u_idxs[1]]
-        u¹_i = v_i[gpu_traj.u_idxs[2]]
-        u²_i = v_i[gpu_traj.u_idxs[3]]
-        u³_i = v_i[gpu_traj.u_idxs[4]]
-        rhs = R_i / (R_i * u⁰_i - (d_i¹ * u¹_i + d_i² * u²_i + d_i³ * u³_i))
         τ = τi
         tₖ = t_first + (k_start - 1) * δx⁰
         Δ = tₖ - t_i_px
 
+        # Bracket lower bound (see _bracketed_slot_solve) — carried across slots.
+        lo = τi
+
         for k in k_start:k_end
-            τ = clamp(τ + Δ * rhs, τi, τf)
-            v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
-            for _ in 1:n_iters
-                τ = clamp(τ + f * rhs, τi, τf)
-                v, f, rhs, r_norm, d¹, d², d³ = _lightcone_eval(τ, gpu_traj, r_obs, tₖ)
-            end
+            τ, lo, v, f, rhs, r_norm, d¹, d², d³ =
+                _bracketed_slot_solve(τ, Δ, rhs, lo, gpu_traj, r_obs, tₖ, τi, τf, n_iters)
 
             # Field write from the converged eval (X reuses r_norm and d).
             uμ = v[gpu_traj.u_idxs]
@@ -340,6 +353,8 @@ function accumulate_field(
         mode::Val = Val(:split),
         sync_per_electron::Bool = true,
     )
+    n_iters ≥ 1 || throw(ArgumentError(
+        "n_iters must be ≥ 1 — n_iters = 0 degrades to an unchecked Euler march"))
     Nx, Ny = length(screen.x_grid), length(screen.y_grid)
     N_samples = length(screen.x⁰_samples)
     c = screen.c

--- a/src/gpu/kernel_rk4.jl
+++ b/src/gpu/kernel_rk4.jl
@@ -106,7 +106,10 @@ function _gpu_unified_one_electron!(
         iy = ((i_lin - 1) ÷ Nx) + 1
         r_obs = SVector{3}(x_grid[ix], y_grid[iy], z_screen)
 
-        # Pixel-specific advanced-time window x⁰_i, x⁰_f
+        # Pixel-specific advanced-time window x⁰_i, x⁰_f.  NOTE: kernel_newton.jl
+        # computes the same window in screen-relative offsets (light-front
+        # residual) — the two kernels' window blocks are intentionally no longer
+        # line-identical.
         v_i = gpu_traj.itp(τi)
         d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
         d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]
@@ -295,7 +298,10 @@ function _gpu_unified_field_one_electron!(
         iy = ((i_lin - 1) ÷ Nx) + 1
         r_obs = SVector{3}(x_grid[ix], y_grid[iy], z_screen)
 
-        # Pixel-specific advanced-time window x⁰_i, x⁰_f
+        # Pixel-specific advanced-time window x⁰_i, x⁰_f.  NOTE: kernel_newton.jl
+        # computes the same window in screen-relative offsets (light-front
+        # residual) — the two kernels' window blocks are intentionally no longer
+        # line-identical.
         v_i = gpu_traj.itp(τi)
         d_i¹ = r_obs[1] - v_i[gpu_traj.x_idxs[2]]
         d_i² = r_obs[2] - v_i[gpu_traj.x_idxs[3]]

--- a/test/gpu_radiation.jl
+++ b/test/gpu_radiation.jl
@@ -39,6 +39,26 @@ function analytic_traj(; g, A, Ω, vz, τspan, N, K = 1.0)
         SVector{4, Int}(5, 6, 7, 8), K)
 end
 
+# a₀ = 10 born-at-rest plane-wave worldline (exact closed form, u·u = 1):
+#   φ = τ,  w = (a₀²/2)cos²φ,  u = (1+w, a₀cosφ, 0, w),
+#   x = (τ + z, a₀sinφ, 0, z),  z = (a₀²/4)(φ + sinφ·cosφ)
+# In proper time this has only 1st/2nd harmonics at any a₀ — all the a₀³
+# spectral compression lives in the observer-time pull-back, which is exactly
+# what stresses the per-slot root solve at the beaming-angle pixel.
+function planewave_traj(; a₀, ncyc, N, K = 1.0)
+    ts = collect(range(0.0, 2π * ncyc, length = N))
+    w(φ) = (a₀^2 / 2) * cos(φ)^2
+    zz(φ) = (a₀^2 / 4) * (φ + sin(φ) * cos(φ))
+    us = [SVector{8}(τ + zz(τ), a₀ * sin(τ), 0.0, zz(τ),
+                     1 + w(τ), a₀ * cos(τ), 0.0, w(τ)) for τ in ts]
+    itp = CubicSpline(us, ts; extrapolation = ExtrapolationType.Extension)
+    as = [SVector{4}(-a₀^2 * sin(τ) * cos(τ), -a₀ * sin(τ), 0.0,
+                     -a₀^2 * sin(τ) * cos(τ)) for τ in ts]
+    a_itp = CubicSpline(as, ts; extrapolation = ExtrapolationType.Extension)
+    return TrajectoryInterpolant(itp, a_itp, SVector{4, Int}(1, 2, 3, 4),
+        SVector{4, Int}(5, 6, 7, 8), K)
+end
+
 # Relative Frobenius error — robust to the single-slot boundary ambiguity at the
 # edge of each pixel's arrival window (where even Tsit5 vs Vern9 disagree by a
 # few %).  A max-abs metric would report that edge slot instead of the bulk fit.
@@ -127,6 +147,95 @@ rel_l2(a, b) = norm(a .- b) / norm(b)
         @test e1 > 1.0e-2          # a single correction is not enough here
         @test e3 < 5.0e-3          # three corrections reach reference agreement
         @test e3 < e1              # adding corrections reduces the discrepancy
+    end
+
+    @testset "light-front residual holds the floor at production-scale Z" begin
+        # Regression pin for the screen-relative (light-front) spelling of the
+        # light-cone residual.  At Z ~ 2e9 the absolute spelling
+        # x⁰_k − x⁰(τ) − R carries an ε·Z ≈ 2.4e-7 storage-quantization floor;
+        # the regrouped f = tₖ − ψ(τ) − ρ²/(R + d³) keeps rounding at the
+        # interaction scale (~1e-15 here).  Every other testset runs at small Z
+        # where the two spellings agree — this one fails (by ~2 orders) if the
+        # kernel ever regresses to absolute coordinates.
+        g, A, Ω, vz = 1.05, 0.15, 2.0, 0.95
+        traj = analytic_traj(; g, A, Ω, vz, τspan = (0.0, 20.0), N = 8000)
+        gt = ElectronDynamicsModels.to_gpu(traj)
+        LCE = ElectronDynamicsModels._lightcone_eval   # promoted out of Experimental on main
+
+        Z = 2.0e9
+        τstar = 10.3                                  # generic mid-span point
+        for xp in (0.0, 1.0e5)                        # on-axis, and edge (ρ² term live)
+            r_obs = SVector{3}(xp, 0.0, Z)
+            # True arrival time of the emission at τstar from the closed-form
+            # worldline, in BigFloat; τstar is then the exact retarded time for
+            # this target, so the converged residual must vanish to rounding.
+            τb = big(τstar)
+            x1b = big(A) * sin(big(Ω) * τb)
+            arrival = big(g) * τb + sqrt((big(xp) - x1b)^2 + (big(Z) - big(vz) * τb)^2)
+            tₖ = Float64(arrival - big(Z))            # screen-relative target (small)
+            _, f, rhs = LCE(τstar, gt, r_obs, tₖ)
+            @test abs(f) < 1.0e-9                     # old spelling: ~2.4e-7 — fails
+            @test rhs > 0                             # future-directed Doppler factor
+        end
+
+        # End-to-end at the same Z: offset grid + window block wiring
+        # (t_first = x⁰_first − z_screen exact by Sterbenz; tₖ built small).
+        trajs = [traj]
+        Nx = Ny = 5
+        half = 1.0e5
+        x_grid = LinRange(-half, half, Nx)
+        y_grid = LinRange(-half, half, Ny)
+        x⁰ = LinRange(Z, Z + 8.0, 240)
+        screen = ObserverScreen(x_grid, y_grid, Z, x⁰; c = 1.0)
+        A_ref = accumulate_potential(trajs, screen, Vern9())
+        A1 = accumulate_potential(trajs, screen, GPUKernelNewton(), CPU(); n_iters = 1)
+        A3 = accumulate_potential(trajs, screen, GPUKernelNewton(), CPU(); n_iters = 3)
+        @test maximum(abs, A_ref) > 0
+        @test rel_l2(A1, A_ref) < 5.0e-3              # matches the adaptive reference
+        @test rel_l2(A3, A1) < 1.0e-10                # converged: extra iters are no-ops
+    end
+
+    @testset "bracketed step survives aliased sampling (a₀ = 10, worst pixel)" begin
+        # The undamped Newton step fails on screens under-sampled for their
+        # harmonic content: at the beaming-angle pixel (θ = 2/a₀, Doppler
+        # factor swinging ~400× per cycle) with ~64 samples/period, the tangent
+        # throws iterates across arrival-curve wiggles, and MORE undamped
+        # iterations make it WORSE (report: 98/384 → 265/384 failed slots from
+        # n_iters 3 → 6; clamping to the τ-span is not a convergence
+        # mechanism).  The bracketed step turns every iteration into
+        # guaranteed enclosure shrinkage: error decreases monotonically in
+        # n_iters and reaches a converged fixed point.  The residual plateau
+        # vs the adaptive reference (~8% here) is spike-slot value sensitivity
+        # on an aliased grid, not solver error — hence the monotonicity and
+        # self-convergence assertions rather than a tight absolute tolerance.
+        a₀, ncyc = 10.0, 6
+        traj = planewave_traj(; a₀, ncyc, N = 8000)
+        trajs = [traj]
+        τf = last(traj.itp.t)
+
+        θ = 2 / a₀
+        D = 100 * (a₀^2 / 4) * τf
+        z_screen = D * cos(θ)
+        x_grid = [D * sin(θ)]
+        y_grid = [0.0]
+        𝒜(τ) = (v = traj.itp(τ);
+            v[1] + hypot(x_grid[1] - v[2], y_grid[1] - v[3], z_screen - v[4]))
+        x⁰ = LinRange(𝒜(0.0), 𝒜(τf), 64 * ncyc)     # ~64 samples/period: aliased
+        screen = ObserverScreen(x_grid, y_grid, z_screen, x⁰; c = 1.0)
+
+        A_ref = accumulate_potential(trajs, screen, Vern9())
+        An(n) = accumulate_potential(trajs, screen, GPUKernelNewton(), CPU(); n_iters = n)
+        A1, A3, A8, A12 = An(1), An(3), An(8), An(12)
+        err(A) = rel_l2(A, A_ref)
+
+        @test all(isfinite, A12)
+        @test err(A3) < err(A1) / 5        # rapid progress once corrections act
+        @test err(A12) ≤ err(A3)           # more iterations never hurt (bracket!)
+        # The hardest slots converge through the bisection tail (enclosure halves
+        # per iteration), so A8 → A12 still moves at the ~1e-4 level; the march is
+        # deterministic, so a measured-with-margin bound is stable.
+        @test rel_l2(A12, A8) < 1.0e-3
+        @test_throws ArgumentError An(0)   # guard: Euler-march degradation is an error
     end
 
     @testset "n_substeps drives RK4 convergence (forward Doppler)" begin

--- a/test/ll_regime.jl
+++ b/test/ll_regime.jl
@@ -1,0 +1,119 @@
+# ── LL-regime reachability: the newton-hardening ladder, steps 0–1 ──
+# Ladder 0 (dynamics): the Landau–Lifshitz term drives a k·u drift of exactly
+#   the size the exact LL plane-wave solution predicts, with the classical
+#   electron conserving k·u to solver precision (Noether check) and the drift
+#   scaling as a₀².  This is "we are in the classical RR regime", measured.
+# Ladder 1 (kernel): the light-front Newton kernel consumes the RR-perturbed
+#   worldline — k·u drifting is precisely the assumption §2.4 of the
+#   newton-hardening report forbids baking in — and converges to a
+#   tight-tolerance adaptive referee, with the LL-vs-classical difference in
+#   the accumulated potential far above the kernel's numerical floor: the
+#   pipeline resolves the correction, not merely survives the parameters.
+
+using ElectronDynamicsModels
+using ElectronDynamicsModels: TrajectoryInterpolant, ObserverScreen
+using ModelingToolkit
+using OrdinaryDiffEqVerner
+using SciMLBase, StaticArrays, LinearAlgebra
+using KernelAbstractions: CPU
+using Test
+
+const c_au = 137.03599908330932
+const ω_ll = 0.057                                # 800 nm laser (a.u.)
+const ncyc_ll = 10
+const τspan_ll = (0.0, 2π * ncyc_ll / ω_ll)       # φ = ωτ for an electron born at rest
+const δτₑω = 2π * 2.8179403e-15 / 800.0e-9        # τₑ·ω = 2π r_e/λ at 800 nm
+
+function _ll_solve(sys, a₀)
+    # amplitude is the E-field amplitude: a₀ = A/(cω) in atomic units
+    op = [sys.x => zeros(4), sys.u => [c_au, 0.0, 0.0, 0.0],
+        sys.laser.A => a₀ * c_au * ω_ll]
+    prob = ODEProblem{false, SciMLBase.FullSpecialize}(sys, op, τspan_ll;
+        u0_constructor = SVector{8}, fully_determined = true)
+    # SVector states are required downstream: to_gpu's spline conversion
+    # assumes isbits knots.
+    return solve(prob, Vern9(); abstol = 1.0e-12, reltol = 1.0e-12,
+        saveat = range(τspan_ll..., length = 400 * ncyc_ll), dtmax = (2π / ω_ll) / 50)
+end
+
+# light-front momentum h = (u⁰ − u³)/c along the worldline (k̂ = +ẑ)
+_lightfront(sys, sol) = [(sol[sys.u, i][1] - sol[sys.u, i][4]) / c_au for i in eachindex(sol.t)]
+
+_rel_l2(a, b) = norm(a .- b) / norm(b)
+
+function _ll_build(ll::Bool)
+    @named world = Worldline(:τ, :atomic)
+    @named laser = PlaneWave(; amplitude = 10.0 * c_au * ω_ll, frequency = ω_ll, world)
+    electron = if ll
+        @named electron = LandauLifshitzElectron(; laser)
+    else
+        @named electron = ClassicalElectron(; laser)
+    end
+    return ll ? mtkcompile(electron, allow_symbolic = true) : mtkcompile(electron)
+end
+
+@testset "LL regime is reachable (plane wave, a₀ = 10, born at rest)" begin
+    cl_sys = _ll_build(false)
+    ll_sys = _ll_build(true)
+
+    sol_cl = _ll_solve(cl_sys, 10.0)
+    sol_ll = _ll_solve(ll_sys, 10.0)
+    sol_ll20 = _ll_solve(ll_sys, 20.0)
+    @test SciMLBase.successful_retcode(sol_cl)
+    @test SciMLBase.successful_retcode(sol_ll)
+    @test SciMLBase.successful_retcode(sol_ll20)
+
+    @testset "ladder 0 — dynamics at the predicted RR size" begin
+        h_cl = _lightfront(cl_sys, sol_cl)
+        @test abs(1 - h_cl[end] / h_cl[1]) < 1.0e-10   # Noether: k·u exact classically
+
+        drifts = Dict{Float64, Float64}()
+        for (sol, a₀) in ((sol_ll, 10.0), (sol_ll20, 20.0))
+            h = _lightfront(ll_sys, sol)
+            drifts[a₀] = 1 - h[end] / h[1]
+            # Exact LL plane-wave solution, CW carrier:
+            #   1/h(φ) = 1/h₀ + (2/3)·τₑω·∫a′² ⇒ drift ≈ (2π/3)·τₑω·a₀²·n_cyc
+            pred = (2π / 3) * δτₑω * a₀^2 * ncyc_ll
+            @test isapprox(drifts[a₀], pred; rtol = 0.05)   # measured: 0.1% agreement
+            @test all(<(1.0e-12), diff(h))                  # monotone decrease
+        end
+        @test isapprox(drifts[20.0] / drifts[10.0], 4.0; rtol = 0.02)  # ∝ a₀²
+    end
+
+    @testset "ladder 1 — the kernel on the RR-perturbed worldline" begin
+        traj_cl = TrajectoryInterpolant(sol_cl, cl_sys.x, cl_sys.u)
+        traj_ll = TrajectoryInterpolant(sol_ll, ll_sys.x, ll_sys.u)
+
+        a₀ = 10.0
+        θ = 2 / a₀                                     # worst (beaming-angle) pixel
+        zexc = traj_ll.itp(τspan_ll[2])[traj_ll.x_idxs[4]]
+        D = 100 * zexc
+        z_screen = D * cos(θ)
+        x_grid = [D * sin(θ)]
+        y_grid = [0.0]
+        arr(traj, τ) = begin
+            v = traj.itp(τ); xi = traj.x_idxs
+            v[xi[1]] + hypot(x_grid[1] - v[xi[2]], y_grid[1] - v[xi[3]], z_screen - v[xi[4]])
+        end
+        x⁰ = LinRange(max(arr(traj_cl, 0.0), arr(traj_ll, 0.0)),
+            min(arr(traj_cl, τspan_ll[2]), arr(traj_ll, τspan_ll[2])), 256 * ncyc_ll)
+        screen = ObserverScreen(x_grid, y_grid, z_screen, x⁰; c = c_au)
+
+        # Tight-tolerance referee.  The DEFAULT adaptive reference is unusable
+        # in this regime: reltol ~1e-3 on the retarded-time ODE gives O(1)
+        # errors at the Doppler-spike slots (measured 94% L2 against it) —
+        # the referee must be tighter than what it referees.
+        A_ref = accumulate_potential([traj_ll], screen, Vern9();
+            reltol = 1.0e-13, abstol = 1.0e-13)
+        An(traj, n) = accumulate_potential([traj], screen, GPUKernelNewton(), CPU(); n_iters = n)
+        A3, A6, A12 = An(traj_ll, 3), An(traj_ll, 6), An(traj_ll, 12)
+        e3, e6, e12 = _rel_l2(A3, A_ref), _rel_l2(A6, A_ref), _rel_l2(A12, A_ref)
+
+        @test all(isfinite, A12)
+        @test e12 < 1.0e-3            # measured 1.0e-4: converged to the tight referee
+        @test e12 < e6 < e3           # bracket: monotone through the bisection tail
+        # The physics is resolved: LL vs classical differs in the accumulated
+        # potential (measured ~6.7e-2, SNR ~650 over the kernel floor).
+        @test _rel_l2(An(traj_cl, 12), A12) > 10 * e12
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,9 @@ using JET
     @testset "Lorenz Gauge" begin
         include("lorenz_gauge.jl")
     end
+    @testset "LL regime reach (dynamics + kernel)" begin
+        include("ll_regime.jl")
+    end
     @testset "Radiation Reaction" begin
         include("radiation.jl")
     end


### PR DESCRIPTION
Implements the two kernel changes from the [newton-hardening design review](https://research.314159265.dev/reports/newton-hardening/) and the first two rungs of its LL test ladder.

## Changes

**Light-front residual (always on).** The light-cone residual and the window block are evaluated in screen-relative (light-front) form, `f = tₖ − ψ(τ) − ρ²/(R + d³)` with the sample grid carried as offsets `tₖ = x⁰_k − z_screen` (`t_first` exact by Sterbenz). Algebraically identical to the absolute spelling; removes the ε·Z cancellation floor (τ noise ~5e-9 at production Z, growing ∝ γ² — the Float64 wall measured in the [envelope report](https://research.314159265.dev/reports/a0-gamma-envelope/)). The window block intentionally diverges from `kernel_rk4.jl` (noted in both files).

**Bracketed Newton step (the default step).** `lo` carried across slots (raised only at sign-verified points, so it bounds all later roots unconditionally), `hi` rebuilt as `τf` per slot, Newton proposal trusted iff strictly inside the open enclosure, bisection midpoint otherwise. Fixed trip count + branchless select preserve warp lockstep; `n_iters ≥ 1` asserted. Full derivation and the strict-inequality subtlety: report §3.2.

**Refactor.** Window edge and slot solve factored into `_window_edge` / `_bracketed_slot_solve`, shared by the potential and field kernels (payloads stay in each kernel). CPU-backend behavior verified bit-identical through the refactor.

## Validation

- `test/gpu_radiation.jl` 40/40: existing testsets unchanged, plus a light-front floor pin at production-scale Z (BigFloat oracle; the absolute spelling fails it by ~2 orders) and an aliased-sampling stress test at the a₀ = 10 worst pixel (error monotone in `n_iters` — undamped Newton *degrades* 98→265 failed slots from it 3→6; bounded bisection tail).
- `test/ll_regime.jl` 13/13 (new): LL dynamics reaches the classical RR regime at the exact-solution size (k·u drift to 0.1%, ∝ a₀², classical Noether-conserved), and the kernel resolves the LL-vs-classical potential difference at SNR ~650 over its floor. Encodes the referee lesson: default-tolerance adaptive references are unusable in spiky regimes (94% self-error).
- GPU (W7900): `diag_newton_precision` 9.03e-11 at every `n_iters` (pre-change floor 9.36e-11); `v2_newton_kernel_check` reproduces the method-report tables.

## Perf gate (open)

Potential benchmark vs the pre-change baseline (report §3.4): Newton rows +2–5% wall (bracket bookkeeping; accuracy improved to 3.9–6.9e-11), speedups 1.44–1.91× vs RK4 ns=1 retained. Field-path benchmark (the register-pressure gate) still running — results to be posted here. Cloud-GPU (MI300X) smoke test planned when availability allows.

Review guide: report §3.2 for the step, §2.2/§2.5 for the residual algebra and code touchpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)