### PR TITLE
Cube status tracking: producers + auto-publish hook

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -24,6 +24,7 @@ using Dates
 export git_state, assert_committed, run_provenance, run_spec_from_manifest, expand_sweep
 export find_parent_manifest, find_parent_run, spp_from_manifest
 export write_derived, write_comparison, write_summary, write_run_manifest, write_solver_manifest, REQUIRED_CONFIG_KEYS
+export record_reduction!
 export MANIFEST_SCHEMA_VERSION, manifest_schema_version, check_schema_version
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -145,6 +146,7 @@ function run_provenance(;
         "script" => script,
         "host" => gethostname(),
         "slurm_job_id" => get(ENV, "SLURM_JOB_ID", ""),
+        "cloud_provider" => get(ENV, "EDM_CLOUD_PROVIDER", "local"),
         "gpu_backend" => gpu_backend,
         "julia_version" => string(VERSION),
         "timestamp" => string(now()),
@@ -341,6 +343,37 @@ function write_derived(
     name = "derived_$(kind)$(suffix)_$(idtag).toml"
     open(io -> TOML.print(io, m; sorted = true), joinpath(dir, name), "w")
     return joinpath(dir, name)
+end
+
+"""
+    record_reduction!(dir, run_id, file) -> String
+
+Append `file` (a reduction product — a full path, or a basename resolved in `dir`) to the run's
+reduction staging marker `<run_id>.reduced.partial` in `dir`, recording its current byte size.
+The first call writes the header (`run_id`/`reduced_at`/`host`/`reduce_commit` + an empty
+`reduction` array); later calls append. The orchestration renames `.partial` →
+`<run_id>.reduced` atomically once every reducer for the cell succeeds, so the marker's PRESENCE
+is the drainer's "reduce complete" handshake and its CONTENTS enumerate the caches that must land
+durably on the storagebox for the run to be re-renderable WITHOUT the cube (publish-autonomy).
+
+Invariant: every product a drain-path reducer emits must be re-renderable from a cache recorded
+here. A plot rendered directly from the cube with NO cache is invisible to this marker and breaks
+publish-autonomy — add a cache instead of relying on the cube (which is only on the workstation).
+Today's drain-path reducers (harmonic_products, plot_screen_observables) cache every product.
+"""
+function record_reduction!(dir::AbstractString, run_id, file::AbstractString)
+    path = joinpath(dir, "$(run_id).reduced.partial")
+    m = isfile(path) ? TOML.parsefile(path) : Dict{String, Any}(
+        "run_id" => string(run_id),
+        "reduced_at" => string(now()),
+        "host" => gethostname(),
+        "reduce_commit" => _script_repo_commit(),
+        "reduction" => Dict{String, Any}[],
+    )
+    full = isfile(file) ? file : joinpath(dir, file)
+    push!(m["reduction"], Dict{String, Any}("file" => basename(file), "bytes" => filesize(full)))
+    open(io -> TOML.print(io, m; sorted = true), path, "w")
+    return path
 end
 
 # Normalise one comparison side spec to (label, dir, script, where). Accepts a NamedTuple

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -88,7 +88,7 @@ export PATH="$HOME/.juliaup/bin:$PATH"   # no JULIA_PKG_SERVER: the VM uses Juli
 rm -rf EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" EDM
 # VM-local config.env (gitignored ⇒ not cloned): rocm local backend, no ntfy on the VM, and
 # REDUCE_OVERLAP=1 so each cell's reduction overlaps the next cell's GPU compute (paid-time win).
-printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\nREDUCE_OVERLAP=1\n' > EDM/orchestration/config.env
+printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\nREDUCE_OVERLAP=1\nLOCAL_CLOUD_PROVIDER=hotaisle\n' > EDM/orchestration/config.env
 BK=rocm REPO_DIR="$HOME/EDM"; . EDM/orchestration/depot_cache.sh   # julia-actions/cache semantics (default ~/.julia depot)
 depot_cache_restore   # → DC_RESTORED = exact | prefix (instantiate tops it up) | miss (fresh build)
 ok=0; for i in 1 2 3; do

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -218,7 +218,7 @@ export PATH="$HOME/.juliaup/bin:$PATH"   # no JULIA_PKG_SERVER: fresh pod uses J
 rm -rf ~/EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" ~/EDM   # fresh clone = always current
 if [ -n "$HAS_VOL" ]; then mkdir -p /workspace/runs && ln -sfn /workspace/runs ~/EDM/runs   # cubes persist on the volume
 else mkdir -p ~/EDM/runs; fi
-printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=%s\nREDUCE_OVERLAP=1\n' \
+printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=%s\nREDUCE_OVERLAP=1\nLOCAL_CLOUD_PROVIDER=runpod\n' \
     "$BK" "$JULIA_DEPOT_PATH" > ~/EDM/orchestration/config.env
 REPO_DIR=~/EDM; . ~/EDM/orchestration/depot_cache.sh   # julia-actions/cache semantics over the rsync store
 depot_cache_restore   # → DC_RESTORED = exact | prefix (instantiate tops it up) | miss (fresh build)

--- a/orchestration/config.env.example
+++ b/orchestration/config.env.example
@@ -59,3 +59,7 @@ NTFY_ENV="${HOME}/.config/ntfy/edm-campaigns.env"
 
 # ── publish (optional) ───────────────────────────────────────────────────────
 RESEARCH_PUBLISH_CONFIG="${HOME}/.config/research-publish.env"
+# PUBLISH_HOOK: command eval'd once per campaign after all cells + reductions (only if a cell
+# succeeded), with $CAMP (campaign output dir) and $CAMPAIGN in scope. The publish itself lives
+# OUTSIDE this public repo (the private dashboard repo). Empty (default) = no auto-publish.
+# e.g. PUBLISH_HOOK='RSYNC_RSH=/usr/bin/ssh bash "$HOME/Documents/research/EDM_results_dashboard/scripts/research-publish.sh" "$CAMP"'

--- a/orchestration/cube_inventory.sh
+++ b/orchestration/cube_inventory.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Cube inventory for status tracking. Runs on the machine that holds the durable cube archive (the
+# only one that can see it) and reports what's there, so a collector on another host can answer
+# "where is cube X" / "is it safely archived?" without access to that filesystem. READ-ONLY over
+# the archive: it never deletes or moves a cube.
+#
+# Emits one row per cube — uuid, campaign, file, bytes, verified — from the layout the pull scripts
+# write (<archive>/<campaign>/field_*_<uuid>.jls + a sibling .verified_<file> marker, see
+# cube_pull.sh / cube_pull_r2.sh), then optionally rsyncs that one small TSV to the collector host.
+#
+# Paths/hosts are machine-specific — set them in config.env (gitignored), not here:
+#   INV_STORE   cube archive dir (the pull scripts' PULL_DEST)
+#   INV_OUT     output TSV path (default: $INV_STORE/cube_inventory.tsv)
+#   INV_PUSH    optional rsync target (user@host:/path) to ship the TSV to the collector host
+set -eu
+
+STORE="${INV_STORE:?set INV_STORE (cube archive dir = PULL_DEST from the pull scripts)}"
+OUT="${INV_OUT:-$STORE/cube_inventory.tsv}"
+UUID_RE='[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+# Same-dir temp so the final mv is an atomic rename — the collector never reads a half-written
+# inventory (the same commit-point rule as the .reduced marker).
+tmp="$(mktemp "$OUT.XXXXXX")"
+host=$(hostname); now=$(date -u +%FT%TZ)
+printf 'uuid\tcampaign\tfile\tbytes\tverified\thost\tscanned_at\n' > "$tmp"
+
+# Layout: $STORE/<campaign>/field_*_<uuid>.jls (one level under STORE, per the pull scripts).
+find "$STORE" -mindepth 2 -maxdepth 2 -name 'field_*.jls' -printf '%h\t%f\t%s\n' 2>/dev/null |
+while IFS=$'\t' read -r dir file bytes; do
+    uuid=$(printf '%s' "$file" | grep -oE "$UUID_RE" | tail -1)
+    [ -n "$uuid" ] || continue                       # skip anything not carrying a uuid
+    if [ -e "$dir/.verified_$file" ]; then verified=1; else verified=0; fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$uuid" "$(basename "$dir")" "$file" "$bytes" "$verified" "$host" "$now" >> "$tmp"
+done
+
+mv "$tmp" "$OUT"
+n=$(($(wc -l < "$OUT") - 1))
+echo "[inventory] $n cubes → $OUT"
+
+[ -n "${INV_PUSH:-}" ] && rsync -t "$OUT" "$INV_PUSH" && echo "[inventory] pushed → $INV_PUSH"

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -186,4 +186,13 @@ run_cells() {
     local tag=white_check_mark pri=default
     [ "${CELLS_FAIL:-0}" -gt 0 ] && { tag=warning; pri=high; }
     notify "$tag" "$pri" "EDM campaign done" "${CAMPAIGN:-?}: ${CELLS_OK:-0}/${#CELLS[@]} ok, ${CELLS_FAIL:-0} failed (${BACKEND:-?}@$(hostname))"
+    # Campaign-complete publish hook. GENERIC mechanism (like notify / POST_HOOK): the actual publish
+    # — VPS paths, the metadata-union dir, credentials — lives in config.env's PUBLISH_HOOK, kept off
+    # this public repo. Fires once after all cells + reductions, only if a cell succeeded; the hook
+    # (with $CAMP/$CAMPAIGN in scope) publishes just the verified cells (those with a .reduced marker).
+    if [ -n "${PUBLISH_HOOK:-}" ] && [ "${CELLS_OK:-0}" -gt 0 ]; then
+        echo "[$(date -u +%FT%TZ)] publish: $CAMPAIGN → PUBLISH_HOOK"
+        eval "$PUBLISH_HOOK" \
+            || notify rotating_light high "EDM publish FAILED" "${CAMPAIGN:-?}: PUBLISH_HOOK failed on $(hostname)"
+    fi
 }

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -39,6 +39,10 @@ _ORCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # REPO defaults to the repo that CONTAINS this orchestration/ dir (so it's right on any clone —
 # your dev checkout, a cluster node, a cloud VM at $HOME/EDM). config.env's EDM_REPO overrides it.
 : "${REPO:=${EDM_REPO:-$(cd "$_ORCH_DIR/.." && pwd)}}"
+# Cloud provider for status tracking: hotaisle/runpod inject LOCAL_CLOUD_PROVIDER into config.env;
+# SLURM detected via SLURM_JOB_ID; local otherwise. Passed to the solver as EDM_CLOUD_PROVIDER.
+: "${PROVIDER:=${LOCAL_CLOUD_PROVIDER:-${SLURM_JOB_ID:+slurm}}}"
+: "${PROVIDER:=local}"
 
 # ── notifications (optional, ALL backends) ───────────────────────────────────
 # Creds come from $NTFY_ENV (set in config.env → e.g. ~/.config/ntfy/edm-campaigns.env); secrets stay
@@ -62,16 +66,30 @@ notify() {   # notify <tags> <priority> <title> <message>  — no-op unless NTFY
 # <uuid>.reduce_failed marker that reap_reduces waits on. Override with REDUCE_HOOK for a custom reducer.
 _reduce_cell() {
     local uuid=$1 manifest="$CAMP/run_${uuid}.toml" cube rc=0
-    ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} "${JL[@]}" --project=scripts scripts/harmonic_products.jl "$manifest" ) \
+    ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} EDM_REDUCTION_MARKER=1 "${JL[@]}" --project=scripts scripts/harmonic_products.jl "$manifest" ) \
         >> "$CAMP/run_${uuid}.log" 2>&1 || rc=1
     if [ "$rc" -eq 0 ]; then
         for cube in "$CAMP"/field_*_"$uuid".jls; do
             [ -e "$cube" ] || continue
-            ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} "${JL[@]}" --project=scripts scripts/plot_screen_observables.jl "$cube" ) \
+            ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} EDM_REDUCTION_MARKER=1 "${JL[@]}" --project=scripts scripts/plot_screen_observables.jl "$cube" ) \
                 >> "$CAMP/run_${uuid}.log" 2>&1 || rc=1
         done
     fi
