### PR TITLE
gammatau: backfill script for pre-PR-51 runs + trajectory_products refactor

### DIFF
--- a/scripts/gammatau_backfill.jl
+++ b/scripts/gammatau_backfill.jl
@@ -58,8 +58,11 @@ function enrich_marker!(dir, uuid, files)
     red = get!(m, "reduction", Any[])
     for f in files
         bn = basename(f)
-        any(e -> get(e, "file", "") == bn, red) && continue
-        push!(red, Dict{String, Any}("file" => bn, "bytes" => filesize(joinpath(dir, bn))))
+        entry = Dict{String, Any}("file" => bn, "bytes" => filesize(joinpath(dir, bn)))
+        i = findfirst(e -> get(e, "file", "") == bn, red)
+        # Replace, don't skip: a refreshed cache changes size, and build_status verifies
+        # durability BYTE-EXACT against the marker — a stale bytes entry would flag the run.
+        i === nothing ? push!(red, entry) : (red[i] = entry)
     end
     tmp = path * ".tmp"
     open(io -> TOML.print(io, m; sorted = true), tmp, "w")
@@ -76,10 +79,6 @@ function backfill_run(dir, mfile)
         return nothing
     end
     gt, ic = joinpath(dir, "gammatau_$uuid.jls"), joinpath(dir, "ic_$uuid.jls")
-    if isfile(gt) && isfile(ic)
-        println("skip $(first(uuid, 8)) — caches already present")
-        return uuid
-    end
 
     γ0 = Float64(cfg["gamma"])
     λ = las["wavelength"]
@@ -91,6 +90,25 @@ function backfill_run(dir, mfile)
     β = sqrt(1 - 1 / γ0^2)
     u⁰_t, u³_z = γ0 * c, c * sqrt(γ0^2 - 1)
     τi, τf = -cfg["tspan_tau"] * τ, cfg["tspan_tau"] * τ
+
+    R₀ = Rmax * sunflower(N, 2)
+    nb, l, chirp = Int(cfg["bunch_nb"]), Int(cfg["bunch_l"]), Float64(cfg["bunch_chirp"])
+    Z = set["Z"]
+    chirp == 0 || error("bunch_chirp ≠ 0 backfill not supported (chirp needs the p=2 |m|=2 u_rel)")
+    bunch_dz(r) = nb == 0 ? 0.0 :
+        ((1 + β) / 2) * ((r[1]^2 + r[2]^2) / (2Z) + l * atan(r[2], r[1]) / (2π) * λ / nb)
+    xμ = [[u⁰_t * τi, r..., u³_z * τi + bunch_dz(r)] for r in R₀]
+    u⁰ = [u⁰_t, 0.0, 0.0, u³_z]
+
+    # IC products need no solve (deterministic from the manifest): always refresh, so chip
+    # improvements re-render on a rerun. The γ(τ) trace gates the expensive part.
+    write_ic_products(xμ, u⁰, [bunch_dz(r) for r in R₀], dir, uuid;
+        γ0, λ, w₀, nb, l, chirp, p = Int(las["p"]), m = Int(las["m"]))
+    enrich_marker!(dir, uuid, [ic])
+    if isfile(gt)
+        println("$(first(uuid, 8)) — γ(τ) trace present, solve skipped (IC refreshed)")
+        return uuid
+    end
 
     @named world = Worldline(:τ, :atomic)
     @named laser = LaguerreGaussLaser(;
@@ -107,15 +125,6 @@ function backfill_run(dir, mfile)
     end
     sys = mtkcompile(elec)
 
-    R₀ = Rmax * sunflower(N, 2)
-    nb, l, chirp = Int(cfg["bunch_nb"]), Int(cfg["bunch_l"]), Float64(cfg["bunch_chirp"])
-    Z = set["Z"]
-    chirp == 0 || error("bunch_chirp ≠ 0 backfill not supported (chirp needs the p=2 |m|=2 u_rel)")
-    bunch_dz(r) = nb == 0 ? 0.0 :
-        ((1 + β) / 2) * ((r[1]^2 + r[2]^2) / (2Z) + l * atan(r[2], r[1]) / (2π) * λ / nb)
-    xμ = [[u⁰_t * τi, r..., u³_z * τi + bunch_dz(r)] for r in R₀]
-
-    u⁰ = [u⁰_t, 0.0, 0.0, u³_z]
     prob = ODEProblem{false, SciMLBase.FullSpecialize}(
         sys, [sys.x => SVector{4}(xμ[1]...), sys.u => SVector{4}(u⁰...)], (τi, τf),
         u0_constructor = SVector{8}, fully_determined = true
@@ -141,10 +150,7 @@ function backfill_run(dir, mfile)
         γmean, γmin, γmax, drain = γdrain, oversample = GAMMA_TRACE_OS,
         knots_per_period = parse(Float64, cfg["interp_saveat"])))
     @info "γ(τ)/γ₀ trace serialized" first(uuid, 8) mean_drain = sum(γdrain) / N
