### PR TITLE
LL campaigns + ω_bs units + carrier-resolved probes + orchestration hardening

### DIFF
--- a/ext/EDMMakieExt.jl
+++ b/ext/EDMMakieExt.jl
@@ -74,16 +74,24 @@ function ElectronDynamicsModels.plot_harmonic_grid(
 end
 
 function ElectronDynamicsModels.plot_power_spectrum(
-        freqs, power_spec; ω, labels,
+        freqs, power_spec; ω, labels, marks = nothing, n0 = 1,
         colors = [:black, :dodgerblue, :seagreen, :crimson, :darkorange, :purple],
         linestyles = nothing, title = "", outfile = nothing,
     )
-    xh = collect(freqs) ./ (ω / 2π)            # frequency in units of the fundamental
+    # Frequency axis in units of the run's radiated fundamental: the drive ω₁ when n0 = 1
+    # (rest-electron runs), the on-axis backscattered line ω_bs = n0·ω₁ = (1+β)/(1−β)·ω₁ for
+    # boosted runs — integer multiples of the physical line then land on Makie's automatic
+    # ticks, whose default grid replaces the integer comb this plot used to hand-draw (the comb
+    # became wallpaper once spans reached 4γ² ~ 10⁶ ω₁: the aligned dash segments of ~10⁶
+    # overlapping dashed vlines rendered as solid gray bars).
+    xh = collect(freqs) ./ (ω / 2π) ./ n0
+    xlab = n0 == 1 ? "frequency / ω₁" : "frequency / ω_bs   (ω_bs = $(n0) ω₁)"
     yfloor = maximum(power_spec) * 1.0e-30     # log axis needs a positive floor
     fig = with_theme(theme_latexfonts()) do
         f = Figure(size = (1150, 560))
-        ax = Axis(f[1, 1]; xlabel = "frequency / ω₁", ylabel = "Σ_pixels |Â_μ|²", yscale = log10, title)
-        vlines!(ax, 1:floor(Int, last(xh)); color = (:gray, 0.35), linestyle = :dash)
+        ax = Axis(f[1, 1]; xlabel = xlab, ylabel = "Σ_pixels |Â_μ|²", yscale = log10, title)
+        # Explicit guides only where the run extracted harmonic bins (`marks`, in ω₁ units).
+        marks === nothing || vlines!(ax, collect(marks) ./ n0; color = (:gray, 0.6), linewidth = 1)
         for c in axes(power_spec, 2)
             lines!(ax, xh, max.(power_spec[:, c], yfloor); label = labels[c],
                 color = colors[(c - 1) % length(colors) + 1],

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -17,8 +17,9 @@
 # config.env: HOTAISLE_TEAM, HOTAISLE_GPUS, HOTAISLE_REPO_URL, HOTAISLE_BRANCH (, HOTAISLE_API).
 # Secrets stay external: API token at ~/.config/hotaisle/token; ntfy creds (driving-side) via NTFY_ENV.
 # BILLING: 1 GPU = per-minute (1-min minimum); 2/4 carry 60/120-min minimums. Teardown waits out the
-# minimum, then a non-force DELETE — ALWAYS verify the VM is gone in the TUI (ssh admin.hotaisle.app);
-# the API DELETE is best-effort and billing only truly stops on TUI destroy.
+# minimum, then a non-force DELETE. The API DELETE is reliable (validated repeatedly 2026-07):
+# a confirmed 2xx + empty VM list = destroyed and billing stopped; the TUI check is optional
+# double-verification. A FAILED (non-2xx) DELETE still means likely-still-billing — alert + TUI.
 set -Eeuo pipefail
 ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."; ORCH="$(cd "$ORCH" && pwd)"
 . "$ORCH/run_cell.sh"        # config.env + notify() (notifications fire from THIS driving machine)
@@ -118,7 +119,10 @@ download_verify() {
         if [ ! -f "$dst/$fn" ]; then log "[verify] MISSING locally: $fn"; bad=1; continue; fi
         lsum=$(md5sum "$dst/$fn" | awk '{print $1}')
         [ "$lsum" = "$vsum" ] || { log "[verify] MD5 MISMATCH: $fn (vm=$vsum local=$lsum)"; bad=1; }
-    done < <(ssh_vm "cd EDM/runs/$CAMPAIGN && md5sum * 2>/dev/null | grep -vE 'field_.*\\.jls'")
+    # Filter the FILE LIST before hashing — `md5sum * | grep -v` still md5s every kept cube
+    # (~25 min GPU-idle per ~300 GB) and the long-silent ssh pipe can die and hang the driver
+    # (2026-07-19 incident: 43 min idle, driver killed, products published manually).
+    done < <(ssh_vm "cd EDM/runs/$CAMPAIGN && find . -maxdepth 1 -type f ! -name 'field_*.jls' -exec md5sum {} + 2>/dev/null")
     [ "$bad" -eq 0 ] && { log "[verify] $CAMPAIGN OK (md5 match; cubes excluded)"; return 0; }
     notify rotating_light high "EDM download CHECK FAILED" "$CAMPAIGN: md5 mismatch/missing on download to $dst"
     return 1

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -27,10 +27,18 @@
 set -Eeuo pipefail
 ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."; ORCH="$(cd "$ORCH" && pwd)"
 # Caller-env overrides must survive config.env (sourced via run_cell.sh below, where a plain
-# RUNPOD_BRANCH=... assignment would clobber them) — capture before, prefer after.
+# RUNPOD_BRANCH=... assignment would clobber them) — capture before, prefer after. Same for
+# every per-campaign knob a caller passes inline: VOLUME_GB bit us 2026-07-19 (caller's 1400
+# silently reverted to config.env's 0 ⇒ a volumeless pod for a volume-dependent campaign).
 _CALLER_BRANCH="${RUNPOD_BRANCH-}"
+_CALLER_VOLGB="${RUNPOD_VOLUME_GB-}"
+_CALLER_DISK="${RUNPOD_DISK_GB-}"
+_CALLER_DC="${RUNPOD_DC-__unset__}"
 . "$ORCH/run_cell.sh"        # config.env + notify() (notifications fire from THIS driving machine)
 [ -n "$_CALLER_BRANCH" ] && RUNPOD_BRANCH="$_CALLER_BRANCH"
+[ -n "$_CALLER_VOLGB" ] && RUNPOD_VOLUME_GB="$_CALLER_VOLGB"
+[ -n "$_CALLER_DISK" ] && RUNPOD_DISK_GB="$_CALLER_DISK"
+[ "$_CALLER_DC" != "__unset__" ] && RUNPOD_DC="$_CALLER_DC"   # explicit empty = unpinned, must survive too
 
 MODE="${1:?usage: runpod.sh run <campaign.sh> | attach <campaign.sh> | teardown}"
 TOK=$(cat "${RUNPOD_TOKEN_FILE:-$HOME/.config/runpod/token}")

--- a/orchestration/campaigns/ll_a0_ladder.sh
+++ b/orchestration/campaigns/ll_a0_ladder.sh
@@ -1,0 +1,22 @@
+# campaigns/ll_a0_ladder.sh — RR a₀-scaling at γ=1000 (chained after ll_gamma_ladder).
+# Pairs at a₀ {0.5, 5} fill the a₀²γ axis around the γ-ladder's a₀=2 point (RR ∝ a₀²γ:
+# 2.5e2 / 2.5e4 ≈ 0.001% / 0.9% per pulse); the γ=2000 pair extends the γ-ladder between
+# 1000 and 4000. saveat 32 on a₀=5 (high-a₀ spline knot density; floor lesson). Cubes kept.
+CAMPAIGN=ll_a0_ladder
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=16
+  EDM_SPP=2048 EDM_NX=401 EDM_SCREEN_HW=5 EDM_HARMONICS=1,2,3,4
+  EDM_WINDOW_LEAD=0.3 EDM_WINDOW_TAIL=0.3
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
+)
+CELLS=(
+  "a05_cl|EDM_A0=0.5"
+  "a05_ll|EDM_A0=0.5 EDM_SYSTEM=ll"
+  "a5_cl|EDM_A0=5 EDM_INTERP_SAVEAT=32"
+  "a5_ll|EDM_A0=5 EDM_INTERP_SAVEAT=32 EDM_SYSTEM=ll"
+  "g2000_cl|EDM_A0=2 EDM_GAMMA=2000 EDM_TSPAN_TAU=0.008"
+  "g2000_ll|EDM_A0=2 EDM_GAMMA=2000 EDM_TSPAN_TAU=0.008 EDM_SYSTEM=ll"
+)

--- a/orchestration/campaigns/ll_gamma_ladder.sh
+++ b/orchestration/campaigns/ll_gamma_ladder.sh
@@ -1,0 +1,38 @@
+# campaigns/ll_gamma_ladder.sh — Landau–Lifshitz radiation reaction through the old Float64 wall.
+#
+# LL-vs-classical pairs at a₀=2 on a γ-ladder {10, 100, 1000, 4000}; the pre-#44 light-front
+# fix capped the kernel at γ≈2900 (a0-gamma-envelope report), so the γ=4000 pair is physics
+# that did not exist before the hardened kernel. χ = 2γa₀·ħω/mc² ≈ 0.05 at the flagship —
+# safely classical, LL valid. RR significance a₀²γ = 1.6e4 there.
+#
+# Research mode (no fixed-bin scoring): cubes KEPT everywhere; harmonic lists are only
+# feasibility placeholders at high γ (the 4γ² line is unresolvable above γ≈100 at any
+# realizable SPP — observables are worldline energy loss, powspec envelopes, and the kept
+# cubes). Each pair shares the sunflower disk ⇒ the common-disk complex diff isolates the
+# RR imprint (bunched_diff_products.jl pattern; pairs group by (a0, kernel) — here by system).
+# Per-γ scaling: EDM_TSPAN_TAU ∝ 1/γ (proper-time span); screen half-width tracks the ~1/γ
+# beaming cone at Z = 2e5λ (γ≤1000: default 5 w₀ covers it; γ=4000: cone ≈ 0.7 w₀ ⇒ hw=1).
+# n_iters mini-ladder at γ=1000 (it2 = the pair cell) answers the open iteration-count
+# question on the bracketed step.
+CAMPAIGN=ll_gamma_ladder
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_A0=2 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=16
+  EDM_SPP=2048 EDM_NX=401 EDM_SCREEN_HW=5
+  EDM_WINDOW_LEAD=0.3 EDM_WINDOW_TAIL=0.3
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
+)
+CELLS=(
+  "g10_cl|EDM_GAMMA=10 EDM_TSPAN_TAU=1.6 EDM_HARMONICS=199,299,398,597"
+  "g10_ll|EDM_GAMMA=10 EDM_TSPAN_TAU=1.6 EDM_HARMONICS=199,299,398,597 EDM_SYSTEM=ll"
+  "g100_cl|EDM_GAMMA=100 EDM_TSPAN_TAU=0.16 EDM_HARMONICS=1,2,3,4"
+  "g100_ll|EDM_GAMMA=100 EDM_TSPAN_TAU=0.16 EDM_HARMONICS=1,2,3,4 EDM_SYSTEM=ll"
+  "g1000_cl|EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_HARMONICS=1,2,3,4"
+  "g1000_ll|EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_HARMONICS=1,2,3,4 EDM_SYSTEM=ll"
+  "g1000_ll_it1|EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_HARMONICS=1,2,3,4 EDM_SYSTEM=ll EDM_NEWTON_ITERS=1"
+  "g1000_ll_it3|EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_HARMONICS=1,2,3,4 EDM_SYSTEM=ll EDM_NEWTON_ITERS=3"
+  "g4000_cl|EDM_GAMMA=4000 EDM_TSPAN_TAU=0.004 EDM_HARMONICS=1,2,3,4 EDM_SCREEN_HW=1"
+  "g4000_ll|EDM_GAMMA=4000 EDM_TSPAN_TAU=0.004 EDM_HARMONICS=1,2,3,4 EDM_SCREEN_HW=1 EDM_SYSTEM=ll"
+)

--- a/orchestration/campaigns/ll_probe.sh
+++ b/orchestration/campaigns/ll_probe.sh
@@ -1,0 +1,36 @@
+# campaigns/ll_probe.sh — carrier-resolved backscatter probes: does the 4γ² line WALK under RR?
+#
+# Re-run of the crashed ll_rr_strength probe cells. Two design faults fixed: (1) the Nyquist
+# guard (EDM_SPP=8000000 < 2·4004000 = 8008000 — both cells died at startup, the driver counted
+# them done); (2) the as-designed 65² screen would have hit the memory guard anyway — the
+# :narrow window is corner_spread-dominated (full 3.25 w₀ disk ⇒ (√2·hw + Rmax)²/2Z ≈ 0.19λ ⇒
+# N_samples ≈ 1.5e6 at this SPP), so cube memory = N_samples·6·Nx²·8 B pins the screen at 33²
+# (~80 GB) on one 192 GB MI300X. Physics is production-identical (full disk, same LG mode).
+#
+# a₀ ladder {2, 5, 10} at γ=1000, LL/classical common-disk pairs: predicted line walk
+# 2δγ/γ (ΔE/E ≈ 3.5e-7·a₀²γ) ≈ 11 / 70 / 280 bins at the window's 1000 ω₁/bin resolution.
+# a₀=10 sits at a₀²γ = 1e5 — past the √2 field-diff decorrelation ceiling; the spectral walk
+# is the observable that should survive there. χ ≤ 0.0625 (classical regime, LL valid).
+# Extremes first (a2 anchor, a10 max signal), a5 last: a budget runout costs the ladder's
+# interior, not its ends. Bins: the 4γ² edge triplet + a coarse plateau ladder (the nonlinear
+# redshift pushes spectral weight down toward 4γ²/(1+a₀²/2)); the kept cube holds the full
+# spectrum regardless.
+CAMPAIGN=ll_probe
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=32
+  EDM_SPP=8032000 EDM_NX=33 EDM_SCREEN_HW=0.27
+  EDM_WINDOW_LEAD=0.002 EDM_WINDOW_TAIL=0.002
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
+  EDM_HARMONICS=800000,1600000,2400000,3200000,3996000,4000000,4004000
+)
+CELLS=(
+  "a2_cl|EDM_A0=2"
+  "a2_ll|EDM_A0=2 EDM_SYSTEM=ll"
+  "a10_cl|EDM_A0=10"
+  "a10_ll|EDM_A0=10 EDM_SYSTEM=ll"
+  "a5_cl|EDM_A0=5"
+  "a5_ll|EDM_A0=5 EDM_SYSTEM=ll"
+)