-    [ "$rc" -eq 0 ] && touch "$CAMP/${uuid}.reduced" || touch "$CAMP/${uuid}.reduce_failed"
+    # Finalize the reduction marker. The reducers appended each cache they wrote to
+    # <uuid>.reduced.partial (via RunManifests.record_reduction!); turn that into the <uuid>.reduced
+    # sentinel the drainer waits on — but ONLY as an atomic, all-reducers-succeeded commit, so a
+    # reader never sees a half-written marker (docs/status_tracking_design.md §5, sentinel-after-data).
+    local partial="$CAMP/${uuid}.reduced.partial"
+    if [ "$rc" -eq 0 ]; then
+        if [ -f "$partial" ]; then
+            mv "$partial" "$CAMP/${uuid}.reduced"
+        else
+            touch "$CAMP/${uuid}.reduced"
+        fi
+    else
+        rm -f "$partial"
+        touch "$CAMP/${uuid}.reduce_failed"
+    fi
 }
 
 run_cell() {
@@ -103,7 +121,7 @@ run_cell() {
     echo "[$(date -u +%FT%TZ)] cell $label  [$(basename "$SCRIPT") ${BACKEND:-?}]  keep=${KEEP_CUBE:-0} overlap=${REDUCE_OVERLAP:-0}  $uuid :: ${*:-<baseline>}"
     # shellcheck disable=SC2086
     ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} ${BASE[@]+"${BASE[@]}"} $skip \
-          EDM_GPU_BACKEND="$BACKEND" EDM_OUTDIR="$CAMP" EDM_RUN_TAG="$uuid" "$@" \
+          EDM_GPU_BACKEND="$BACKEND" EDM_CLOUD_PROVIDER="$PROVIDER" EDM_OUTDIR="$CAMP" EDM_RUN_TAG="$uuid" "$@" \
           "${JL[@]}" --project=scripts "$SCRIPT" ) > "$log" 2>&1
     local rc=$?
     if [ "$rc" -eq 0 ]; then

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -246,6 +246,8 @@ function write_harmonic_products(
         ),
     )
     println("serialized harmonic maps → $hmapsfile  (window = $win_name)")