-
-    write_ic_products(xμ, u⁰, [bunch_dz(r) for r in R₀], dir, uuid;
-        γ0, λ, w₀, nb, l, chirp)
-    enrich_marker!(dir, uuid, [gt, ic])
+    enrich_marker!(dir, uuid, [gt])
     return uuid
 end
 
@@ -171,12 +177,15 @@ function main_backfill(dir)
     for c_ in cells
         push!(get!(groups, (c_.gamma, c_.a0, c_.iters), []), c_)
     end
+    prs = []
     for g in values(groups)
         cl = findfirst(d -> d.system == "classical", g)
         ll = findfirst(d -> d.system == "ll", g)
         (cl === nothing || ll === nothing) && continue
         gamma_drain_product(dir, g[cl], g[ll], g[cl].gamma, g[cl].a0)
+        push!(prs, (; γ = g[cl].gamma, a0 = g[cl].a0, clid = g[cl].id, llid = g[ll].id))
     end
+    drain_ladder_summary(dir, prs)
     println("backfilled $(length(done)) runs in $dir")
     return
 end

--- a/scripts/gammatau_backfill.jl
+++ b/scripts/gammatau_backfill.jl
@@ -1,0 +1,186 @@
+# Backfill trajectory-side products for EXISTING inverse-Thomson runs that predate the
+# run-time gammatau/ic emission (PR #51): re-solve each run's trajectory ensemble from its
+# run_<uuid>.toml on CPU — deterministic from [config]/[laser]/[setup] (same solver, same
+# tolerances, same uniform saveat; the field cube is never touched) — then emit, under the
+# ORIGINAL run uuid:
+#   • gammatau_<uuid>.jls   γ(τ)/γ₀ trace through the production-spec trajectory splines
+#   • ic_<uuid>.jls + chip  as-run initial conditions (write_ic_products)
+#   • the classical|LL γ(τ)/γ₀ comparison chips (ll_system_chips.gamma_drain_product)
+# and enrich each run's .reduced marker with the new caches (atomic tmp+mv; these runs'
+# reduce already finished, so appending to the final marker is safe), so stage_products
+# ships them to the storagebox and build_status tracks them.
+#
+#   julia +release --project=scripts -t auto scripts/gammatau_backfill.jl <campaign_dir>
+#
+# Idempotent: runs whose gammatau_ + ic_ caches already exist are skipped (pair chips are
+# re-rendered — cheap). Env: EDM_GAMMA_TRACE_OVERSAMPLE (default 4), same as the solver.
+
+using ElectronDynamicsModels
+using ModelingToolkit
+using OrdinaryDiffEqVerner   # explicit Vern9 — pure ODE, no implicit-init solver needed
+using SciMLBase
+using StaticArrays
+using SymbolicIndexingInterface
+using LinearAlgebra
+using Serialization
+using Statistics
+using Printf
+using TOML
+using Dates
+using CairoMakie
+using RunManifests
+
+include(joinpath(@__DIR__, "trajectory_products.jl"))   # gamma_trace + write_ic_products
+include(joinpath(@__DIR__, "ll_system_chips.jl"))       # gamma_drain_product (main() is guarded)
+
+const c = 137.03599908330932
+const GAMMA_TRACE_OS = parse(Int, get(ENV, "EDM_GAMMA_TRACE_OVERSAMPLE", "4"))
+GAMMA_TRACE_OS > 0 || error("EDM_GAMMA_TRACE_OVERSAMPLE must be > 0 for a backfill")
+
+# Sunflower distribution — identical to inverse_thomson_scattering.jl.
+const ϕgold = (1 + √5) / 2
+sf_radius(k, n, b) = k > n - b ? 1.0 : sqrt(k - 0.5) / sqrt(n - (b + 1) / 2)
+function sunflower(n, α)
+    b = round(Int, α * sqrt(n))
+    return [[sf_radius(k, n, b) * cos(k * 2π / ϕgold^2),
+             sf_radius(k, n, b) * sin(k * 2π / ϕgold^2)] for k in 1:n]
+end
+
+# Append `files` to the run's FINAL .reduced marker (record_reduction! writes .partial for the
+# in-flight reduce; here the reduce is long done, so we edit the committed marker — atomically,
+# tmp+mv, so a status collector never sees a half-written TOML). Legacy empty sentinels get the
+# full header. Idempotent per basename.
+function enrich_marker!(dir, uuid, files)
+    path = joinpath(dir, "$(uuid).reduced")
+    m = (isfile(path) && filesize(path) > 0) ? TOML.parsefile(path) : Dict{String, Any}(
+        "run_id" => string(uuid), "reduced_at" => string(now()), "host" => gethostname(),
+        "reduction" => Any[])
+    red = get!(m, "reduction", Any[])
+    for f in files
+        bn = basename(f)
+        any(e -> get(e, "file", "") == bn, red) && continue
+        push!(red, Dict{String, Any}("file" => bn, "bytes" => filesize(joinpath(dir, bn))))
+    end
+    tmp = path * ".tmp"
+    open(io -> TOML.print(io, m; sorted = true), tmp, "w")
+    mv(tmp, path; force = true)
+    return path
+end
+
+function backfill_run(dir, mfile)
+    m = TOML.parsefile(mfile)
+    uuid = m["provenance"]["run_id"]
+    cfg, las, set = m["config"], m["laser"], m["setup"]
+    if get(cfg, "scattering", "") != "inverse"
+        println("skip $(first(uuid, 8)) — not an inverse run")
+        return nothing
+    end
+    gt, ic = joinpath(dir, "gammatau_$uuid.jls"), joinpath(dir, "ic_$uuid.jls")
+    if isfile(gt) && isfile(ic)
+        println("skip $(first(uuid, 8)) — caches already present")
+        return uuid
+    end
+
+    γ0 = Float64(cfg["gamma"])
+    λ = las["wavelength"]
+    ω = 2π * c / λ
+    τ = las["temporal_width"]
+    w₀ = las["w0"]
+    Rmax = set["Rmax"]
+    N = Int(cfg["N"])
+    β = sqrt(1 - 1 / γ0^2)
+    u⁰_t, u³_z = γ0 * c, c * sqrt(γ0^2 - 1)
+    τi, τf = -cfg["tspan_tau"] * τ, cfg["tspan_tau"] * τ
+
+    @named world = Worldline(:τ, :atomic)
+    @named laser = LaguerreGaussLaser(;
+        wavelength = λ, a0 = cfg["a0"], beam_waist = w₀,
+        radial_index = Int(las["p"]), azimuthal_index = Int(las["m"]),
+        world, temporal_profile = Symbol(las["profile"]), temporal_width = τ,
+        focus_position = las["focus_position"], polarization = Symbol(las["pol"]),
+        initial_phase = las["phi0"], k_direction = [0, 0, -1],
+    )
+    elec = if get(cfg, "system", "classical") == "ll"
+        @named elec = LandauLifshitzElectron(; laser)
+    else
+        @named elec = ClassicalElectron(; laser)
+    end
+    sys = mtkcompile(elec)
+
+    R₀ = Rmax * sunflower(N, 2)
+    nb, l, chirp = Int(cfg["bunch_nb"]), Int(cfg["bunch_l"]), Float64(cfg["bunch_chirp"])
+    Z = set["Z"]
+    chirp == 0 || error("bunch_chirp ≠ 0 backfill not supported (chirp needs the p=2 |m|=2 u_rel)")
+    bunch_dz(r) = nb == 0 ? 0.0 :
+        ((1 + β) / 2) * ((r[1]^2 + r[2]^2) / (2Z) + l * atan(r[2], r[1]) / (2π) * λ / nb)
+    xμ = [[u⁰_t * τi, r..., u³_z * τi + bunch_dz(r)] for r in R₀]
+
+    u⁰ = [u⁰_t, 0.0, 0.0, u³_z]
+    prob = ODEProblem{false, SciMLBase.FullSpecialize}(
+        sys, [sys.x => SVector{4}(xμ[1]...), sys.u => SVector{4}(u⁰...)], (τi, τf),
+        u0_constructor = SVector{8}, fully_determined = true
+    )
+    set_x = setsym_oop(prob, [Initial(sys.x); Initial(sys.u)])
+    function prob_func(prob, ctx)
+        u0, p = set_x(prob, SVector{8}(xμ[ctx.sim_id]..., u⁰...))
+        return remake(prob; u0, p)
+    end
+    saveat = collect(τi:((2π / ω) / (γ0 * (1 + β)) / parse(Float64, cfg["interp_saveat"])):τf)
+    t_solve = @elapsed solution = solve(
+        EnsembleProblem(prob; prob_func, safetycopy = false), Vern9(), EnsembleThreads();
+        reltol = cfg["reltol"], abstol = cfg["abstol"], dtmax = cfg["dtmax"],
+        trajectories = N, saveat
+    )
+    trajs = trajectory_interpolants(solution)
+    @info "trajectories re-solved" first(uuid, 8) cfg["system"] t_solve knots = length(saveat)
+
+    knot_dt = saveat[2] - saveat[1]
+    γτ_grid = collect(τi:(knot_dt / GAMMA_TRACE_OS):τf)
+    γmean, γmin, γmax, γdrain = gamma_trace(trajs, γτ_grid, c, γ0, τf)
+    serialize(gt, (; τs = γτ_grid, γ0, ω, τ_pulse = τ,
+        γmean, γmin, γmax, drain = γdrain, oversample = GAMMA_TRACE_OS,
+        knots_per_period = parse(Float64, cfg["interp_saveat"])))
+    @info "γ(τ)/γ₀ trace serialized" first(uuid, 8) mean_drain = sum(γdrain) / N
+
+    write_ic_products(xμ, u⁰, [bunch_dz(r) for r in R₀], dir, uuid;
+        γ0, λ, w₀, nb, l, chirp)
+    enrich_marker!(dir, uuid, [gt, ic])
+    return uuid
+end
+
+function main_backfill(dir)
+    mfiles = sort(filter(f -> startswith(basename(f), "run_") && endswith(f, ".toml"),
+        readdir(dir; join = true)))
+    isempty(mfiles) && error("no run_*.toml in $dir")
+    done = String[]
+    for mf in mfiles
+        u = backfill_run(dir, mf)
+        u === nothing || push!(done, u)
+        GC.gc()
+    end
+    # Pair pass: the classical|LL γ(τ)/γ₀ overlay chips (2-parent, comparison card).
+    cells = []
+    for mf in mfiles
+        m = TOML.parsefile(mf)
+        c_ = m["config"]
+        push!(cells, (; id = m["provenance"]["run_id"],
+            system = get(c_, "system", "classical"), gamma = c_["gamma"], a0 = c_["a0"],
+            iters = get(c_, "newton_iters", 2)))
+    end
+    groups = Dict()
+    for c_ in cells
+        push!(get!(groups, (c_.gamma, c_.a0, c_.iters), []), c_)
+    end
+    for g in values(groups)
+        cl = findfirst(d -> d.system == "classical", g)
+        ll = findfirst(d -> d.system == "ll", g)
+        (cl === nothing || ll === nothing) && continue
+        gamma_drain_product(dir, g[cl], g[ll], g[cl].gamma, g[cl].a0)
+    end
+    println("backfilled $(length(done)) runs in $dir")
+    return
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main_backfill(isempty(ARGS) ? "." : ARGS[1])
+end

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -63,6 +63,7 @@ using UUIDs
 using RunManifests
 
 include(joinpath(@__DIR__, "harmonic_products.jl"))   # write_harmonic_products (shared with the recovery path)
