### PR TITLE
fix the −7π/16 LPWA↔numeric phase offset: saveat a_knots + φ₀ convention

### DIFF
--- a/orchestration/campaigns/linpol_maps.sh
+++ b/orchestration/campaigns/linpol_maps.sh
@@ -7,7 +7,7 @@ BASE=(
   EDM_N=400 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
   EDM_POL=linear                       # linear polarization (ξ = (1,0)); default is circular_minus
-  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
 )
 CELLS=(
   "a1em5|EDM_A0=1e-5"

--- a/orchestration/campaigns/linpol_maps_N10k_Nx400.sh
+++ b/orchestration/campaigns/linpol_maps_N10k_Nx400.sh
@@ -9,7 +9,7 @@ BASE=(
   EDM_N=10000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
   EDM_POL=linear                       # linear polarization (ξ = (1,0))
-  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
 )
 CELLS=(
   "a1em5|EDM_A0=1e-5"

--- a/orchestration/campaigns/linpol_maps_N5k.sh
+++ b/orchestration/campaigns/linpol_maps_N5k.sh
@@ -7,7 +7,7 @@ BASE=(
   EDM_N=5000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
   EDM_POL=linear                       # linear polarization (ξ = (1,0)); default is circular_minus
-  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
 )
 CELLS=(
   "a1em5|EDM_A0=1e-5"

--- a/orchestration/campaigns/lowa0_maps.sh
+++ b/orchestration/campaigns/lowa0_maps.sh
@@ -6,7 +6,7 @@ BASE=(
   EDM_NX=400 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
   EDM_N=10000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
-  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
 )
 CELLS=(
   "a1em5|EDM_A0=1e-5"

--- a/orchestration/campaigns/lpwa_boundary.sh
+++ b/orchestration/campaigns/lpwa_boundary.sh
@@ -10,7 +10,7 @@ BASE=(
   EDM_NX=400 EDM_FIELD_MODE=total
   EDM_N=10000
   EDM_NSAMPLES=12160 EDM_SPP=32          # matches newton_a0_high (Nyquist h16)
-  EDM_INITIAL_PHASE=-1.5707963267948966  # phi0 = -pi/2, matches numeric side
+  EDM_INITIAL_PHASE=-1.5707963267948966  # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
 )
 CELLS=(
     "a2em1|EDM_A0=0.2"

--- a/orchestration/campaigns/lpwa_boundary_rerun.sh
+++ b/orchestration/campaigns/lpwa_boundary_rerun.sh
@@ -8,7 +8,7 @@ BASE=(
   EDM_NX=400 EDM_FIELD_MODE=total
   EDM_N=10000
   EDM_NSAMPLES=12160 EDM_SPP=32          # matches newton_a0_high (Nyquist h16)
-  EDM_INITIAL_PHASE=-1.5707963267948966  # phi0 = -pi/2, matches numeric side
+  EDM_INITIAL_PHASE=-1.5707963267948966  # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
 )
 CELLS=(
     "a5em1|EDM_A0=0.5"

--- a/orchestration/campaigns/newton_a0_high.sh
+++ b/orchestration/campaigns/newton_a0_high.sh
@@ -12,7 +12,7 @@ BASE=(
   EDM_N=10000 EDM_RELTOL=1e-12
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
   EDM_POL=circular_minus
-  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
   EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=3
   EDM_NSAMPLES=12160 EDM_SPP=32         # UNIFORM across cells (Nyquist h16, 380-period window):
                                         # keeps the a0 sweep 1-D on the dashboard and the maps

--- a/orchestration/campaigns/newton_a0_low.sh
+++ b/orchestration/campaigns/newton_a0_low.sh
@@ -11,7 +11,7 @@ BASE=(
   EDM_NX=400 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=split
   EDM_N=10000 EDM_RELTOL=1e-12
   EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the floor fix)
-  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2 (published convention)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2: corpus continuity with pre-PR#62 runs (arbitrary since #62 unified the φ₀ convention)
   EDM_ACCUM_ALG=newton EDM_NEWTON_ITERS=2
 )
 CELLS=(

--- a/scripts/lpwa.jl
+++ b/scripts/lpwa.jl
@@ -62,7 +62,12 @@ A(ρ) = A₀ * (√2 * ρ / w₀)^abs(m) * _₁F₁(-p, abs(m) + 1, 2 * (ρ / w�
 function trajectory(τ, ℜ₀)
     x₀, y₀, z₀ = ℜ₀
     ρ₀ = norm(ℜ₀)
-    φ = -m * atan(y₀, x₀) + ϕ₀
+    # φ₀ CONVENTION: EDM_INITIAL_PHASE means the E-FIELD carrier phase (external_fields.jl's
+    # laser: E ∝ e^{i(ωt+ϕ₀)}). This closed form phases the VELOCITY carrier — v ∝ A ∝ ∫E dt
+    # lags E by π/2 (the sin ↔ cos quarter turn) — so map the E convention onto it here.
+    # History: the June 2026 configs compensated implicitly (lpwa ϕ₀=0 vs thomson −π/2);
+    # undocumented, that resurfaced as a global −π/2 offset in the 2026-07 pairs.
+    φ = -m * atan(y₀, x₀) + ϕ₀ + π / 2
 
     k = ω / c
     u⁰ = c

--- a/src/radiation.jl
+++ b/src/radiation.jl
@@ -24,7 +24,14 @@ function TrajectoryInterpolant(sol::SciMLBase.AbstractODESolution, x_syms, u_sym
     # model-consistent — more accurate than differentiating `itp` afterwards,
     # which would amplify the cubic spline's interpolation error. Storing them in
     # a dedicated spline keeps evaluation a cheap, thread-safe lookup.
-    a_knots = [SVector{4}(sol(t, Val{1})[u_idxs]) for t in sol.t]
+    # ONLY valid for dense solutions: with `saveat` the solution interpolation is the
+    # stored-value LINEAR fallback, and `Val{1}` returns left-segment slopes ≈ a(t − h/2) —
+    # a half-knot delay that stamped a −n·π/16 global phase on every saveat-era harmonic
+    # map (root-caused 2026-07-24). On non-dense solutions differentiate the cubic spline
+    # instead: zero phase bias, mirroring lpwa.jl's a_itp construction.
+    a_knots = sol.dense ?
+        [SVector{4}(sol(t, Val{1})[u_idxs]) for t in sol.t] :
+        [SVector{4}(DataInterpolations.derivative(itp, t)[u_idxs]) for t in sol.t]
     a_itp = CubicSpline(a_knots, sol.t; extrapolation = ExtrapolationType.Extension)
     sys = sol.prob.f.sys
     _world = _find_world(sys)

--- a/test/interp_saveat_acceleration.jl
+++ b/test/interp_saveat_acceleration.jl
@@ -1,0 +1,50 @@
+# With `saveat`, the ODE solution is NOT dense: `sol(t, Val{1})` silently falls back to the
+# stored-value linear interpolation and returns left-segment slopes — i.e. acceleration
+# delayed by half a saveat knot. Fed into TrajectoryInterpolant's a_itp, that delay stamped
+# a −n·π/16 global phase on every EDM_INTERP_SAVEAT-era harmonic map (root-caused
+# 2026-07-24). The fix differentiates the trajectory's own cubic spline on non-dense
+# solutions; this test pins it by demanding the saveat-built acceleration match the dense
+# solution's model-consistent derivative inside the pulse.
+using Test
+using ElectronDynamicsModels
+using ModelingToolkit, OrdinaryDiffEqVerner, SciMLBase, StaticArrays, LinearAlgebra
+using SymbolicIndexingInterface: variable_index
+import ElectronDynamicsModels as EDM
+
+let
+    c = 137.03599908330932
+    ω = 0.057
+    τp = 150 / ω
+    λ = 2π * c / ω
+    w₀ = 75λ
+    τi, τf = -8τp, 8τp
+    @named world = Worldline(:τ, :atomic)
+    @named laser = LaguerreGaussLaser(;
+        wavelength = λ, a0 = 0.1, beam_waist = w₀,
+        radial_index = 2, azimuthal_index = -2, world, temporal_profile = :gaussian,
+        temporal_width = τp, focus_position = 0.0, polarization = :circular_minus,
+        initial_phase = -π / 2)
+    @named elec = ClassicalElectron(; laser)
+    sys = mtkcompile(elec)
+    u0 = [sys.x => SVector{4}(τi * c, 1.2w₀, 0.7w₀, 0.0),
+        sys.u => SVector{4}(c, 0.0, 0.0, 0.0)]
+    prob = ODEProblem{false, SciMLBase.FullSpecialize}(
+        sys, u0, (τi, τf), u0_constructor = SVector{8}, fully_determined = true)
+
+    sol_dense = solve(prob, Vern9(); reltol = 1.0e-12, abstol = 1.0e-13)
+    sol_sv = solve(prob, Vern9(); reltol = 1.0e-12, abstol = 1.0e-13,
+        saveat = collect(τi:((2π / ω) / 16):τf))
+
+    tr_sv = EDM.TrajectoryInterpolant(sol_sv, sys.x, sys.u)
+    uidx = SVector{4, Int}(variable_index.((sol_dense,), collect(sys.u)))
+
+    # Probe between knots across the pulse core. The pre-fix half-knot delay shifts the
+    # ω-oscillating acceleration by π/16 ⇒ ~20% pointwise error; the spline derivative is
+    # accurate to ≪1% at 16 knots/period.
+    worst = maximum(range(-τp, τp; length = 41)) do τ
+        a_ref = sol_dense(τ, Val{1})[uidx]
+        a_sv = EDM.state_with_acceleration(tr_sv, τ)[3]
+        norm(a_sv - a_ref) / max(norm(a_ref), eps())
+    end
+    @test worst < 0.02
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,9 @@ using JET
     @testset "GPU Interpolation" begin
         include("gpu_interp.jl")
     end
+    @testset "Interpolant acceleration under saveat" begin
+        include("interp_saveat_acceleration.jl")
+    end
     @testset "GPU Radiation Accumulation" begin
         include("gpu_radiation.jl")
     end


### PR DESCRIPTION
Root-caused the constant −0.4375π (−78.75°) global phase offset between the 2026-07 LPWA and numeric harmonic maps (June-era pairs measured exactly 0). Two independent mechanisms, both exactly quantified and fixed:

1. **`src/radiation.jl`** — under `saveat` (non-dense solution) `sol(t, Val{1})` returns half-knot-delayed linear slopes for the acceleration knots → −n·π/16 on every saveat-era map. Fixed by differentiating the trajectory's own cubic spline on non-dense solutions. The Newton kernel is exonerated (≡ RK4 to 0.0000π on the same interpolant).
2. **`scripts/lpwa.jl`** — φ₀ phased the velocity/A carrier there vs the E carrier in the numeric laser (π/2 apart); the June configs compensated implicitly (lpwa 0 vs thomson −π/2) and the compensation was undocumented. lpwa now maps the E-carrier convention onto its own (+π/2), so `EDM_INITIAL_PHASE` means the same thing in both scripts.

**Validation** (CPU repro, production sampling): `NUM_adaptive − NUM_saveat16`: −n·π/16 → **0.0000π** at h1–h4; `LPWA − NUM_newton`: −0.4375π → pure −π/2 + the genuine model term, which the lpwa +π/2 cancels. New regression test `test/interp_saveat_acceleration.jl` (pre-fix fails at ~20% error, post-fix <2%).

Published maps are phase-only affected (magnitudes exact); the comparison pipeline phase-aligns and records Δφ, so no re-runs are required for the thesis figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)