+    # Drain-path only (EDM_REDUCTION_MARKER set by run_cell _reduce_cell): enumerate the cache in .reduced.
+    get(ENV, "EDM_REDUCTION_MARKER", "0") == "1" && record_reduction!(outdir, run_tag, hmapsfile)
 
     # Reduce-only mode (`.reduce_only` flag in outdir, or EDM_REDUCE_ONLY=1): do ONLY the work
     # that needs the cube in RAM — hmaps + the powspec cache — and skip every plot render.
@@ -265,6 +267,8 @@ function write_harmonic_products(
     # cube pass for 24 runs solely because this array used to be discarded after plotting.
     serialize(joinpath(outdir, "powspec_$(run_tag).jls"),
         (; freqs = collect(freqs), ps, n0, harmonics = collect(harmonics), window = "none"))
+    get(ENV, "EDM_REDUCTION_MARKER", "0") == "1" &&
+        record_reduction!(outdir, run_tag, "powspec_$(run_tag).jls")
     if reduce_only
         println("reduce-only: hmaps + powspec cache serialized; renders deferred")
         return (; hmapsfile, plots, fields_h, fields_far_h, window = win_name)

--- a/scripts/plot_screen_observables.jl
+++ b/scripts/plot_screen_observables.jl
@@ -287,5 +287,7 @@ let pid = parent[1]
                 raw"The dotted line marks the peak-emission slot used for the snapshots above."
         )
         println("derived sidecars → observables (total/far) + obs_vortex + obs_temporal (parent run $pid)")
