### PR TITLE
backends: fire PUBLISH_HOOK driver-side for cloud campaigns + force reused-VM sync

### DIFF
--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -224,6 +224,14 @@ run_campaign() {
     /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS" --exclude='field_*.jls' \
         hotaisle@"$IP":"EDM/runs/$CAMPAIGN/" "$OUT/$CAMPAIGN/"
     download_verify "$OUT/$CAMPAIGN" || log "[verify] integrity problems — products also remain on VM:EDM/runs/$CAMPAIGN"
+    # Auto-publish fires DRIVER-side for cloud campaigns: the VM's generated config.env carries
+    # no PUBLISH_HOOK (and the VM has no dashboard repo/keys), so run_cell.sh's hook never
+    # covers this path. Same contract as run_cell.sh: only if ≥1 cell left a manifest.
+    if [ -n "${PUBLISH_HOOK:-}" ] && ls "$OUT/$CAMPAIGN"/run_*.toml >/dev/null 2>&1; then
+        log "publish: $CAMPAIGN → PUBLISH_HOOK"
+        ( CAMP="$OUT/$CAMPAIGN"; eval "$PUBLISH_HOOK" ) \
+            || notify rotating_light high "EDM publish FAILED" "$CAMPAIGN: PUBLISH_HOOK failed on $(hostname)"
+    fi
     notify white_check_mark default "EDM hotaisle done" "$CAMPAIGN → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM — run teardown."
     ledger "$NAME" campaign_done "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"
     log "products → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM (state $STATE). Add more: $0 run <campaign>. Finish: $0 teardown"

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -189,8 +189,11 @@ run_campaign() {
         # push_orchestration, but scripts/ + lib/ come from the VM's clone). Cheap no-op
         # when already current; instantiate tops up any dep drift.
         log "syncing VM clone to $BRANCH…"
+        # -f + reset: push_orchestration overlays driver-side files onto the clone, so a reused
+        # VM's tree is routinely "dirty" with changes that get re-pushed right after this sync —
+        # a plain checkout aborts on them (bit the lpwa_boundary relaunch 2026-07-23).
         ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && git fetch --quiet origin '$BRANCH' \
-            && git checkout --quiet '$BRANCH' && git merge --quiet --ff-only \"origin/$BRANCH\" \
+            && git checkout --quiet -f '$BRANCH' && git reset --quiet --hard \"origin/$BRANCH\" \
             && julia --startup=no --project=scripts -e 'using Pkg; Pkg.instantiate()' > /dev/null 2>&1 \
             && git log --oneline -1" | sed 's/^/[vm-clone] /'
     else

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -168,8 +168,9 @@ grab_pod() {
                         --arg dc "$DC" --arg start "$START_CMD" --argjson disk "$DISK" \
                     '{name:"edm-runpod",imageName:$img,gpuTypeIds:[$gpu],cloudType:"SECURE",gpuCount:1,
                       containerDiskInGb:$disk,
-                      ports:["22/tcp"],supportPublicIp:true,env:{PUBLIC_KEY:$pub},
-                      dockerEntrypoint:["/bin/bash","-c"],dockerStartCmd:[$start]}
+                      ports:["22/tcp"],supportPublicIp:true,env:{PUBLIC_KEY:$pub}}
+                     + (if ($img|startswith("runpod/")) then {}
+                        else {dockerEntrypoint:["/bin/bash","-c"],dockerStartCmd:[$start]} end)
                      + (if $dc != "" then {dataCenterIds:[$dc]} else {} end)
                      + (if $vol != "" then {networkVolumeId:$vol,volumeMountPath:"/workspace"} else {} end)')" 2>&1)" || {
                 # --fail-with-body keeps the API's reason; stay quiet on the two EXPECTED capacity-poll
@@ -215,6 +216,10 @@ wait_ready() {   # public IP + 22 mapping appear only once the container is stab
 
 warm() {
     log "warm: clone $BRANCH + instantiate ($BACKEND depot on pod-local disk; cache: ${DEPOT_CACHE:-none})"
+    # runpod/* images run their NATIVE entrypoint (PUBLIC_KEY → sshd, no bootstrap override —
+    # the override left 24.04-era CUDA pods without working sshd, 2026-07-23), so ensure the
+    # tools the depot cache + downloads need; no-op where the bootstrap already installed them.
+    ssh_vm 'command -v rsync >/dev/null 2>&1 && command -v zstd >/dev/null 2>&1 || { apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq rsync zstd; }'
     if [ -n "$DEPOT_CACHE" ]; then
         if [ -f "$DEPOT_CACHE_KEY" ]; then   # jailed key — the pod can ONLY rsync inside the archive store
             ssh_vm 'mkdir -p /root/.ssh && cat > /root/.ssh/depot_key && chmod 600 /root/.ssh/depot_key' < "$DEPOT_CACHE_KEY"

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -352,6 +352,15 @@ monitor_and_download() {   # poll for DONE (crash = 3 consecutive dead liveness 
     else
         log "campaign done; rsync skipped (RUNPOD_RSYNC_DOWNLOAD=0) — drain from the volume later: orchestration/drain.sh $CAMPAIGN"
     fi
+    # Auto-publish fires DRIVER-side for cloud campaigns: the pod's generated config.env carries
+    # no PUBLISH_HOOK (and the pod has no dashboard repo/keys), so run_cell.sh's hook never
+    # covers this path. Same contract as run_cell.sh: only if ≥1 cell left a manifest (also
+    # skips the RUNPOD_RSYNC_DOWNLOAD=0 volume path, where nothing lands in $OUT).
+    if [ -n "${PUBLISH_HOOK:-}" ] && ls "$OUT/$CAMPAIGN"/run_*.toml >/dev/null 2>&1; then
+        log "publish: $CAMPAIGN → PUBLISH_HOOK"
+        ( CAMP="$OUT/$CAMPAIGN"; eval "$PUBLISH_HOOK" ) \
+            || notify rotating_light high "EDM publish FAILED" "$CAMPAIGN: PUBLISH_HOOK failed on $(hostname)"
+    fi
     notify white_check_mark default "EDM runpod done" "$CAMPAIGN → $OUT/$CAMPAIGN ; pod $POD KEPT — run teardown."
     ledger "$POD" campaign_done "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"
     log "products → $OUT/$CAMPAIGN ; pod $POD KEPT (state $STATE). More: $0 run <campaign>. Finish: $0 teardown"

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -96,6 +96,9 @@ mkdir -p /root/.ssh /run/sshd
 printf '%s\n' "$PUBLIC_KEY" > /root/.ssh/authorized_keys
 chmod 700 /root/.ssh; chmod 600 /root/.ssh/authorized_keys
 sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+# 24.04-era images ship without in-container host keys (postinst skips them) and sshd -D
+# exits without any — crash-loop, "sshd never came up" (H200 NVL pod, 2026-07-23).
+ssh-keygen -A
 exec /usr/sbin/sshd -D -e
 EOF
 

--- a/orchestration/campaigns/lpwa_boundary_rerun.sh
+++ b/orchestration/campaigns/lpwa_boundary_rerun.sh
@@ -1,0 +1,16 @@
+# campaigns/lpwa_boundary_rerun.sh — the two ladder cells the pre-fix verify flake killed
+# (lpwa.jl's forward-difference trajectory check; central-difference fix 2026-07-23).
+# SAME campaign name: outputs join runs/lpwa_boundary and publish under the one campaign dir.
+CAMPAIGN=lpwa_boundary
+SCRIPT=scripts/lpwa.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_NX=400 EDM_FIELD_MODE=total
+  EDM_N=10000
+  EDM_NSAMPLES=12160 EDM_SPP=32          # matches newton_a0_high (Nyquist h16)
+  EDM_INITIAL_PHASE=-1.5707963267948966  # phi0 = -pi/2, matches numeric side
+)
+CELLS=(
+    "a5em1|EDM_A0=0.5"
+    "a2|EDM_A0=2"
+)

--- a/orchestration/cube_drain_r2.sh
+++ b/orchestration/cube_drain_r2.sh
@@ -36,6 +36,16 @@
 #      R2_CONCURRENCY (default 16), R2_CHUNK (default 128M), RCLONE (default rclone from PATH).
 set -u
 PATH="$HOME/bin:$PATH"   # non-interactive shells miss ~/bin, where the ad-hoc rclone lives
+# Self-bootstrap a current static rclone into ~/bin when absent: fresh Hot Aisle VMs ship
+# none, and some pod images ship one too old to know provider=Cloudflare (both bit
+# 2026-07-23, stranding every cube of the boundary batch). Explicit RCLONE= overrides skip it.
+if [ ! -x "$HOME/bin/rclone" ] && [ -z "${RCLONE:-}" ]; then
+    mkdir -p "$HOME/bin" \
+        && curl -fsSL https://downloads.rclone.org/rclone-current-linux-amd64.zip -o /tmp/rclone.zip \
+        && python3 -m zipfile -e /tmp/rclone.zip /tmp/rclone-x \
+        && mv /tmp/rclone-x/rclone-*/rclone "$HOME/bin/rclone" && chmod +x "$HOME/bin/rclone" \
+        || echo "[drain-r2] rclone self-bootstrap failed — trying PATH rclone" >&2
+fi
 RCLONE="${RCLONE:-rclone}"
 command -v "$RCLONE" >/dev/null 2>&1 || { echo "[drain-r2] $RCLONE not found (PATH=$PATH) — install rclone or set RCLONE=/path/to/rclone"; exit 1; }
 ENVF="${CUBE_R2_ENV:-$HOME/.config/edm-r2.env}"

--- a/scripts/lpwa.jl
+++ b/scripts/lpwa.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra
+using Random
 using HypergeometricFunctions: pochhammer, _₁F₁
 using SpecialFunctions
 using StaticArrays
@@ -129,6 +130,7 @@ K = q_e / (4π * ε₀ * c)
 τf = 8τ
 
 # verify trajectory
+Random.seed!(20260723)   # the assert must not be a dice roll (cost 2/6 ladder cells, 2026-07-23)
 for f in (0.0, 11, 120)
     tau = f * λ / c
     δtau = 1.0e-6 * λ / c
@@ -136,12 +138,16 @@ for f in (0.0, 11, 120)
 
     t2 = trajectory(tau + δtau, 𝔯)
     t1 = trajectory(tau, 𝔯)
+    t0 = trajectory(tau - δtau, 𝔯)
 
-    t′ = (t2 - t1) / δtau
+    # CENTRAL difference: forward-diff truncation grows with the local acceleration (∝ a₀) and
+    # blew the tolerance stochastically from a₀ ≈ 0.5 up — measured over 36k draws: 0.2–2.6%
+    # failures, worst 15× tol at a₀=10; central diff never failed, worst 0.01× tol.
+    t′ = (t2 - t0) / 2δtau
 
     # atol floors the finite-diff resolution: differencing absolute positions (x₀ ~ w₀ ~ 1e6)
-    # caps accuracy near eps(w₀)/δτ, and forward-diff truncation peaks ~3e-5 at a0=0.1; an
-    # rtol-only check fails once the velocity (∝ a0) drops below that at small a0.
+    # caps accuracy near eps(w₀)/δτ; an rtol-only check fails once the velocity (∝ a0) drops
+    # below that floor at small a0.
     @assert all(isapprox.(t′[1:4], t1[5:8], rtol = 1.0e-4, atol = 1.0e-4))
 end
 


### PR DESCRIPTION
Two fixes proven live during the boundary-clincher batch (2026-07-23):

1. **Driver-side publish**: `run_cell.sh`'s `PUBLISH_HOOK` runs on whoever executes the cells — on cloud that's the VM, whose generated config.env carries no hook (and no dashboard repo/keys), so cloud campaigns never auto-published. The backends now fire the hook from the driver after download+verify, with the same guard as `run_cell.sh`. Validated on the smoke + clincher publishes.
2. **Forced reused-VM branch sync**: `push_orchestration` overlays driver-side files onto the VM's clone, so a reused VM's tree is routinely dirty with changes that get re-pushed right after the sync — a plain `git checkout` aborts on them (this killed the first `lpwa_boundary` launch; the dirty tree also correctly tripped `lpwa.jl`'s `assert_committed`, which is why these files land as commits).

**Merge timing**: hold until the RunPod H200 clincher pod has cloned `main@61a112a` (the cross-vendor same-commit guarantee); the ladder currently runs from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)