+include(joinpath(@__DIR__, "trajectory_products.jl"))   # gamma_trace + write_ic_products (shared with gammatau_backfill.jl)
 include(joinpath(@__DIR__, "gpu_telemetry.jl"))   # with_gpu_sampler + gpu_manifest_section → the manifest [gpu] section
 
 # GPU backend selected via ENV: "rocm" (workstation default) or "cuda" (issaf H200).
@@ -388,34 +389,6 @@ trajs = trajectory_interpolants(solution)
 # product. EDM_GAMMA_TRACE_OVERSAMPLE=0 disables the trace entirely.
 const GAMMA_TRACE_OS = parse(Int, get(ENV, "EDM_GAMMA_TRACE_OVERSAMPLE", "4"))
 GAMMA_TRACE_OS >= 0 || error("EDM_GAMMA_TRACE_OVERSAMPLE must be ≥ 0, got $GAMMA_TRACE_OS")
-function gamma_trace(trajs, τs, c, γ0, τf)
-    # One accumulator per electron CHUNK, not per threadid: threadid() can exceed nthreads()
-    # (interactive pool) and tasks migrate, so threadid-indexed accumulators are unsound.
-    nch = max(1, min(Threads.nthreads(), length(trajs)))
-    chunks = collect(Iterators.partition(eachindex(trajs), cld(length(trajs), nch)))
-    sums = [zeros(length(τs)) for _ in chunks]
-    los = [fill(Inf, length(τs)) for _ in chunks]
-    his = [fill(-Inf, length(τs)) for _ in chunks]
-    drain = zeros(length(trajs))
-    tasks = map(enumerate(chunks)) do (ci, ch)
-        Threads.@spawn begin
-            s, lo, hi = sums[ci], los[ci], his[ci]
-            for e in ch
-                tr = trajs[e]
-                @inbounds for (k, τk) in enumerate(τs)
-                    γ = tr(τk)[2][1] / c
-                    s[k] += γ
-                    γ < lo[k] && (lo[k] = γ)
-                    γ > hi[k] && (hi[k] = γ)
-                end
-                drain[e] = 1 - tr(τf)[2][1] / (γ0 * c)
-            end
-        end
-    end
-    foreach(wait, tasks)
-    return reduce(+, sums) ./ length(trajs),
-        reduce((a, b) -> min.(a, b), los), reduce((a, b) -> max.(a, b), his), drain
-end
 if GAMMA_TRACE_OS > 0
     t_gtrace = @elapsed begin
         knot_dt = (2π / ω) / (GAMMA * (1 + β)) / parse(Float64, INTERP_SAVEAT)