+        # Drain-path only (EDM_REDUCTION_MARKER): enumerate the obs cache in <uuid>.reduced (cf. harmonic_products).
+        get(ENV, "EDM_REDUCTION_MARKER", "0") == "1" && record_reduction!(dir, pid, cachefile)
     end
 end


### PR DESCRIPTION
## Cube status tracking — producers + auto-publish hook

Adds the per-run **status-tracking producers** and a generic **campaign publish hook**. The status
*view* is built downstream (private dashboard builder); this repo only emits the durable markers +
inventory it's built from, plus a generic trigger — no infra or publish logic lands here.

- **Enriched `.reduced` marker** — `RunManifests.record_reduction!` records each reduction cache
  (file + bytes); `_reduce_cell` finalizes it atomically (`.partial`→`.reduced`) only on
  all-reducers-success, preserving the drainer handshake and sentinel-after-data.
- **Reducer wiring** — `harmonic_products.jl` / `plot_screen_observables.jl` record hmaps, powspec,
  and the obs cache, gated on `EDM_REDUCTION_MARKER`.
- **`orchestration/cube_inventory.sh`** — workstation scan of the permanent cube archive → a
  uuid/campaign/bytes/verified TSV.
- **Cloud-provider stamp** into run provenance (`hotaisle`/`runpod`/`slurm`/`local`).
- **`PUBLISH_HOOK`** — generic per-campaign completion hook (like `notify`); the publish itself is
  configured via `config.env` and lives outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