--- a/orchestration/campaigns/ll_probe_fix.sh
+++ b/orchestration/campaigns/ll_probe_fix.sh
@@ -1,0 +1,17 @@
+# campaigns/ll_probe_fix.sh — makeup for a10_cl, the one ll_probe_rerun cell lost to host-OOM
+# (2026-07-19: an ssh ControlPath collision ran a second campaign's warm + cell startup on the
+# same pod while a backgrounded reduce held ~100 GB — LLVM ERROR: out of memory at cell start).
+CAMPAIGN=ll_probe
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=32
+  EDM_SPP=8032000 EDM_NX=33 EDM_SCREEN_HW=0.27
+  EDM_WINDOW_LEAD=0.002 EDM_WINDOW_TAIL=0.002
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
+  EDM_HARMONICS=800000,1600000,2400000,3200000,3996000,4000000,4004000
+)
+CELLS=(
+  "a10_cl|EDM_A0=10"
+)

--- a/orchestration/campaigns/ll_probe_rerun.sh
+++ b/orchestration/campaigns/ll_probe_rerun.sh
@@ -1,0 +1,23 @@
+# campaigns/ll_probe_rerun.sh — the 5 ll_probe cells lost to the 2026-07-19 disk-overflow
+# incident (120 GB pod disk, drainer uploads but never deletes locally ⇒ cube 2 truncated at
+# the quota, cells 3–6 got 8 KiB stubs; cell a2_cl survived and is archived). Same physics as
+# ll_probe — run on a pod with a NETWORK VOLUME (RUNPOD_VOLUME_GB≈1400) so cubes land off the
+# container disk entirely; the volume drains via orchestration/drain.sh after the campaign.
+CAMPAIGN=ll_probe
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=32
+  EDM_SPP=8032000 EDM_NX=33 EDM_SCREEN_HW=0.27
+  EDM_WINDOW_LEAD=0.002 EDM_WINDOW_TAIL=0.002
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
+  EDM_HARMONICS=800000,1600000,2400000,3200000,3996000,4000000,4004000
+)
+CELLS=(
+  "a2_ll|EDM_A0=2 EDM_SYSTEM=ll"
+  "a10_cl|EDM_A0=10"
+  "a10_ll|EDM_A0=10 EDM_SYSTEM=ll"
+  "a5_cl|EDM_A0=5"
+  "a5_ll|EDM_A0=5 EDM_SYSTEM=ll"
+)