@@ -429,45 +402,8 @@ if GAMMA_TRACE_OS > 0
     @info "γ(τ)/γ₀ trace serialized" t_gtrace n_τ = length(γτ_grid) mean_drain = sum(γdrain) / length(γdrain)
 end
 
-# ── As-run initial conditions: cache + chip. The disk and its Δz offsets are deterministic
-# from [config], but the cache pins the EXACT as-run xμ₀/u₀ (reconstruction drift becomes
-# visible instead of silent) and lets the IC chip re-render anywhere without an EDM solve —
-# the same publish-autonomy contract as the γ(τ) trace (both are enumerated in the .reduced
-# marker at reduce time). `datafile` on the sidecar ships the cache to the storagebox and
-# puts a /data download URL on the chip. Cheap (N×4 floats ≈ 64 KB at N = 2000): always on.
-function write_ic_products(xμ0, u0, dz, outdir, run_tag; γ0, λ, w₀, nb, l, chirp)
-    icfile = joinpath(outdir, "ic_$(run_tag).jls")
-    X = permutedims(reduce(hcat, xμ0))       # N×4 as-run start 4-positions (bunch_dz included)
-    serialize(icfile, (; xμ0 = X, u0 = collect(u0), dz = collect(dz), γ0, λ, w₀,
-        bunch = (; nb, l, chirp)))
-    x, y = X[:, 2] ./ λ, X[:, 3] ./ λ
-    dzλ = collect(dz) ./ λ
-    fig = Figure(size = (1080, 480))
-    ax1 = Axis(fig[1, 1]; title = "start disk, colored by bunching offset Δz",
-        xlabel = "x  [λ]", ylabel = "y  [λ]", aspect = 1)
-    sc = scatter!(ax1, x, y; color = dzλ, markersize = 5)
-    Colorbar(fig[1, 2], sc; label = "Δz  [λ]")
-    ax2 = Axis(fig[1, 3]; title = "arrival surface: lens parabola + helix spread",
-        xlabel = "(ρ/w₀)²", ylabel = "Δz  [λ]")
-    scatter!(ax2, (x .^ 2 .+ y .^ 2) .* (λ / w₀)^2, dzλ;
-        color = atan.(y, x), colormap = :twilight, markersize = 4)
-    Label(fig[0, :], @sprintf("as-run initial conditions — N = %d, γ = %g, n_b = %d, ℓ = %d",
-        length(x), γ0, nb, l), fontsize = 17)
-    out = joinpath(outdir, "inverse_thomson_ic_$(run_tag).png")
-    save(out, fig)
-    write_derived(
-        outdir; kind = "ic", label = "initial conditions (as run)",
-        run_id = run_tag, plot = basename(out), datafile = basename(icfile),
-        plot_params = Dict("N" => length(x), "bunch_nb" => nb, "bunch_l" => l,
-            "max |Δz| [λ]" => round(maximum(abs, dzλ); sigdigits = 3)),
-        description = "The exact as-run start disk: transverse sunflower positions colored by " *
-            "the longitudinal bunching offset Δz (the arrival-surface placement), and Δz against " *
-            "(ρ/w₀)² — the lens parabola, with the ℓθ helix as the azimuthal spread. The " *
-            "`ic_<id>.jls` cache stores xμ₀/u₀/Δz, so this chip re-renders without an EDM solve.",
-    )
-    println("saved → $(basename(out))")
-    return icfile
-end
+# As-run initial-conditions cache + chip (write_ic_products lives in trajectory_products.jl,
+# shared with the gammatau_backfill.jl path).
 write_ic_products(xμ, u⁰, [bunch_dz(r) for r in R₀], OUTDIR, RUN_TAG;
     γ0 = GAMMA, λ, w₀, nb = BUNCH_NB, l = BUNCH_L, chirp = BUNCH_CHIRP)
 

