### PR TITLE
gammatau: γ(τ)/γ₀ trace + classical-vs-LL comparison product

### DIFF
--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -249,13 +249,15 @@ function write_harmonic_products(
     # Drain-path only (EDM_REDUCTION_MARKER set by run_cell _reduce_cell): enumerate the cache in .reduced.
     if get(ENV, "EDM_REDUCTION_MARKER", "0") == "1"
         record_reduction!(outdir, run_tag, hmapsfile)
-        # The solver-side γ(τ) trace (inverse runs, EDM_GAMMA_TRACE_OVERSAMPLE > 0) is a reduction
-        # cache too: the gammatau comparison chip (ll_system_chips.jl) re-renders from it and can
-        # NEVER be rebuilt from the cube — the trajectories are gone after the run — so it must
-        # ride the same publish-autonomy enumeration. Written at run time, recorded here at reduce
-        # time because only the drain path stamps the marker.
-        gtfile = joinpath(outdir, "gammatau_$(run_tag).jls")
-        isfile(gtfile) && record_reduction!(outdir, run_tag, gtfile)
+        # Solver-side caches — the γ(τ) trace (EDM_GAMMA_TRACE_OVERSAMPLE > 0) and the as-run
+        # IC table — are publish-autonomy caches too: their chips re-render from them and can
+        # NEVER be rebuilt from the cube (the trajectories are gone after the run). They are
+        # written at run time but recorded here at reduce time, because only the drain path
+        # stamps the marker. isfile-guarded: rest-electron runs emit neither.
+        for pre in ("gammatau_", "ic_")
+            f = joinpath(outdir, "$(pre)$(run_tag).jls")
+            isfile(f) && record_reduction!(outdir, run_tag, f)
+        end
     end
 
     # Reduce-only mode (`.reduce_only` flag in outdir, or EDM_REDUCE_ONLY=1): do ONLY the work

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -247,7 +247,16 @@ function write_harmonic_products(
     )
     println("serialized harmonic maps → $hmapsfile  (window = $win_name)")
     # Drain-path only (EDM_REDUCTION_MARKER set by run_cell _reduce_cell): enumerate the cache in .reduced.
-    get(ENV, "EDM_REDUCTION_MARKER", "0") == "1" && record_reduction!(outdir, run_tag, hmapsfile)
+    if get(ENV, "EDM_REDUCTION_MARKER", "0") == "1"
+        record_reduction!(outdir, run_tag, hmapsfile)
+        # The solver-side γ(τ) trace (inverse runs, EDM_GAMMA_TRACE_OVERSAMPLE > 0) is a reduction
+        # cache too: the gammatau comparison chip (ll_system_chips.jl) re-renders from it and can
+        # NEVER be rebuilt from the cube — the trajectories are gone after the run — so it must
+        # ride the same publish-autonomy enumeration. Written at run time, recorded here at reduce
+        # time because only the drain path stamps the marker.
+        gtfile = joinpath(outdir, "gammatau_$(run_tag).jls")
+        isfile(gtfile) && record_reduction!(outdir, run_tag, gtfile)
+    end
 
     # Reduce-only mode (`.reduce_only` flag in outdir, or EDM_REDUCE_ONLY=1): do ONLY the work
     # that needs the cube in RAM — hmaps + the powspec cache — and skip every plot render.

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -429,6 +429,48 @@ if GAMMA_TRACE_OS > 0
     @info "γ(τ)/γ₀ trace serialized" t_gtrace n_τ = length(γτ_grid) mean_drain = sum(γdrain) / length(γdrain)
 end
 
+# ── As-run initial conditions: cache + chip. The disk and its Δz offsets are deterministic
+# from [config], but the cache pins the EXACT as-run xμ₀/u₀ (reconstruction drift becomes
+# visible instead of silent) and lets the IC chip re-render anywhere without an EDM solve —
+# the same publish-autonomy contract as the γ(τ) trace (both are enumerated in the .reduced
+# marker at reduce time). `datafile` on the sidecar ships the cache to the storagebox and
+# puts a /data download URL on the chip. Cheap (N×4 floats ≈ 64 KB at N = 2000): always on.
+function write_ic_products(xμ0, u0, dz, outdir, run_tag; γ0, λ, w₀, nb, l, chirp)
+    icfile = joinpath(outdir, "ic_$(run_tag).jls")
+    X = permutedims(reduce(hcat, xμ0))       # N×4 as-run start 4-positions (bunch_dz included)
+    serialize(icfile, (; xμ0 = X, u0 = collect(u0), dz = collect(dz), γ0, λ, w₀,
+        bunch = (; nb, l, chirp)))
+    x, y = X[:, 2] ./ λ, X[:, 3] ./ λ
+    dzλ = collect(dz) ./ λ
+    fig = Figure(size = (1080, 480))
+    ax1 = Axis(fig[1, 1]; title = "start disk, colored by bunching offset Δz",
+        xlabel = "x  [λ]", ylabel = "y  [λ]", aspect = 1)
+    sc = scatter!(ax1, x, y; color = dzλ, markersize = 5)
+    Colorbar(fig[1, 2], sc; label = "Δz  [λ]")
+    ax2 = Axis(fig[1, 3]; title = "arrival surface: lens parabola + helix spread",
+        xlabel = "(ρ/w₀)²", ylabel = "Δz  [λ]")
+    scatter!(ax2, (x .^ 2 .+ y .^ 2) .* (λ / w₀)^2, dzλ;
+        color = atan.(y, x), colormap = :twilight, markersize = 4)
+    Label(fig[0, :], @sprintf("as-run initial conditions — N = %d, γ = %g, n_b = %d, ℓ = %d",
+        length(x), γ0, nb, l), fontsize = 17)
+    out = joinpath(outdir, "inverse_thomson_ic_$(run_tag).png")
+    save(out, fig)
+    write_derived(
+        outdir; kind = "ic", label = "initial conditions (as run)",
+        run_id = run_tag, plot = basename(out), datafile = basename(icfile),
+        plot_params = Dict("N" => length(x), "bunch_nb" => nb, "bunch_l" => l,
+            "max |Δz| [λ]" => round(maximum(abs, dzλ); sigdigits = 3)),
+        description = "The exact as-run start disk: transverse sunflower positions colored by " *
+            "the longitudinal bunching offset Δz (the arrival-surface placement), and Δz against " *
+            "(ρ/w₀)² — the lens parabola, with the ℓθ helix as the azimuthal spread. The " *
+            "`ic_<id>.jls` cache stores xμ₀/u₀/Δz, so this chip re-renders without an EDM solve.",
+    )
+    println("saved → $(basename(out))")
+    return icfile
+end
+write_ic_products(xμ, u⁰, [bunch_dz(r) for r in R₀], OUTDIR, RUN_TAG;
+    γ0 = GAMMA, λ, w₀, nb = BUNCH_NB, l = BUNCH_L, chirp = BUNCH_CHIRP)
+
 # (Screen geometry + observer-window sizing and their guards live ABOVE the ensemble solve,
 # so bad configurations fail before the expensive integration.)
 x⁰_samples = range(start = x⁰_start, step = c * δt, length = N_samples)

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -379,6 +379,56 @@ t_trajectories = @elapsed solution = solve(
 # Radiation computation
 trajs = trajectory_interpolants(solution)
 
+# ── γ(τ)/γ₀ trace, sampled through the trajectory INTERPOLANTS rather than the raw ODE
+# solutions: the uniform-saveat CubicSpline is what the radiation kernel actually integrates,
+# so reading γ through it — between knots, at EDM_GAMMA_TRACE_OVERSAMPLE× the knot rate —
+# keeps saveat-undersampling and spline artifacts visible in the trace instead of hidden by
+# the solver's dense output. Emits a small (~MBs) gammatau_<tag>.jls sidecar next to the cube;
+# ll_system_chips.jl overlays the classical|LL pair of traces as a 2-parent comparison
+# product. EDM_GAMMA_TRACE_OVERSAMPLE=0 disables the trace entirely.
+const GAMMA_TRACE_OS = parse(Int, get(ENV, "EDM_GAMMA_TRACE_OVERSAMPLE", "4"))
+GAMMA_TRACE_OS >= 0 || error("EDM_GAMMA_TRACE_OVERSAMPLE must be ≥ 0, got $GAMMA_TRACE_OS")
+function gamma_trace(trajs, τs, c, γ0, τf)
+    # One accumulator per electron CHUNK, not per threadid: threadid() can exceed nthreads()
+    # (interactive pool) and tasks migrate, so threadid-indexed accumulators are unsound.
+    nch = max(1, min(Threads.nthreads(), length(trajs)))
+    chunks = collect(Iterators.partition(eachindex(trajs), cld(length(trajs), nch)))
+    sums = [zeros(length(τs)) for _ in chunks]
+    los = [fill(Inf, length(τs)) for _ in chunks]
+    his = [fill(-Inf, length(τs)) for _ in chunks]
+    drain = zeros(length(trajs))
+    tasks = map(enumerate(chunks)) do (ci, ch)
+        Threads.@spawn begin
+            s, lo, hi = sums[ci], los[ci], his[ci]
+            for e in ch
+                tr = trajs[e]
+                @inbounds for (k, τk) in enumerate(τs)
+                    γ = tr(τk)[2][1] / c
+                    s[k] += γ
+                    γ < lo[k] && (lo[k] = γ)
+                    γ > hi[k] && (hi[k] = γ)
+                end
+                drain[e] = 1 - tr(τf)[2][1] / (γ0 * c)
+            end
+        end
+    end
+    foreach(wait, tasks)
+    return reduce(+, sums) ./ length(trajs),
+        reduce((a, b) -> min.(a, b), los), reduce((a, b) -> max.(a, b), his), drain
+end
+if GAMMA_TRACE_OS > 0
+    t_gtrace = @elapsed begin
+        knot_dt = (2π / ω) / (GAMMA * (1 + β)) / parse(Float64, INTERP_SAVEAT)
+        γτ_grid = collect(τi:(knot_dt / GAMMA_TRACE_OS):τf)
+        γmean, γmin, γmax, γdrain = gamma_trace(trajs, γτ_grid, c, GAMMA, τf)
+        gtfile = joinpath(OUTDIR, "gammatau_$(RUN_TAG).jls")
+        serialize(gtfile, (; τs = γτ_grid, γ0 = Float64(GAMMA), ω, τ_pulse = τ,
+            γmean, γmin, γmax, drain = γdrain, oversample = GAMMA_TRACE_OS,
+            knots_per_period = parse(Float64, INTERP_SAVEAT)))
+    end
+    @info "γ(τ)/γ₀ trace serialized" t_gtrace n_τ = length(γτ_grid) mean_drain = sum(γdrain) / length(γdrain)
+end
+
 # (Screen geometry + observer-window sizing and their guards live ABOVE the ensemble solve,
 # so bad configurations fail before the expensive integration.)
 x⁰_samples = range(start = x⁰_start, step = c * δt, length = N_samples)

--- a/scripts/ll_system_chips.jl
+++ b/scripts/ll_system_chips.jl
@@ -110,8 +110,72 @@ function main(dir)
             )
             println("saved → $(basename(out))")
         end
+        gamma_drain_product(dir, cl, ll, γ, a0)
     end
     write_system_comparisons(dir, pairs)
+    return
+end
+
+# γ(τ)/γ₀ overlay — the radiation-reaction drain seen from the trajectory side, the
+# energy-loss meter the N₀-line centroid shift (≈ 2Δγ/γ) must agree with. Reads the
+# gammatau_<id>.jls traces the solver samples through its trajectory interpolants (the
+# uniform-saveat splines the radiation kernel integrates, read between knots — so
+# saveat-sampling artifacts stay visible), and overlays the pair. 2 parents route the chip
+# to the comparison card next to the field-map diffs. Pre-knob runs have no trace: skipped.
+function gamma_drain_product(dir, cl, ll, γ, a0)
+    fcl = joinpath(dir, "gammatau_$(cl.id).jls")
+    fll = joinpath(dir, "gammatau_$(ll.id).jls")
+    (isfile(fcl) && isfile(fll)) ||
+        return println("gammatau: no traces for the γ=$γ a₀=$a0 pair — skip")
+    g_cl, g_ll = deserialize(fcl), deserialize(fll)
+    length(g_cl.τs) == length(g_ll.τs) ||
+        return println("gammatau: trace grids differ for the γ=$γ a₀=$a0 pair — skip")
+    x = g_ll.τs ./ g_ll.τ_pulse                       # proper time in pulse widths
+    r_cl, r_ll = g_cl.γmean ./ g_cl.γ0, g_ll.γmean ./ g_ll.γ0
+    # Data-driven zoom on where the drain ACCUMULATES (per-step |Δ(γ/γ₀)| ≥ 2% of its max),
+    # padded 50% per side: the interaction is ~τ₀/γ of proper time — a sliver of the
+    # ±TSPAN_TAU·τ₀ span — and a deviation-LEVEL window would drag to the span's end, because
+    # the drained γ stays low after the pulse.
+    step = max.(abs.(diff(r_cl)), abs.(diff(r_ll)))
+    idx = findall(>=(0.02 * max(maximum(step), eps())), step)
+    lo, hi = isempty(idx) ? (firstindex(x), lastindex(x)) : (first(idx), last(idx) + 1)
+    pad = (hi - lo) ÷ 2
+    zoom = max(firstindex(x), lo - pad):min(lastindex(x), hi + pad)
+    drain = sum(g_ll.drain) / length(g_ll.drain)
+    fig = Figure(size = (1240, 470))
+    for (i, rng) in enumerate((eachindex(x), zoom))
+        ax = Axis(fig[1, i]; title = i == 1 ? "full span" : "interaction zoom",
+            xlabel = "τ / τ₀  (proper time, pulse widths)", ylabel = i == 1 ? "γ(τ) / γ₀" : "")
+        band!(ax, x[rng], g_cl.γmin[rng] ./ g_cl.γ0, g_cl.γmax[rng] ./ g_cl.γ0;
+            color = (:seagreen, 0.25))
+        band!(ax, x[rng], g_ll.γmin[rng] ./ g_ll.γ0, g_ll.γmax[rng] ./ g_ll.γ0;
+            color = (:crimson, 0.25))
+        lines!(ax, x[rng], r_cl[rng]; color = :seagreen, label = "classical")
+        lines!(ax, x[rng], r_ll[rng]; color = :crimson, label = "Landau–Lifshitz")
+        i == 1 && axislegend(ax; position = :lb)
+    end
+    Label(fig[0, :], @sprintf(
+        "γ=%g  a₀=%g — γ(τ)/γ₀ through the trajectory splines  (mean; bands = min–max over the disk)",
+        γ, a0), fontsize = 18)
+    out = joinpath(dir, @sprintf("inverse_thomson_gammatau_%s-%s.png",
+        first(ll.id, 8), first(cl.id, 8)))
+    save(out, fig)
+    write_derived(
+        dir; kind = "gammatau", label = "γ(τ)/γ₀ — radiation-reaction drain",
+        run_id = [cl.id, ll.id], plot = basename(out), source = "gammatau_$(ll.id).jls",
+        plot_params = Dict(
+            "Δγ/γ (LL, disk mean)" => round(drain; sigdigits = 3),
+            "Δγ/γ (LL, max)" => round(maximum(g_ll.drain); sigdigits = 3),
+            "classical residual" => round(maximum(abs, r_cl .- 1); sigdigits = 2),
+            "predicted N₀-line shift 2Δγ/γ" => round(2drain; sigdigits = 3),
+            "trace oversample" => g_ll.oversample),
+        description = "Disk-mean γ(τ)/γ₀ (bands: min–max over electrons), classical vs " *
+            "Landau–Lifshitz, sampled through the SAME uniform-saveat trajectory splines the " *
+            "radiation kernel integrates, read between knots — saveat-sampling artifacts stay " *
+            "visible rather than being smoothed by the solver's dense output. The LL end-state " *
+            "drain Δγ/γ predicts a red-shift of the scattered N₀ line's centroid by 2Δγ/γ.",
+    )
+    println("saved → $(basename(out))")
     return
 end
 


### PR DESCRIPTION
Adds the γ(τ)/γ₀ energy-drain view to the inverse-Thomson pipeline, as a comparison product (classical vs Landau–Lifshitz), per the primer-review follow-ups.

**Run side (`inverse_thomson_scattering.jl`).** After the ensemble solve, γ is sampled through the **trajectory interpolants** — the uniform-saveat splines the radiation kernel actually integrates — read *between* knots at `EDM_GAMMA_TRACE_OVERSAMPLE`× the knot rate (default 4, `0` disables). Sampling the splines rather than the raw ODE solutions keeps saveat-undersampling / spline artifacts visible in the trace instead of hidden by the solver's dense output. Emits a small `gammatau_<tag>.jls` sidecar (disk mean/min/max of γ(τ), per-electron end-state drain, pulse scales); nothing goes into `[config]`, so mixed pre/post-knob pools stay warning-free on the dashboard.

**Product side (`ll_system_chips.jl`).** For each classical|LL pair with traces, renders a two-panel overlay (full span + derivative-windowed interaction zoom; mean lines, min–max bands) and emits it as a 2-parent `gammatau` derived artifact — it routes to the campaign's comparison card next to the LL − classical field-map diffs. `plot_params` carry Δγ/γ (disk mean and max), the classical residual (should be ~0), and the **predicted N₀-line centroid shift 2Δγ/γ** — the number the spectral-side centroid measurement has to match. Pre-knob runs without traces are skipped with a note.

Smoke-tested: `gamma_trace` against fake interpolants (mean/min/max/drain exact), `gamma_drain_product` end-to-end on synthetic traces (PNG + 2-parent sidecar verified, TOML parsed back). The full run script parse-checks; it wasn't executed end-to-end (needs a GPU campaign) — the next LL campaign will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)