--- a/orchestration/campaigns/ll_probe_s.sh
+++ b/orchestration/campaigns/ll_probe_s.sh
@@ -1,0 +1,38 @@
+# campaigns/ll_probe_s.sh — S config: speckle-resolved backscatter probes at γ=100, the
+# a₀-driven deep-RR corner of the (a₀, γ) envelope. Carrier-resolved AND grain-resolved:
+# ω_bs = 4γ² ≈ 4e4 ω₁ makes the carrier 47× cheaper than the γ=1000 probes, refunding the
+# pixels — SPP=170000 reaches 2.13 ω_bs (fundamental + first harmonic, 6% margin), and the
+# 361² screen at hw = 0.464λ (0.00619 w₀) gives 2 px per 2ω_bs speckle grain, 4 px per ω_bs
+# grain, ~90×90-grain field of view (window is Rmax-dominated ⇒ screen extent is time-free).
+# Odd NX ⇒ a pixel exactly on axis (the bunched_resolved node-at-origin lesson).
+#
+# Pairs at a₀ {10, 30, 100}: ΔE/E ≈ 0.35% / 3% / 35% (the a₀=100 pair probes where the linear
+# 3.5e-7·a₀²γ law must bend), line walk ≈ 280 / 2500 / ~23000 ω₁ at ~6.4 ω₁/bin; χ ≤ 0.0625
+# (classical, LL valid). Asymmetric statistics: the signal scales as a₀², so the weak a₀=10
+# pair gets N=4000 while a₀ {30,100} keep the production N=2000 — line position (the walk) is
+# N-independent, and each pair stays common-disk internally. Extremes first.
+#
+# Cube: N_samples ≈ 26,700 × 6 × 361² × 8 B ≈ 155 GiB (81% of the MI300X guard; host peak
+# ~1.06× post chunked-permute 5abd239). Run on a NETWORK VOLUME pod (RUNPOD_VOLUME_GB≈1400,
+# shared with ll_probe_rerun) — cubes bypass the container disk; drain.sh empties the volume
+# after the campaign. Bins: plateau ladder + 4γ² edge triplet + mid-gap + first-harmonic
+# triplet (all ≤ Nyquist 85000 ω₁); the kept cube holds the full spectrum regardless.
+CAMPAIGN=ll_probe_s
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_GAMMA=100 EDM_TSPAN_TAU=0.16 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=64
+  EDM_SPP=170000 EDM_NX=361 EDM_SCREEN_HW=0.00619
+  EDM_WINDOW_LEAD=0.002 EDM_WINDOW_TAIL=0.002
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
+  EDM_HARMONICS=8000,16000,24000,32000,39898,39998,40098,60000,79896,79996,80096
+)
+CELLS=(
+  "a10_cl|EDM_A0=10 EDM_N=4000"
+  "a10_ll|EDM_A0=10 EDM_N=4000 EDM_SYSTEM=ll"
+  "a100_cl|EDM_A0=100"
+  "a100_ll|EDM_A0=100 EDM_SYSTEM=ll"
+  "a30_cl|EDM_A0=30"
+  "a30_ll|EDM_A0=30 EDM_SYSTEM=ll"
+)

--- a/orchestration/campaigns/ll_rr_strength.sh
+++ b/orchestration/campaigns/ll_rr_strength.sh
@@ -1,0 +1,27 @@
+# campaigns/ll_rr_strength.sh — into the ~10% radiation-reaction regime (chained last).
+# γ=4000 × a₀ {4, 6, 8}: ΔE/E per pulse ≈ 3.5e-7·a₀²γ ⇒ 2% / 5% / 9%; χ = 0.10/0.15/0.20 —
+# the ladder walks LL from exact (χ≈0.05) to its first quantum-correction territory (χ≈0.2).
+# The γ=2000, a₀=8 pair (χ=0.10, ΔE/E≈4.5%) separates a₀- from χ-dependence. a₀=8 sits at the
+# measured solver-envelope edge (clean a₀≈6–9) — envelope stress-test by construction.
+# saveat 32 everywhere (a₀ ≥ 4); expect the 4γ² line to WALK ~20% during the pulse at a₀=8
+# (γ-decay chirp) — powspec + kept cubes are the observables, bins are placeholders.
+CAMPAIGN=ll_rr_strength
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_GAMMA=4000 EDM_TSPAN_TAU=0.004 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=32
+  EDM_SPP=2048 EDM_NX=401 EDM_SCREEN_HW=1 EDM_HARMONICS=1,2,3,4
+  EDM_WINDOW_LEAD=0.3 EDM_WINDOW_TAIL=0.3
+  EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
+)
+CELLS=(
+  "a4_cl|EDM_A0=4"
+  "a4_ll|EDM_A0=4 EDM_SYSTEM=ll"
+  "a6_cl|EDM_A0=6"
+  "a6_ll|EDM_A0=6 EDM_SYSTEM=ll"
+  "a8_cl|EDM_A0=8"
+  "a8_ll|EDM_A0=8 EDM_SYSTEM=ll"
+  "g2000a8_cl|EDM_A0=8 EDM_GAMMA=2000 EDM_TSPAN_TAU=0.008 EDM_SCREEN_HW=2"
+  "g2000a8_ll|EDM_A0=8 EDM_GAMMA=2000 EDM_TSPAN_TAU=0.008 EDM_SCREEN_HW=2 EDM_SYSTEM=ll"
+)

--- a/orchestration/campaigns/ll_rr_strength.sh
+++ b/orchestration/campaigns/ll_rr_strength.sh
@@ -24,4 +24,10 @@ CELLS=(
   "a8_ll|EDM_A0=8 EDM_SYSTEM=ll"
   "g2000a8_cl|EDM_A0=8 EDM_GAMMA=2000 EDM_TSPAN_TAU=0.008 EDM_SCREEN_HW=2"
   "g2000a8_ll|EDM_A0=8 EDM_GAMMA=2000 EDM_TSPAN_TAU=0.008 EDM_SCREEN_HW=2 EDM_SYSTEM=ll"
+  # Burst-resolved SPECTRAL probes (LAST: experimental guards may trip; main cells land first).
+  # Temporal analogue of the 7.2 recipe: arrival spread matched to the burst (hw 0.27 w0 ->
+  # ~1e-3 T), SPP 8e6 clears the 4g^2 = 4e6 w Nyquist, margins at burst scale, NX 65 keeps the
+  # cube ~8 GB. Goal: the RR line-walk (4g^2 line dropping as gamma decays) in the spectrum.
+  "probe_cl|EDM_A0=2 EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_SCREEN_HW=0.27 EDM_NX=65 EDM_SPP=8000000 EDM_WINDOW_LEAD=0.002 EDM_WINDOW_TAIL=0.002 EDM_HARMONICS=3996000,4000000,4004000"
+  "probe_ll|EDM_A0=2 EDM_GAMMA=1000 EDM_TSPAN_TAU=0.016 EDM_SCREEN_HW=0.27 EDM_NX=65 EDM_SPP=8000000 EDM_WINDOW_LEAD=0.002 EDM_WINDOW_TAIL=0.002 EDM_HARMONICS=3996000,4000000,4004000 EDM_SYSTEM=ll"
 )

--- a/orchestration/campaigns/ll_smoke.sh
+++ b/orchestration/campaigns/ll_smoke.sh
@@ -1,0 +1,15 @@
+# campaigns/ll_smoke.sh — MI300X shakeout of the hardened Newton kernel (PR #44:
+# light-front residual + bracketed step) + depot-cache warm for the LL campaign.
+# Tiny cell, minutes; the cloud-GPU gate the PR's validation section calls for.
+CAMPAIGN=ll_smoke
+SCRIPT=scripts/inverse_thomson_scattering.jl
+BASE=(
+  EDM_A0=1 EDM_GAMMA=10 EDM_WINDOW=narrow EDM_FIELD_MODE=total
+  EDM_N=100 EDM_NSUBSTEPS=1 EDM_INTERP_SAVEAT=16
+  EDM_TSPAN_TAU=1.6 EDM_SPP=2048 EDM_SCREEN_HW=0.4 EDM_NX=65
+  EDM_WINDOW_LEAD=0.3 EDM_WINDOW_TAIL=0.3 EDM_HARMONICS=199,299,398,597
+)
+CELLS=(
+  "smoke_newton|EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2"
+  "smoke_ll|EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2 EDM_SYSTEM=ll"
+)

--- a/orchestration/cube_drain_r2.sh
+++ b/orchestration/cube_drain_r2.sh
@@ -60,6 +60,15 @@ while :; do
         if RC copyto "$cube" "r2:$BUCKET/cubes/$camp/$uuid/$base" &&
            echo "$sha  $base" | RC rcat "r2:$BUCKET/cubes/$camp/$uuid/$base.sha256"; then
             touch "$dir/.drained_$base"; log "uploaded $base (sha256 $sha)"