--- a/scripts/ll_system_chips.jl
+++ b/scripts/ll_system_chips.jl
@@ -53,7 +53,7 @@ function main(dir)
         ll = findfirst(c -> c.system == "ll", g)
         (cl === nothing || ll === nothing) && continue
         cl, ll = g[cl], g[ll]
-        push!(pairs, (; γ, a0, it))
+        push!(pairs, (; γ, a0, it, clid = cl.id, llid = ll.id))
         w₀ = cl.h.w₀
         # Boosted pairs (n0 > 1) label bins in ω_bs = n0·ω₁ units, like the h<n> chips.
         hlabel(n) = cl.n0 == 1 ? "$(n)ω₁" : @sprintf("%.4g ω_bs", n / cl.n0)
@@ -112,7 +112,55 @@ function main(dir)
         end
         gamma_drain_product(dir, cl, ll, γ, a0)
     end
+    drain_ladder_summary(dir, pairs)
     write_system_comparisons(dir, pairs)
+    return
+end
+
+# Campaign-level drain ladder: the measured Δγ/γ of every classical|LL pair against the
+# campaign axis, with the linear small-drain law 3.5e-7·a₀²γ overlaid — the "does the law
+# bend" summary the LL probe campaigns exist for. A [summary] sidecar (axis = the varying
+# param), so it lands on the sweep card next to the plots, not buried in per-pair
+# plot_params. Needs ≥2 pairs with gammatau traces; skips quietly otherwise.
+function drain_ladder_summary(dir, pairs)
+    rows = []
+    for pr in pairs
+        f = joinpath(dir, "gammatau_$(pr.llid).jls")
+        isfile(f) || continue
+        g = deserialize(f)
+        push!(rows, (; pr.γ, pr.a0, pr.clid, pr.llid,
+            drain = sum(g.drain) / length(g.drain)))
+    end
+    length(rows) >= 2 || return println("drain ladder: <2 pairs with γ(τ) traces — skip")
+    axis = length(unique(r.a0 for r in rows)) > 1 ? "a0" : "gamma"
+    sort!(rows, by = r -> axis == "a0" ? r.a0 : r.γ)
+    xs = axis == "a0" ? [r.a0 for r in rows] : [Float64(r.γ) for r in rows]
+    meas = [r.drain for r in rows]
+    lin = [3.5e-7 * r.a0^2 * r.γ for r in rows]
+    fig = Figure(size = (760, 520))
+    ax = Axis(fig[1, 1]; xscale = log10, yscale = log10,
+        xlabel = axis == "a0" ? "a₀" : "γ", ylabel = "Δγ/γ  (disk mean)",
+        title = @sprintf("radiation-reaction drain vs the linear law  (%s)",
+            axis == "a0" ? @sprintf("γ = %g", rows[1].γ) : @sprintf("a₀ = %g", rows[1].a0)))
+    lines!(ax, xs, lin; color = :gray40, linestyle = :dash, label = "3.5×10⁻⁷ a₀² γ")
+    scatterlines!(ax, xs, meas; color = :crimson, markersize = 12, label = "measured (LL)")
+    axislegend(ax; position = :lt)
+    out = joinpath(dir, "inverse_thomson_drain_ladder_$(first(rows[1].llid, 8)).png")
+    save(out, fig)
+    write_summary(
+        dir; kind = "drain_ladder", label = "Δγ/γ drain ladder vs $(axis == "a0" ? "a₀" : "γ")",
+        run_ids = [id for r in rows for id in (r.clid, r.llid)],
+        axis, plot = basename(out),
+        plot_params = Dict(
+            (axis == "a0" ? "a₀ values" : "γ values") => xs,
+            "measured Δγ/γ" => [round(v; sigdigits = 3) for v in meas],
+            "linear law" => [round(v; sigdigits = 3) for v in lin]),
+        description = "Disk-mean radiation-reaction drain Δγ/γ per classical|LL pair (from the " *
+            "γ(τ) traces) against the linear small-drain law \$3.5\\times10^{-7} a_0^2\\gamma\$. " *
+            "Where the points fall below the dashed line, the linear law has bent — the " *
+            "operating corner the probe campaigns were sized to find.",
+    )
+    println("summary → drain ladder ($(length(rows)) pairs, axis = $axis)")
     return
 end
 

