### PR TITLE
cube_inventory: world-readable output for cross-user push

### DIFF
--- a/orchestration/cube_inventory.sh
+++ b/orchestration/cube_inventory.sh
@@ -35,6 +35,7 @@ while IFS=$'\t' read -r dir file bytes; do
 done
 
 mv "$tmp" "$OUT"
+chmod 644 "$OUT"   # mktemp is 600; make it world-readable so a cross-user INV_PUSH lands readable
 n=$(($(wc -l < "$OUT") - 1))
 echo "[inventory] $n cubes → $OUT"
 


### PR DESCRIPTION
The inventory TSV comes from `mktemp` (mode 600), so `INV_PUSH` rsync'd it to the VPS as 600 and the `publish` user running `build_status` could not read it (`eachline` threw, failing the build). `chmod 644` after the atomic `mv` makes the source world-readable so the push propagates 644.

Deployed workaround already in place (VPS `chmod 644`, persists across `rsync -t`); this fixes it at the source so future deploys are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)