+            # Small-disk pods (e.g. RunPod's default 120 GB container disk): free the local copy
+            # once the upload + sha sidecar are in the bucket — the puller verifies end-to-end
+            # against that sha before archiving. Without this, cubes accumulate and the NEXT
+            # cell's write truncates at the quota (2026-07-19: cube 2 died at 44/74 GiB, cells
+            # 3-6 got 8 KiB stubs — the container quota is enforced lazily, so the writes
+            # "succeeded" and the corruption only surfaced at reduce time as EOFError).
+            if [ "${DRAIN_DELETE_LOCAL:-0}" = 1 ]; then
+                rm -f "$cube" && log "local freed: $base (R2 copy authoritative until archived)"
+            fi
         else
             log "upload failed for $base — retrying next sweep"
         fi

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -78,6 +78,23 @@ run_cell() {
     local label=$1; shift
     local uuid; uuid=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
     mkdir -p "$CAMP"
+    # Disk gate (adaptive, KEEP_CUBE campaigns): container-disk quotas are enforced LAZILY —
+    # a cube write into a full disk "succeeds" and only surfaces as EOFError at reduce time
+    # (2026-07-19 incident). Cell 1 sets the scale; later cells wait until free space ≥ 1.25×
+    # the largest cube seen so far, polling while the drainer frees uploads. Bounded wait
+    # (30 min) so a dead drainer degrades to the old behavior + a loud note, not a deadlock.
+    if [ "${KEEP_CUBE:-0}" = 1 ]; then
+        local need free t=0
+        need=$(find "$CAMP" -maxdepth 1 -name 'field_*.jls' -printf '%s\n' 2>/dev/null | sort -n | tail -1)
+        if [ -n "${need:-}" ] && [ "$need" -gt 0 ]; then
+            need=$((need + need / 4))
+            while free=$(df -B1 --output=avail "$CAMP" | tail -1) && [ "$free" -lt "$need" ]; do
+                [ "$t" -eq 0 ] && echo "[$(date -u +%FT%TZ)] disk gate: $label waits for $((need / 2 ** 30)) GiB free in $CAMP (have $((free / 2 ** 30)))"
+                t=$((t + 30)); [ "$t" -gt 1800 ] && { echo "[$(date -u +%FT%TZ)] disk gate: TIMEOUT after 30 min — proceeding at risk"; break; }
+                sleep 30
+            done
+        fi
+    fi
     [ -f "$CAMP/cells.tsv" ] || printf 'label\tuuid\tscript\tbackend\toverrides\n' > "$CAMP/cells.tsv"
     printf '%s\t%s\t%s\t%s\t%s\n' "$label" "$uuid" "$(basename "$SCRIPT")" "${BACKEND:-?}" "$*" >> "$CAMP/cells.tsv"
     local log="$CAMP/run_${uuid}.log"

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -60,28 +60,38 @@ formula is compared against. `style` (colormap + per-panel colorrange) comes fro
 function write_field_products(
         fields_h, fields_far_h, harmonics, ffund, x_grid, y_grid;
         w₀, run_tag, outdir, source_datafile, title_prefix, fileprefix,
-        style = harmonic_field_style(), window = "hann",
+        style = harmonic_field_style(), window = "hann", n0 = 1,
     )
     fieldsets = fields_far_h === nothing ? (("total", fields_h),) :
         (("total", fields_h), ("far", fields_far_h))
     for (k, n) in enumerate(harmonics), (ftype, fh) in fieldsets
         tag = ftype == "far" ? "fieldfar" : "field"
         out = joinpath(outdir, @sprintf("%s_%s_h%d_%s.png", fileprefix, tag, n, run_tag))
+        # Boosted runs (n0 > 1) label bins as multiples of the on-axis backscattered line
+        # ω_bs = n0·ω₁ — the physically meaningful unit there; ω₁ multiples stay for n0 = 1.
+        # `kind`/filenames keep the raw bin number n (stable chip URLs across the rescale).
         plot_harmonic_grid(
             fh[k, :, :, :], x_grid, y_grid;
             w₀, labels = COMPLABELS, style...,
-            title = @sprintf(
-                "%s (%s field) — %dω₁ (%.3f× fundamental)",
-                title_prefix, ftype, n, ffund[k]
-            ),
+            title = n0 == 1 ?
+                @sprintf("%s (%s field) — %dω₁ (%.3f× fundamental)",
+                title_prefix, ftype, n, ffund[k]) :
+                @sprintf("%s (%s field) — %dω₁ = %.4g ω_bs (ω_bs = %dω₁)",
+                title_prefix, ftype, n, ffund[k] / n0, n0),
             outfile = out,
         )
         println("saved → $out")
         write_derived(
-            outdir; kind = "h$n", label = @sprintf("%dω₁ field maps", n), run_id = run_tag,
+            outdir; kind = "h$n",
+            label = n0 == 1 ? @sprintf("%dω₁ field maps", n) :
+                @sprintf("%.4g ω_bs field maps", n / n0),
+            run_id = run_tag,
             plot = basename(out), source = source_datafile,
             setup = Dict("field" => ftype), plot_params = Dict("apodization" => window),
-            description = "Field harmonic maps at $(n)ω₁ — each panel a component (Eˣ…Bᶻ). " *
+            description = "Field harmonic maps at $(n)ω₁" *
+                (n0 == 1 ? "" : " = $(round(n / n0, sigdigits = 4)) ω_bs (ω_bs = $(n0)ω₁, " *
+                    "the on-axis backscattered fundamental)") *
+                " — each panel a component (Eˣ…Bᶻ). " *
                 "Toggle total (far 1/R + near 1/R²) vs far (radiation 1/R only); the far field is " *
                 "what the LPWA analytic formula is compared against in the lpwa-vs-numeric view. " *
                 "Time→frequency reduction apodized with the '$window' window (leakage suppression).",
@@ -111,22 +121,43 @@ speckle hides while the raw maps stay the ground truth. One `envelope` chip per 
 """
 function write_envelope_products(
         fields_h, harmonics, x_grid, y_grid;
-        w₀, Z, Rmax, λ, grain_mult = 3.0, run_tag, outdir, source_datafile,
+        w₀, Z, Rmax, λ, n0 = 1, grain_mult = 3.0, run_tag, outdir, source_datafile,
         title_prefix, fileprefix,
     )
     px = x_grid[2] - x_grid[1]
     for (k, n) in enumerate(harmonics)
-        grain = (λ / n) * Z / (2 * Rmax)
+        # Aliased maps (bin n ≪ the 4γ² line n0) still carry the LINE's speckle: the grain is
+        # set by the physical scattered wavelength, not the bin label.
+        grain = (λ / max(n, n0)) * Z / (2 * Rmax)
         σ = grain_mult * grain
-        I_E = _gaussian_blur(dropdims(sum(abs2, fields_h[k, 1:3, :, :]; dims = 1); dims = 1), σ / px)
+        I_E_raw = dropdims(sum(abs2, fields_h[k, 1:3, :, :]; dims = 1); dims = 1)
+        I_E = _gaussian_blur(I_E_raw, σ / px)
         I_B = _gaussian_blur(dropdims(sum(abs2, fields_h[k, 4:6, :, :]; dims = 1); dims = 1), σ / px)
         out = joinpath(outdir, @sprintf("%s_envelope_h%d_%s.png", fileprefix, n, run_tag))
-        fig = Figure(size = (1100, 500))
+        fig = Figure(size = (1550, 500))
         for (j, (lbl, I)) in enumerate((("⟨|E|²⟩", I_E), ("⟨|B|²⟩", I_B)))
             ax = Axis(fig[1, j], title = lbl, xlabel = "x / w₀", ylabel = "y / w₀", aspect = 1)
             hm = heatmap!(ax, x_grid ./ w₀, y_grid ./ w₀, I, colormap = :viridis)
             Colorbar(fig[2, j], hm, vertical = false)
         end
+        # Azimuthal average: for axisymmetric features (beaming annuli) every radius averages
+        # hundreds of speckle grains — the strongest de-speckling available, no blur needed.
+        nx, ny = size(I_E_raw)
+        cx, cy = (nx + 1) / 2, (ny + 1) / 2
+        rmax_px = min(cx, cy) - 1
+        nbins = 60
+        acc = zeros(nbins); cnt = zeros(Int, nbins)
+        for j2 in 1:ny, i2 in 1:nx
+            r = hypot(i2 - cx, j2 - cy)
+            b = clamp(ceil(Int, r / rmax_px * nbins), 1, nbins)
+            r <= rmax_px || continue
+            acc[b] += I_E_raw[i2, j2]; cnt[b] += 1
+        end
+        prof = acc ./ max.(cnt, 1)
+        rs = ((1:nbins) .- 0.5) ./ nbins .* (rmax_px * px / w₀)
+        axp = Axis(fig[1, 3], title = "⟨|E|²⟩(r) azimuthal mean", xlabel = "r / w₀",
+            ylabel = "intensity", yscale = log10)
+        lines!(axp, rs, max.(prof, 1e-300))
         Label(fig[0, :], @sprintf("%s — intensity envelope at %dω₁ (blur σ = %.2g w₀ = %.3g grains)",
             title_prefix, n, σ / w₀, grain_mult), fontsize = 18)
         save(out, fig)
@@ -175,7 +206,7 @@ symmetric per-panel range) is owned by [`harmonic_field_style`], applied in [`wr
 function write_harmonic_products(
         fld, x_grid, y_grid, ω, δt; w₀, run_tag, outdir, source_datafile,
         harmonics = (1, 2, 3, 4), title_prefix, fileprefix, window = hann,
-        style = harmonic_field_style(),
+        style = harmonic_field_style(), n0 = 1,
     )
     N_samples = size(fld.E, 1)
     freqs = rfftfreq(N_samples, 1 / δt)
@@ -212,7 +243,7 @@ function write_harmonic_products(
     # the reduced maps by write_field_products so the cached-hmaps recolor path shares the code.
     write_field_products(
         fields_h, fields_far_h, harmonics, ffund, x_grid, y_grid;
-        w₀, run_tag, outdir, source_datafile, title_prefix, fileprefix, window = win_name, style,
+        w₀, run_tag, outdir, source_datafile, title_prefix, fileprefix, window = win_name, style, n0,
     )
 
     plots = String[]
@@ -221,7 +252,8 @@ function write_harmonic_products(
     # raw leakage floor (apodizing it would hide the very thing it diagnoses).
     plot_power_spectrum(
         freqs, power_spectrum(fld; window = nothing);
-        ω, labels = COMPLABELS, title = "$title_prefix — field power spectra (un-windowed)", outfile = psfile,
+        ω, labels = COMPLABELS, marks = collect(Float64, harmonics), n0,
+        title = "$title_prefix — field power spectra (un-windowed)", outfile = psfile,
     )
     println("saved → $psfile")
     push!(plots, psfile)
@@ -342,8 +374,11 @@ function recover_from_manifest(toml)
     # Envelope view geometry (inverse runs only): the blur grain needs the screen distance +
     # disk radius; both live in [setup]. `nothing` ⇒ no envelope chips (rest-electron runs).
     st = get(m, "setup", Dict())
+    # On-axis backscattered fundamental ω_bs = n0·ω₁ (≈4γ²): frequency unit for boosted runs'
+    # powspec axis + harmonic-map labels, and the envelope blur-grain wavelength.
+    n0 = round(Int, get(cfg, "backscatter_n0", 1))
     envgeo = (inverse && haskey(st, "Z") && haskey(st, "Rmax")) ?
-        (; Z = st["Z"], Rmax = st["Rmax"], λ = las["wavelength"]) : nothing
+        (; Z = st["Z"], Rmax = st["Rmax"], λ = las["wavelength"], n0) : nothing
     envelope!(fields_h, harmonics, x_grid, y_grid, w₀) = envgeo === nothing ? nothing :
         write_envelope_products(
             fields_h, harmonics, x_grid, y_grid;
@@ -368,7 +403,7 @@ function recover_from_manifest(toml)
         hprod = write_harmonic_products(
             fld, x_grid, y_grid, ω, δt;
             w₀ = las["w0"], run_tag, outdir = dir,
-            source_datafile = m["outputs"]["datafile"], title_prefix, fileprefix, style,
+            source_datafile = m["outputs"]["datafile"], title_prefix, fileprefix, style, n0,
             # The run's own bins (≈4γ²ω for inverse :narrow) — a deferred reduction must produce
             # exactly what the inline (non-SKIP_POST) path would have; legacy default (1,2,3,4).
             harmonics = Tuple(get(cfg, "harmonics", (1, 2, 3, 4))),
@@ -405,7 +440,7 @@ function recover_from_manifest(toml)
     write_field_products(
         h.fields_h, far, h.harmonics, ffund, h.x_grid, h.y_grid;
         w₀ = h.w₀, run_tag, outdir = dir,
-        source_datafile = m["outputs"]["datafile"], title_prefix, fileprefix, window = win, style,
+        source_datafile = m["outputs"]["datafile"], title_prefix, fileprefix, window = win, style, n0,
     )
     envelope!(h.fields_h, h.harmonics, h.x_grid, h.y_grid, h.w₀)
     return write_phase_products(

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -319,35 +319,25 @@ function write_phase_products(
                 "in the Plot parameters.",
         )
         push!(plots, out)
-
-        # Polar companion — separate chip (azimuth → angular axis, ∠F → radial).
-        pout = joinpath(outdir, @sprintf("%s_phasePolar%s_h%d_%s.png", fileprefix, fld_tag, n, run_tag))
-        plot_phase_polar(
-            fields_h[k, comps, :, :], x_grid, y_grid;
-            w₀, labels = lbls, radii = ringradii, tol = ringtol,
-            title = @sprintf("%s — ∠F %s-field (polar) at %dω₁", title_prefix, fld_tag, n), outfile = pout,
-        )
-        println("saved → $pout")
-        write_derived(
-            outdir; kind = "phasePolar$fld_tag", label = "$title_prefix ∠F $fld_tag (polar)",
-            run_id = run_tag, plot = basename(pout), source = source_datafile,
-            setup = Dict("harmonic" => n), plot_params = base_pp,
-        )
-        push!(plots, pout)
     end
+    # phasePolar RETIRED (2026-07-19): the polar view duplicated the ring-scatter panel's
+    # information; `plot_phase_polar` stays in the package for manual use, and
+    # `_retire_stale_phase` cleans previously-published polar artifacts on recolor.
     return plots
 end
 
-# Delete the superseded single-grid phase artifacts (kinds `phase`/`phaserings`) for `run_tag` so
-# a re-plotted run doesn't show both old and new (phaseE/phaseB) chips. Matches the OLD names only
-# (NOT `phaseE`/`phaseB`): `derived_phase_<n>_<id8>` / `derived_phaserings_…` sidecars carrying this
-# run's id8, and `*_phase_h<n>_<tag>.png` / `*_phaserings_h<n>_<tag>.png`.
+# Delete superseded phase artifacts for `run_tag` so a re-plotted run doesn't show retired
+# chips alongside current ones: the old single-grid kinds (`phase`/`phaserings`, replaced by
+# phaseE/phaseB) and the retired `phasePolar<E|B>` companion (2026-07-19 — duplicated the ring
+# scatter). Matches the OLD names only (NOT `phaseE`/`phaseB`).
 function _retire_stale_phase(dir, run_tag)
     id8 = first(run_tag, 8)
     for f in readdir(dir)
-        stale = ((occursin(r"^derived_phase_\d", f) || startswith(f, "derived_phaserings_")) && occursin(id8, f)) ||
+        stale = ((occursin(r"^derived_phase_\d", f) || startswith(f, "derived_phaserings_") ||
+                  startswith(f, "derived_phasePolar")) && occursin(id8, f)) ||
             occursin(Regex("_phase_h\\d+_" * run_tag * "\\.png\$"), f) ||
-            occursin(Regex("_phaserings_h\\d+_" * run_tag * "\\.png\$"), f)
+            occursin(Regex("_phaserings_h\\d+_" * run_tag * "\\.png\$"), f) ||
+            occursin(Regex("_phasePolar[EB]_h\\d+_" * run_tag * "\\.png\$"), f)
         stale || continue
         rm(joinpath(dir, f))
         println("retired stale → $f")

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -444,11 +444,12 @@ else
         harmonics = HARMONICS,   # :narrow ⇒ around the ≈4γ²ω backscatter line; :full ⇒ (1,2,3,4)
         title_prefix = "Inverse Thomson scattering", fileprefix = "inverse_thomson",
         style = harmonic_field_style(cap_mult = 4.0),   # speckle maps: median-capped colorrange
+        n0 = N0,                 # boosted runs label frequencies in ω_bs = N0·ω₁ units
     )
     # Speckle-envelope chips (per-bin maps are envelope × speckle; see the report).
     write_envelope_products(
         hprod.fields_h, HARMONICS, screen.x_grid, screen.y_grid;
-        w₀, Z, Rmax, λ, run_tag = RUN_TAG, outdir = OUTDIR,
+        w₀, Z, Rmax, λ, n0 = N0, run_tag = RUN_TAG, outdir = OUTDIR,
         source_datafile = basename(datafile),
         title_prefix = "Inverse Thomson scattering", fileprefix = "inverse_thomson",
     )

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -108,6 +108,8 @@ const TSPAN_TAU = parse(Float64, get(ENV, "EDM_TSPAN_TAU", "8")) # proper-time s
 TSPAN_TAU > 0 || error("EDM_TSPAN_TAU must be > 0, got $TSPAN_TAU")
 const SYNC = parse(Bool, get(ENV, "EDM_SYNC_PER_ELECTRON", "false"))
 const FIELD_MODE = Symbol(get(ENV, "EDM_FIELD_MODE", "split"))   # :split → (E,B,E_far,B_far) | :total → (E,B) only (halves VRAM/output)
+const SYSTEM = lowercase(get(ENV, "EDM_SYSTEM", "classical"))    # electron dynamics: classical | ll (Landau–Lifshitz radiation reaction)
+SYSTEM in ("classical", "ll") || error("EDM_SYSTEM must be \"classical\" or \"ll\", got \"$SYSTEM\"")
 FIELD_MODE in (:split, :total) || error("EDM_FIELD_MODE must be \"split\" or \"total\", got \"$FIELD_MODE\"")
 # Observer-time window mode. :full = the wide legacy window (coarse δt=T/SPP; at SPP=16 the ≈4γ²ω
 # backscatter line ALIASES onto ~2ω — see header). :narrow = recentre the sample window on the burst
@@ -275,7 +277,11 @@ end
     initial_phase = ϕ₀,
     k_direction = [0, 0, -1],
 )
-@named elec = ClassicalElectron(; laser)
+elec = if SYSTEM == "ll"
+    @named elec = LandauLifshitzElectron(; laser)
+else
+    @named elec = ClassicalElectron(; laser)
+end
 sys = mtkcompile(elec)
 
 # Meet-at-origin timing: with x⁰(τ)=γc·τ and z(τ)=γβc·τ (force-free flight), every electron
@@ -470,6 +476,7 @@ config = Dict{String, Any}(
     "sync_per_electron" => SYNC,       # replay input: run_spec_from_manifest reads this
     "observable" => "field",           # distinguishes this run from the 4-potential (_A) runs
     "scattering" => "inverse",         # counter-propagating boosted electrons vs. rest-electron thomson_scattering.jl
+    "system" => SYSTEM,                # classical | ll — written unconditionally (mixed pools crash axis detection)
     "window" => string(WINDOW),        # :full (wide, coarse) | :narrow (burst-centred, high-SPP)
     "screen_hw_w0" => SCREEN_HW,       # EDM_SCREEN_HW knob (w₀ units; [setup].screen_hw is the derived a.u. value)
     "tspan_tau" => TSPAN_TAU,          # EDM_TSPAN_TAU knob (proper-time span per side, τ units; [setup].τi/τf are derived)

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -495,6 +495,7 @@ config = Dict{String, Any}(
 
 outputs = Dict{String, Any}(
     "datafile" => basename(datafile),
+    "gpu_trace" => basename(gputracefile),   # builder gates the util/power/VRAM panels on this key
     "log" => "run_$(RUN_TAG).log",   # captured by the run wrapper; travels with the run
 )
 if !SKIP_POST

--- a/scripts/ll_system_chips.jl
+++ b/scripts/ll_system_chips.jl
@@ -1,0 +1,146 @@
+# System-view chips + comparison declarations for LL campaigns.
+#
+# classical | Landau–Lifshitz is a VIEW of the same cell (the builder collapses each
+# common-disk pair via VIEW_PARAMS): per harmonic, a `sys_h<n>` kind whose two sidecars
+# (anchored on the CLASSICAL run) vary only in setup.system — the builder renders one picker
+# per varying setup key per kind, so harmonic must live in the KIND, not in setup (a shared
+# kind="sysview" flattened 4 harmonics × 3 systems into one 12-value picker).
+#
+# The LL − classical diff (common-disk complex difference — cancels shared speckle, isolates
+# the coherent RR imprint; the speckle report's bunched-diff pattern) is NOT a view of either
+# run: it's emitted as 2-parent `diff` artifacts + a [comparison] declaration per campaign
+# (differs = system, along = gamma or a0), surfacing on the comparison tab like the
+# Newton-vs-RK4 kernel comparison, with ladder navigation along the campaign axis.
+#
+#   julia +release --project=scripts scripts/ll_system_chips.jl <campaign_dir>
+using TOML, Serialization, Statistics, Printf
+using ElectronDynamicsModels
+using CairoMakie
+using RunManifests
+
+include(joinpath(@__DIR__, "harmonic_products.jl"))   # harmonic_field_style, COMPLABELS
+
+function load_cells(dir)
+    cells = []
+    for f in sort(readdir(dir))
+        (startswith(f, "run_") && endswith(f, ".toml")) || continue
+        m = TOML.parsefile(joinpath(dir, f))
+        id = m["provenance"]["run_id"]
+        hm = joinpath(dir, "hmaps_$id.jls")
+        isfile(hm) || continue
+        c = m["config"]
+        push!(cells, (; id, system = get(c, "system", "classical"), gamma = get(c, "gamma", 0),
+            a0 = c["a0"], iters = get(c, "newton_iters", 2),
+            n0 = round(Int, get(c, "backscatter_n0", 1)), h = deserialize(hm)))
+    end
+    return cells
+end
+
+function main(dir)
+    cells = load_cells(dir)
+    groups = Dict()
+    for c in cells
+        push!(get!(groups, (c.gamma, c.a0, c.iters), []), c)
+    end
+    style = harmonic_field_style(cap_mult = 4.0)
+    pairs = []
+    for ((γ, a0, it), g) in groups
+        cl = findfirst(c -> c.system == "classical", g)
+        ll = findfirst(c -> c.system == "ll", g)
+        (cl === nothing || ll === nothing) && continue
+        cl, ll = g[cl], g[ll]
+        push!(pairs, (; γ, a0, it))
+        w₀ = cl.h.w₀
+        # Boosted pairs (n0 > 1) label bins in ω_bs = n0·ω₁ units, like the h<n> chips.
+        hlabel(n) = cl.n0 == 1 ? "$(n)ω₁" : @sprintf("%.4g ω_bs", n / cl.n0)
+        for (k, n) in enumerate(cl.h.harmonics)
+            # classical | Landau–Lifshitz — the two views of the cell (far/total pattern).
+            for (view, maps) in (("classical", cl.h.fields_h[k, :, :, :]),
+                    ("ll", ll.h.fields_h[k, :, :, :]))
+                out = joinpath(dir, @sprintf("inverse_thomson_sys_%s_h%d_%s.png", view, n, first(cl.id, 8)))
+                plot_harmonic_grid(
+                    maps, cl.h.x_grid, cl.h.y_grid;
+                    w₀, labels = COMPLABELS, style...,
+                    title = @sprintf("γ=%g a₀=%g — %s at %s", γ, a0, view, hlabel(n)),
+                    outfile = out,
+                )
+                write_derived(
+                    dir; kind = "sys_h$n", label = "system view $(hlabel(n))",
+                    run_id = cl.id, plot = basename(out),
+                    source = "hmaps_$(view == "classical" ? cl.id : ll.id).jls",
+                    setup = Dict("system" => view),
+                    description = "Classical | Landau–Lifshitz views of the same cell " *
+                        "(common disk). The LL − classical difference lives on the campaign's " *
+                        "comparison card. LL partner run: $(first(ll.id, 8)).",
+                )
+                println("saved → $(basename(out))")
+            end
+            # LL − classical (common disk) — a comparison artifact between the two runs, not a
+            # view of either: 2 parents route it to the comparison card's matched cell.
+            dmaps = ll.h.fields_h[k, :, :, :] .- cl.h.fields_h[k, :, :, :]
+            out = joinpath(dir, @sprintf("inverse_thomson_sys_diff_h%d_%s.png", n, first(cl.id, 8)))
+            plot_harmonic_grid(
+                dmaps, cl.h.x_grid, cl.h.y_grid;
+                w₀, labels = COMPLABELS, style...,
+                title = @sprintf("γ=%g a₀=%g — diff at %s  (LL − classical, common disk)",
+                    γ, a0, hlabel(n)),
+                outfile = out,
+            )
+            write_derived(
+                dir; kind = "diff", label = "LL − classical field maps",
+                run_id = [cl.id, ll.id], plot = basename(out),
+                source = "hmaps_$(ll.id).jls",
+                setup = Dict("harmonic" => n),
+                plot_params = Dict("rel-L2 (E)" =>
+                    round(sqrt(sum(abs2, dmaps[1:3, :, :])) /
+                          max(sqrt(sum(abs2, cl.h.fields_h[k, 1:3, :, :])), eps()), sigdigits = 3)),
+                description = "Common-disk complex difference LL − classical at $(hlabel(n)) — " *
+                    "cancels the shared speckle and isolates the coherent radiation-reaction " *
+                    "imprint (rel-L2 ∝ a₀²γ, saturating at the √2 decorrelation ceiling).",
+            )
+            println("saved → $(basename(out))")
+        end
+    end
+    write_system_comparisons(dir, pairs)
+    return
+end
+
+# One [comparison] declaration per campaign (differs = system): a ladder along gamma (γ-ladder
+# shape: one a₀) or along a0 (pinned to the majority γ), plus a single-cell pair card for any
+# off-ladder pair (e.g. the γ=2000 satellite). Sides select raw runs by `where` — the builder
+# resolves view-collapsed LL members from the pre-collapse run list.
+function write_system_comparisons(dir, pairs)
+    isempty(pairs) && return
+    camp = basename(abspath(dir))
+    side(sys, w) = Dict("label" => sys == "ll" ? "Landau–Lifshitz" : "classical",
+        "dir" => camp, "where" => merge(Dict{String, Any}("system" => sys), w))
+    decl(w, along, tag) = begin
+        out = write_comparison(
+            dir; label = "radiation reaction: Landau–Lifshitz vs classical",
+            differs = "system", along,
+            sides = [side("classical", w), side("ll", w)],
+            filename = "comparison_$(camp)_system$(tag).toml",
+        )
+        println("comparison → $(basename(out))  (along = $along)")
+    end
+    its = unique(p.it for p in pairs)
+    itpin = length(its) == 1 ? Dict{String, Any}("newton_iters" => its[1]) : Dict{String, Any}()
+    γs, a0s = unique(p.γ for p in pairs), unique(p.a0 for p in pairs)
+    if length(γs) > 1 && length(a0s) == 1
+        decl(merge(itpin, Dict{String, Any}("a0" => a0s[1])), "gamma", "")
+    else
+        γmaj = argmax(γ -> count(p -> p.γ == γ, pairs), γs)
+        mains = [p for p in pairs if p.γ == γmaj]
+        length(mains) ≥ 2 && decl(merge(itpin, Dict{String, Any}("gamma" => γmaj)), "a0", "")
+        for p in pairs
+            (length(mains) ≥ 2 && p.γ == γmaj) && continue
+            decl(merge(itpin, Dict{String, Any}("gamma" => p.γ, "a0" => p.a0)), "gamma",
+                "_g$(Int(p.γ))a$(p.a0)")
+        end
+    end
+    return
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(isempty(ARGS) ? "." : ARGS[1])
+end

--- a/scripts/ll_system_chips.jl
+++ b/scripts/ll_system_chips.jl
@@ -1,10 +1,14 @@
-# System-view chips + comparison declarations for LL campaigns.
+# System-view pickers + comparison declarations for LL campaigns.
 #
 # classical | Landau–Lifshitz is a VIEW of the same cell (the builder collapses each
-# common-disk pair via VIEW_PARAMS): per harmonic, a `sys_h<n>` kind whose two sidecars
-# (anchored on the CLASSICAL run) vary only in setup.system — the builder renders one picker
-# per varying setup key per kind, so harmonic must live in the KIND, not in setup (a shared
-# kind="sysview" flattened 4 harmonics × 3 systems into one 12-value picker).
+# common-disk pair via VIEW_PARAMS), surfaced directly on the pair's `h<n>` field-map chips:
+# the classical run's auto-emitted single-value sidecar is REPLACED by two sidecars that reuse
+# the two runs' existing field-map PNGs (no re-render), varying only in setup.system. This
+# works because LL pairs run total-mode cubes — `field` is constant within the kind, so
+# `system` is the single varying setup key the builder renders as one picker (a second varying
+# key would flatten the picker into a cross-product — the retired kind="sysview" lesson);
+# split-mode pairs are guarded and skipped. Run AFTER any recolor pass: write_field_products
+# re-emits the single-value sidecar this script replaces.
 #
 # The LL − classical diff (common-disk complex difference — cancels shared speckle, isolates
 # the coherent RR imprint; the speckle report's bunched-diff pattern) is NOT a view of either
@@ -53,27 +57,33 @@ function main(dir)
         w₀ = cl.h.w₀
         # Boosted pairs (n0 > 1) label bins in ω_bs = n0·ω₁ units, like the h<n> chips.
         hlabel(n) = cl.n0 == 1 ? "$(n)ω₁" : @sprintf("%.4g ω_bs", n / cl.n0)
+        split = hasproperty(cl.h, :fields_far_h) && cl.h.fields_far_h !== nothing
+        split && @warn "split-mode pair — a system toggle on h<n> would add a second varying " *
+            "setup key (field) and flatten the picker; skipping the view merge" γ a0
+        win = hasproperty(cl.h, :window) ? cl.h.window : "hann"
         for (k, n) in enumerate(cl.h.harmonics)
-            # classical | Landau–Lifshitz — the two views of the cell (far/total pattern).
-            for (view, maps) in (("classical", cl.h.fields_h[k, :, :, :]),
-                    ("ll", ll.h.fields_h[k, :, :, :]))
-                out = joinpath(dir, @sprintf("inverse_thomson_sys_%s_h%d_%s.png", view, n, first(cl.id, 8)))
-                plot_harmonic_grid(
-                    maps, cl.h.x_grid, cl.h.y_grid;
-                    w₀, labels = COMPLABELS, style...,
-                    title = @sprintf("γ=%g a₀=%g — %s at %s", γ, a0, view, hlabel(n)),
-                    outfile = out,
-                )
-                write_derived(
-                    dir; kind = "sys_h$n", label = "system view $(hlabel(n))",
-                    run_id = cl.id, plot = basename(out),
-                    source = "hmaps_$(view == "classical" ? cl.id : ll.id).jls",
-                    setup = Dict("system" => view),
-                    description = "Classical | Landau–Lifshitz views of the same cell " *
-                        "(common disk). The LL − classical difference lives on the campaign's " *
-                        "comparison card. LL partner run: $(first(ll.id, 8)).",
-                )
-                println("saved → $(basename(out))")
+            # classical | Landau–Lifshitz directly on the pair's h<n> chip: two sidecars
+            # reusing the runs' own field-map PNGs (write_field_products already rendered
+            # both); the classical run's auto single-value sidecar is replaced below.
+            if !split
+                for (view, r) in (("classical", cl), ("ll", ll))
+                    write_derived(
+                        dir; kind = "h$n",
+                        label = cl.n0 == 1 ? @sprintf("%dω₁ field maps", n) :
+                            @sprintf("%.4g ω_bs field maps", n / cl.n0),
+                        run_id = cl.id,
+                        plot = @sprintf("inverse_thomson_field_h%d_%s.png", n, r.id),
+                        source = "hmaps_$(r.id).jls",
+                        setup = Dict("field" => "total", "system" => view),
+                        plot_params = Dict("apodization" => win),
+                        description = "Field harmonic maps at $(hlabel(n)) — toggle the " *
+                            "electron model (classical | Landau–Lifshitz, common disk). The " *
+                            "LL − classical difference lives on the campaign's comparison " *
+                            "card. LL partner run: $(first(ll.id, 8)).",
+                    )
+                end
+                rm(joinpath(dir, "derived_h$(n)_total_$(first(cl.id, 8)).toml"); force = true)
+                println("h$n → system picker (classical|ll)")
             end
             # LL − classical (common disk) — a comparison artifact between the two runs, not a
             # view of either: 2 parents route it to the comparison card's matched cell.

--- a/src/gpu/accumulate.jl
+++ b/src/gpu/accumulate.jl
@@ -143,3 +143,34 @@ function _gpu_accumulate_kernel!(gpu_traj, screen, τ_all_cpu, τ_buf, A_buf, ba
     end
     return
 end
+
+"""
+    _download_permuted(buf) -> Array{T,4}
+
+Download an accumulation buffer laid out `[ix, iy, μ, k]` (pixel-fastest for coalesced
+device writes; observer slot `k` slowest) into the cube layout `[k, μ, ix, iy]` without a
+full-size intermediate. The old `permutedims(Array(buf), (4, 3, 1, 2))` held cube + copy on
+the host — a 2× peak that capped carrier-resolved cube designs at ~half the node's RAM (the
+permute lives on the host because the >2³¹-element GPU `permutedims` overflows its 32-bit
+linear indices, cudaError 700). Downloading contiguous `k`-chunks through the linear
+`copyto!` DMA path and `permutedims!`-ing each into a view of the preallocated cube keeps
+the host peak at ~(1 + 1/16)× cube; device memory and kernels are untouched, and every
+transfer stays far below 2³¹ elements. Works unchanged on the CPU backend (`buf::Array`).
+"""
+function _download_permuted(buf::AbstractArray{T, 4}) where {T}
+    Nx, Ny, M, K = size(buf)
+    out = Array{T, 4}(undef, K, M, Nx, Ny)
+    chunk = max(1, cld(K, 16))
+    stage = Array{T}(undef, Nx * Ny * M * chunk)
+    bufv = vec(buf)
+    slab = Nx * Ny * M
+    for k0 in 1:chunk:K
+        nk = min(chunk, K - k0 + 1)
+        copyto!(stage, 1, bufv, (k0 - 1) * slab + 1, nk * slab)
+        permutedims!(
+            view(out, k0:(k0 + nk - 1), :, :, :),
+            reshape(view(stage, 1:(nk * slab)), Nx, Ny, M, nk), (4, 3, 1, 2),
+        )
+    end
+    return out
+end

--- a/src/gpu/kernel_newton.jl
+++ b/src/gpu/kernel_newton.jl
@@ -265,7 +265,7 @@ function accumulate_potential(
         finalize(gpu_traj.itp.c2)
     end
 
-    return permutedims(Array(A_buf), (4, 3, 1, 2))
+    return _download_permuted(A_buf)
 end
 
 # ── Field variant of the Newton light-cone kernel ──
@@ -404,16 +404,16 @@ function accumulate_field(
     end
 
     if mode == Val(:split)
-        E_far = permutedims(Array(E1_buf), (4, 3, 1, 2))
-        B_far = permutedims(Array(B1_buf), (4, 3, 1, 2))
-        E_near = permutedims(Array(E2_buf), (4, 3, 1, 2))
-        B_near = permutedims(Array(B2_buf), (4, 3, 1, 2))
+        E_far = _download_permuted(E1_buf)
+        B_far = _download_permuted(B1_buf)
+        E_near = _download_permuted(E2_buf)
+        B_near = _download_permuted(B2_buf)
         E = E_far .+ E_near
         B = B_far .+ B_near
         return (; E, B, E_far, B_far)
     else
-        E = permutedims(Array(E1_buf), (4, 3, 1, 2))
-        B = permutedims(Array(B1_buf), (4, 3, 1, 2))
+        E = _download_permuted(E1_buf)
+        B = _download_permuted(B1_buf)
         return (; E, B)
     end
 end

--- a/src/gpu/kernel_rk4.jl
+++ b/src/gpu/kernel_rk4.jl
@@ -266,11 +266,9 @@ function accumulate_potential(
     end
 
     # Permute the pixel-fastest buffer back to the public (N_samples, 4, Nx, Ny)
-    # layout. Do it on the HOST: a full-res A_buf has > 2³¹ elements
-    # (400·400·4·8000 = 5.12e9) and GPU `permutedims` uses 32-bit linear
-    # indexing → illegal-address overflow. The device→host copy is 64-bit-safe,
-    # so copy first, then permute with CPU (Int64) indexing.
-    return permutedims(Array(A_buf), (4, 3, 1, 2))
+    # layout on the HOST (GPU permutedims overflows 32-bit indices past 2³¹ elements),
+    # chunked so the peak stays ~1× cube instead of 2× — see _download_permuted.
+    return _download_permuted(A_buf)
 end
 
 # ── Field variant of the unified RK4 kernel ──
@@ -455,17 +453,17 @@ function accumulate_field(
     end
 
     if mode == Val(:split)
-        E_far = permutedims(Array(E1_buf), (4, 3, 1, 2))
-        B_far = permutedims(Array(B1_buf), (4, 3, 1, 2))
-        E_near = permutedims(Array(E2_buf), (4, 3, 1, 2))
-        B_near = permutedims(Array(B2_buf), (4, 3, 1, 2))
+        E_far = _download_permuted(E1_buf)
+        B_far = _download_permuted(B1_buf)
+        E_near = _download_permuted(E2_buf)
+        B_near = _download_permuted(B2_buf)
         E = E_far .+ E_near
         B = B_far .+ B_near
         return (; E, B, E_far, B_far)
     else
         # Level-2: far+near already summed in the kernel → E1/B1 hold the total directly.
-        E = permutedims(Array(E1_buf), (4, 3, 1, 2))
-        B = permutedims(Array(B1_buf), (4, 3, 1, 2))
+        E = _download_permuted(E1_buf)
+        B = _download_permuted(B1_buf)
         return (; E, B)
     end
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -26,11 +26,13 @@ calling this without it raises a `MethodError`.
 function plot_harmonic_grid end
 
 """
-    plot_power_spectrum(freqs, power_spec; ω, labels, colors=…, linestyles=nothing, title="", outfile=nothing)
+    plot_power_spectrum(freqs, power_spec; ω, labels, marks=nothing, n0=1, colors=…, linestyles=nothing, title="", outfile=nothing)
 
 Log-y plot of per-component power spectra `power_spec` (`(Nf, n)`, from [`power_spectrum`]) vs
-`freqs`, x-axis in units of the fundamental ω₁ (= `ω/2π`), with dashed integer-harmonic markers
-and a legend. Saves to `outfile` if given; returns the `Figure`.
+`freqs`, x-axis in units of the run's radiated fundamental: ω₁ (= `ω/2π`) when `n0 = 1`, else
+the backscattered line ω_bs = `n0`·ω₁ (boosted runs; `n0 ≈ 4γ²` from the manifest's
+`backscatter_n0`). Reference gridlines come from Makie's automatic ticks; `marks` (extracted
+harmonic bins, in ω₁ units) adds explicit guides. Saves to `outfile` if given; returns the `Figure`.
 
 **Requires CairoMakie** — `using CairoMakie` activates the implementation (package extension).
 """


### PR DESCRIPTION
Consolidates the Landau–Lifshitz campaign stream (night-2 + the probe/S work):

## Physics / pipeline
- **`EDM_SYSTEM=classical|ll`** knob in `inverse_thomson_scattering.jl` (LandauLifshitzElectron pairs on common disks) + `[config].system` in manifests.
- **ω_bs frequency units** across plotting: `plot_power_spectrum` axis in the backscattered fundamental (`n0 = backscatter_n0 ≈ 4γ²`), hand-drawn integer comb removed (≥10⁶ aligned-dash vlines rendered as solid gray bars at γ≫1; Makie's auto tick grid replaces it, explicit guides only at extracted bins). `h<n>` chip labels/titles as ω_bs multiples; envelope blur grain at the line wavelength (live path was blurring with the bin-1 grain).
- **`ll_system_chips.jl`**: classical|Landau–Lifshitz view picker directly on the pair's `h<n>` chips (reuses existing PNGs), LL − classical diffs as 2-parent comparison artifacts + per-campaign `[comparison]` declarations (differs=system, along=γ/a₀). phasePolar retired (recolor auto-cleans).
- **Chunked host download-permute**: cube returns at ~1.06× host peak instead of 2× (the >2³¹ GPU permutedims Int32 overflow forced host permutes; the 2× copy capped carrier-resolved designs at half the node RAM). Verified vs monolithic permute + gpu_radiation 40/40.

## Campaigns
`ll_gamma_ladder`, `ll_a0_ladder`, `ll_rr_strength` (night-2, published), `ll_probe` (γ=1000 carrier-resolved, SPP Nyquist fix from the crashed probes), `ll_probe_s` (γ=100 deep-RR, carrier- AND grain-resolved, 361²), `ll_probe_rerun`/`ll_probe_fix` (disk-overflow casualties).

## Orchestration hardening (each from a real incident)
- runpod.sh: caller env overrides survive config.env for all knobs (a caller's `RUNPOD_VOLUME_GB=1400` silently reverted to 0 → volumeless pod for a volume-dependent campaign).
- run_cell.sh: adaptive disk gate (lazy container-disk quotas turn overfull writes into silent truncation surfacing as reduce-time EOFError).
- cube_drain_r2.sh: `DRAIN_DELETE_LOCAL=1` for small-disk pods.
- hotaisle.sh: verify hashes exclude cubes from the file list (not just the output); teardown wording matches the validated API-DELETE reliability.

## Known followups (deliberately not in this PR)
- Per-state ssh ControlPath in runpod.sh (two concurrent drivers multiplex onto one master socket — discovered live; `runpod_b.sh` copy is the running stopgap, fold back once drivers exit).
- Wire DRAIN_DELETE_LOCAL into the volumeless-pod drainer start; RunPod create-error logging in grab_pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cn5htwc8e3JAe2iVhALLXh