--- a/scripts/trajectory_products.jl
+++ b/scripts/trajectory_products.jl
@@ -1,0 +1,79 @@
+# Trajectory-side products shared between the live solver (inverse_thomson_scattering.jl)
+# and the backfill path (gammatau_backfill.jl): the γ(τ)/γ₀ trace reduction and the as-run
+# initial-conditions cache + chip. Included, not a module — the includer provides
+# Serialization, CairoMakie, Printf, and RunManifests (write_derived), same contract as
+# harmonic_products.jl.
+
+# γ(τ)/γ₀ across the ensemble, sampled through the trajectory INTERPOLANTS (the uniform-saveat
+# CubicSplines the radiation kernel integrates), read between knots at the caller's τ grid — so
+# saveat-undersampling and spline artifacts stay visible instead of hidden by the solver's
+# dense output. Returns (γmean, γmin, γmax, drain): disk mean/min/max at each τ plus the
+# per-electron end-state drain 1 − γ(τf)/γ₀.
+function gamma_trace(trajs, τs, c, γ0, τf)
+    # One accumulator per electron CHUNK, not per threadid: threadid() can exceed nthreads()
+    # (interactive pool) and tasks migrate, so threadid-indexed accumulators are unsound.
+    nch = max(1, min(Threads.nthreads(), length(trajs)))
+    chunks = collect(Iterators.partition(eachindex(trajs), cld(length(trajs), nch)))
+    sums = [zeros(length(τs)) for _ in chunks]
+    los = [fill(Inf, length(τs)) for _ in chunks]
+    his = [fill(-Inf, length(τs)) for _ in chunks]
+    drain = zeros(length(trajs))
+    tasks = map(enumerate(chunks)) do (ci, ch)
+        Threads.@spawn begin
+            s, lo, hi = sums[ci], los[ci], his[ci]
+            for e in ch
+                tr = trajs[e]
+                @inbounds for (k, τk) in enumerate(τs)
+                    γ = tr(τk)[2][1] / c
+                    s[k] += γ
+                    γ < lo[k] && (lo[k] = γ)
+                    γ > hi[k] && (hi[k] = γ)
+                end
+                drain[e] = 1 - tr(τf)[2][1] / (γ0 * c)
+            end
+        end
+    end
+    foreach(wait, tasks)
+    return reduce(+, sums) ./ length(trajs),
+        reduce((a, b) -> min.(a, b), los), reduce((a, b) -> max.(a, b), his), drain
+end
+
+# As-run initial conditions: cache + chip. The disk and its Δz offsets are deterministic
+# from [config], but the cache pins the EXACT as-run xμ₀/u₀ (reconstruction drift becomes
+# visible instead of silent) and lets the IC chip re-render anywhere without an EDM solve —
+# the same publish-autonomy contract as the γ(τ) trace (both are enumerated in the .reduced
+# marker at reduce time). `datafile` on the sidecar ships the cache to the storagebox and
+# puts a /data download URL on the chip. Cheap (N×4 floats ≈ 64 KB at N = 2000): always on.
+function write_ic_products(xμ0, u0, dz, outdir, run_tag; γ0, λ, w₀, nb, l, chirp)
+    icfile = joinpath(outdir, "ic_$(run_tag).jls")
+    X = permutedims(reduce(hcat, xμ0))       # N×4 as-run start 4-positions (bunch_dz included)
+    serialize(icfile, (; xμ0 = X, u0 = collect(u0), dz = collect(dz), γ0, λ, w₀,
+        bunch = (; nb, l, chirp)))
+    x, y = X[:, 2] ./ λ, X[:, 3] ./ λ
+    dzλ = collect(dz) ./ λ
+    fig = Figure(size = (1080, 480))
+    ax1 = Axis(fig[1, 1]; title = "start disk, colored by bunching offset Δz",
+        xlabel = "x  [λ]", ylabel = "y  [λ]", aspect = 1)
+    sc = scatter!(ax1, x, y; color = dzλ, markersize = 5)
+    Colorbar(fig[1, 2], sc; label = "Δz  [λ]")
+    ax2 = Axis(fig[1, 3]; title = "arrival surface: lens parabola + helix spread",
+        xlabel = "(ρ/w₀)²", ylabel = "Δz  [λ]")
+    scatter!(ax2, (x .^ 2 .+ y .^ 2) .* (λ / w₀)^2, dzλ;
+        color = atan.(y, x), colormap = :twilight, markersize = 4)
+    Label(fig[0, :], @sprintf("as-run initial conditions — N = %d, γ = %g, n_b = %d, ℓ = %d",
+        length(x), γ0, nb, l), fontsize = 17)
+    out = joinpath(outdir, "inverse_thomson_ic_$(run_tag).png")
+    save(out, fig)
+    write_derived(
+        outdir; kind = "ic", label = "initial conditions (as run)",
+        run_id = run_tag, plot = basename(out), datafile = basename(icfile),
+        plot_params = Dict("N" => length(x), "bunch_nb" => nb, "bunch_l" => l,
+            "max |Δz| [λ]" => round(maximum(abs, dzλ); sigdigits = 3)),
+        description = "The exact as-run start disk: transverse sunflower positions colored by " *
+            "the longitudinal bunching offset Δz (the arrival-surface placement), and Δz against " *
+            "(ρ/w₀)² — the lens parabola, with the ℓθ helix as the azimuthal spread. The " *
+            "`ic_<id>.jls` cache stores xμ₀/u₀/Δz, so this chip re-renders without an EDM solve.",
+    )
+    println("saved → $(basename(out))")
+    return icfile
+end

--- a/scripts/trajectory_products.jl
+++ b/scripts/trajectory_products.jl
@@ -43,36 +43,60 @@ end
 # visible instead of silent) and lets the IC chip re-render anywhere without an EDM solve —
 # the same publish-autonomy contract as the γ(τ) trace (both are enumerated in the .reduced
 # marker at reduce time). `datafile` on the sidecar ships the cache to the storagebox and
-# puts a /data download URL on the chip. Cheap (N×4 floats ≈ 64 KB at N = 2000): always on.
-function write_ic_products(xμ0, u0, dz, outdir, run_tag; γ0, λ, w₀, nb, l, chirp)
+# puts a /data download URL on the chip. Cheap (N×6 floats ≈ 100 KB at N = 2000): always on.
+#
+# The chip is MODE-AWARE, because unbunched runs (nb = 0, most campaigns) have Δz ≡ 0 and a
+# Δz-only chip degenerates to a flat disk over a flat line. Panel 1 colors the disk by the
+# local LG amplitude |u_rel| (closed form, p = 2 |m| = 2 — the production mode) — who actually
+# radiates — and panel 2 shows the arrival surface when bunched, or the sampled mode profile
+# |u_rel|(ρ) when not. Other (p, m): panel 1 falls back to Δz coloring, no weight panel.
+function write_ic_products(xμ0, u0, dz, outdir, run_tag; γ0, λ, w₀, nb, l, chirp, p = 2, m = -2)
     icfile = joinpath(outdir, "ic_$(run_tag).jls")
     X = permutedims(reduce(hcat, xμ0))       # N×4 as-run start 4-positions (bunch_dz included)
-    serialize(icfile, (; xμ0 = X, u0 = collect(u0), dz = collect(dz), γ0, λ, w₀,
-        bunch = (; nb, l, chirp)))
     x, y = X[:, 2] ./ λ, X[:, 3] ./ λ
     dzλ = collect(dz) ./ λ
+    ρw₀ = sqrt.(x .^ 2 .+ y .^ 2) .* (λ / w₀)
+    urel = (Int(p) == 2 && abs(Int(m)) == 2) ?
+        (σ = ρw₀ .^ 2; abs.(√12 .* 2 .* σ .* (1 .- 4 .* σ ./ 3 .+ σ .^ 2 ./ 3) .* exp.(-σ))) :
+        nothing
+    neff = urel === nothing ? nothing : sum(urel)^2 / (length(urel) * sum(abs2, urel))
+    serialize(icfile, (; xμ0 = X, u0 = collect(u0), dz = collect(dz), γ0, λ, w₀,
+        p = Int(p), m = Int(m), u_rel = urel, bunch = (; nb, l, chirp)))
     fig = Figure(size = (1080, 480))
-    ax1 = Axis(fig[1, 1]; title = "start disk, colored by bunching offset Δz",
+    ax1 = Axis(fig[1, 1]; title = urel === nothing ?
+            "start disk, colored by bunching offset Δz" :
+            "start disk, colored by the local drive amplitude",
         xlabel = "x  [λ]", ylabel = "y  [λ]", aspect = 1)
-    sc = scatter!(ax1, x, y; color = dzλ, markersize = 5)
-    Colorbar(fig[1, 2], sc; label = "Δz  [λ]")
-    ax2 = Axis(fig[1, 3]; title = "arrival surface: lens parabola + helix spread",
-        xlabel = "(ρ/w₀)²", ylabel = "Δz  [λ]")
-    scatter!(ax2, (x .^ 2 .+ y .^ 2) .* (λ / w₀)^2, dzλ;
-        color = atan.(y, x), colormap = :twilight, markersize = 4)
+    sc = scatter!(ax1, x, y; color = urel === nothing ? dzλ : urel, markersize = 5,
+        colormap = urel === nothing ? :viridis : :inferno)
+    Colorbar(fig[1, 2], sc; label = urel === nothing ? "Δz  [λ]" : "|u_rel|")
+    if nb != 0
+        ax2 = Axis(fig[1, 3]; title = "arrival surface: lens parabola + helix spread",
+            xlabel = "(ρ/w₀)²", ylabel = "Δz  [λ]")
+        scatter!(ax2, ρw₀ .^ 2, dzλ; color = atan.(y, x), colormap = :twilight, markersize = 4)
+    elseif urel !== nothing
+        ax2 = Axis(fig[1, 3]; title = @sprintf("mode sampling — N_eff/N = %.2f", neff),
+            xlabel = "ρ / w₀", ylabel = "|u_rel|")
+        scatter!(ax2, ρw₀, urel; color = (:crimson, 0.5), markersize = 4)
+    end
     Label(fig[0, :], @sprintf("as-run initial conditions — N = %d, γ = %g, n_b = %d, ℓ = %d",
         length(x), γ0, nb, l), fontsize = 17)
     out = joinpath(outdir, "inverse_thomson_ic_$(run_tag).png")
     save(out, fig)
+    pp = Dict{String, Any}("N" => length(x), "bunch_nb" => nb, "bunch_l" => l,
+        "max |Δz| [λ]" => round(maximum(abs, dzλ); sigdigits = 3))
+    neff === nothing || (pp["N_eff/N"] = round(neff; sigdigits = 3))
     write_derived(
         outdir; kind = "ic", label = "initial conditions (as run)",
         run_id = run_tag, plot = basename(out), datafile = basename(icfile),
-        plot_params = Dict("N" => length(x), "bunch_nb" => nb, "bunch_l" => l,
-            "max |Δz| [λ]" => round(maximum(abs, dzλ); sigdigits = 3)),
-        description = "The exact as-run start disk: transverse sunflower positions colored by " *
-            "the longitudinal bunching offset Δz (the arrival-surface placement), and Δz against " *
-            "(ρ/w₀)² — the lens parabola, with the ℓθ helix as the azimuthal spread. The " *
-            "`ic_<id>.jls` cache stores xμ₀/u₀/Δz, so this chip re-renders without an EDM solve.",
+        plot_params = pp,
+        description = "The exact as-run start disk. Left: transverse sunflower positions " *
+            "colored by the local LG amplitude |u_rel| (who actually radiates; the weight " *
+            "behind the N_eff ceiling). Right: bunched runs show the arrival surface — Δz " *
+            "against (ρ/w₀)², the lens parabola with the ℓθ helix as azimuthal spread — and " *
+            "unbunched runs the sampled mode profile |u_rel|(ρ) with its rings and nodes. The " *
+            "`ic_<id>.jls` cache stores xμ₀/u₀/Δz/|u_rel|, so this chip re-renders without an " *
+            "EDM solve.",
     )
     println("saved → $(basename(out))")
     return icfile


### PR DESCRIPTION
Follow-up to #51, for adding the γ(τ)/γ₀ + IC products to runs that predate the run-time emission (first target: `ll_probe_s`).

- `gamma_trace` + `write_ic_products` move to a shared `scripts/trajectory_products.jl` (include-shared, the `harmonic_products.jl` pattern) — no behavior change in the run script.
- `scripts/gammatau_backfill.jl <campaign_dir>` re-solves each run's trajectory ensemble from its manifest on CPU (deterministic from `[config]/[laser]/[setup]`: same solver, tolerances, dtmax, uniform saveat — the cube is never touched; γ=100 cells re-solve in ~1 min each) and emits the traces/IC cache/chips under the **original** run uuid, then renders the classical|LL pair overlays via `ll_system_chips.gamma_drain_product`. Each run's final `.reduced` marker is enriched atomically (tmp+mv) with the new caches so `stage_products` (dashboard PR #47) ships them and `build_status` tracks them.
- Validated end-to-end on the archived `ll_probe_s` metadata (6 runs, γ=100, a₀ ∈ {10, 30, 100} × {classical, ll}) — see the republished campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)