### PR TITLE
Doppler-equivalent Thomson runs (γ-scaled ω) + per-electron pixel traces

### DIFF
--- a/orchestration/campaigns/gamma_equiv.sh
+++ b/orchestration/campaigns/gamma_equiv.sh
@@ -1,0 +1,28 @@
+# campaigns/gamma_equiv.sh — Doppler-equivalent Thomson: run the laser at the wavelength a
+# counter-propagating electron of γ = {2, 5, 10} would see (ω′ = (γ+√(γ²−1))·ω₀), at a0 = 1e-2.
+# EDM_OMEGA_SCALE pins the transverse/detector geometry to the lab λ₀ layout (transverse lengths
+# are boost-invariant) and keeps the pulse cycle count.
+# Screen zoom (v2, corrected): the pattern does NOT scale ∝ λ′ across the ladder — with geometry
+# pinned, the source's Fraunhofer distance a²/λ′ grows as 1/λ′ (1.1·Z at γ=2, 5.9·Z at γ=10), so
+# the screen slides into the Fresnel zone and the pattern shrinks slower than 1/s (measured ×13.6
+# at γ=10, not ×19.95). g2/g5 keep the full ±25 w₀ production frame (screen-identical to base;
+# corner-path spread 42/111 T′ < the 191 T′ pulse half-span, so the sampling window keeps the
+# peak). Only g10 needs a zoom — at ±25 w₀ its 224 T′ spread would open the window after the
+# peak passed the central pixels; ±8 w₀ (spread 36 T′) is safe and frames ~6 Fresnel zones.
+# "base" = same cell at λ₀ (scale 1): the pure-wavelength-change control.
+# Sizing: 201²/N2k/Ns6k ≈ 21 min/cell on the W7900 (scaled from lowa0_maps 400²/N6k = 12.9 ks).
+CAMPAIGN=gamma_equiv
+SCRIPT=scripts/thomson_scattering.jl
+BASE=(
+  EDM_NX=201 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12
+  EDM_A0=1e-2
+  EDM_INTERP_SAVEAT=16                 # uniform trajectory output (the 2ω-floor fix)
+  EDM_INITIAL_PHASE=-1.5707963267948966   # φ0 = -π/2: corpus continuity (arbitrary since PR #62)
+)
+CELLS=(
+  "g2|EDM_OMEGA_SCALE=3.7320508075688776"
+  "g5|EDM_OMEGA_SCALE=9.898979485566356"
+  "g10|EDM_OMEGA_SCALE=19.949874371066196 EDM_SCREEN_HALFW=8"
+  "base|"
+)

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -317,7 +317,7 @@ The per-field-type ∠F view from reduced harmonic maps `fields_h` (`(length(har
 Ny)`): for E (comps `1:3`) and B (`4:6`), per harmonic, two derived chips — `phaseE`/`phaseB`
 (heatmap with dashed R±ringtol annuli beside the ∠F-vs-azimuth winding + per-radius linear fit on
 the transverse components) and a separate polar companion `phasePolarE`/`phasePolarB`. Test radii
-are `4,8,12 w₀`. `[plot_params]` records the ring geometry (`ringtol/w₀`, `radii/w₀`) plus, per
+are `4/25, 8/25, 12/25` of the screen half-extent (= `4,8,12 w₀` on the production ±25 w₀ screen). `[plot_params]` records the ring geometry (`ringtol/w₀`, `radii/w₀`) plus, per
 transverse component, the winding `slope` (≈ ℓ) and offset `b/π` over the radii. Takes `fields_h`
 (not the cube), so the live solve and the cached-hmaps recovery share one implementation;
 `x_grid`/`y_grid` may be ranges or vectors (hmaps stores them collected, hence `x_grid[2]-x_grid[1]`).
@@ -326,7 +326,12 @@ function write_phase_products(
         fields_h, x_grid, y_grid; w₀, harmonics, run_tag, outdir, source_datafile,
         title_prefix, fileprefix,
     )
-    ringradii = w₀ .* (4, 8, 12)              # test radii in beam waists
+    # Test radii scale with the screen: 4/25, 8/25, 12/25 of the half-extent — identical to the
+    # legacy 4, 8, 12 w₀ on the production ±25 w₀ screen, but on-screen for zoomed runs
+    # (EDM_SCREEN_HW / EDM_SCREEN_HALFW), whose fixed-w₀ rings fell outside the grid and left
+    # the ∠F heatmap circles and the ∠F-vs-azimuth panels empty.
+    hw = max(abs(first(x_grid)), abs(last(x_grid)))
+    ringradii = hw .* (4, 8, 12) ./ 25
     ringtol = 0.5 * (x_grid[2] - x_grid[1])   # ½ pixel pitch; thin annulus (vector x_grid ⇒ not `step`)
     base_pp = Dict{String, Any}(
         "ringtol/w₀" => round(ringtol / w₀; sigdigits = 3),

--- a/scripts/plot_pixel_traces.jl
+++ b/scripts/plot_pixel_traces.jl
@@ -1,0 +1,249 @@
+# scripts/plot_pixel_traces.jl — per-electron E(t) traces at selected screen pixels.
+#
+# Usage: julia --project=scripts scripts/plot_pixel_traces.jl <run_manifest.toml>
+#
+# Reconstructs the run from its manifest (same pattern as analyze_trajectories.jl — the
+# recorded wavelength/w0/Rmax carry any EDM_OMEGA_SCALE/EDM_SCREEN_HALFW geometry as-is),
+# re-solves a handful of electron trajectories, and evaluates each electron's individual
+# Liénard–Wiechert E(t) at a row of pixels along +x — the center pixel plus a few at given
+# radii — via the CPU reference accumulate_field. The full-N coherent sum (scaled by 1/N,
+# so coherent structure lands on the per-electron amplitude) is overlaid for comparison.
+#
+# ENV knobs:
+#   EDM_TRACE_RADII      pixel radii as fractions of the screen half-extent, default "0,0.25,0.5,0.75"
+#   EDM_TRACE_ELECTRONS  sunflower indices (csv); default 5 electrons at r/Rmax ≈ 0, ¼, ½, ¾, 1
+#                        (k = N·f² since the sunflower radius grows as √k)
+#   EDM_TRACE_TOTAL      1 (default) → also accumulate the full-N sum; 0 → skip (much faster)
+#   EDM_OUTDIR           output dir, default = the manifest's directory
+#
+# Writes pixeltraces_<tag>.png + pixeltraces_<tag>.jls (per-electron + total traces, grids).
+
+using ElectronDynamicsModels
+using ModelingToolkit
+using OrdinaryDiffEqVerner   # explicit Vern9 — trajectories + the retarded-time ODE
+using SciMLBase
+using StaticArrays
+using SymbolicIndexingInterface
+using LinearAlgebra
+using Printf
+using CairoMakie
+using Serialization
+using TOML
+
+const c = 137.03599908330932   # speed of light, atomic units (repo convention)
+
+length(ARGS) == 1 || error("usage: plot_pixel_traces.jl <run_manifest.toml>")
+const MFILE = abspath(ARGS[1])
+isfile(MFILE) || error("no manifest at $MFILE")
+
+const RADII = parse.(Float64, split(get(ENV, "EDM_TRACE_RADII", "0,0.25,0.5,0.75"), ","))
+all(0 .<= RADII .<= 1) || error("EDM_TRACE_RADII are fractions of the screen half-extent (0…1)")
+const TRACE_TOTAL = get(ENV, "EDM_TRACE_TOTAL", "1") == "1"
+const OUTDIR = get(ENV, "EDM_OUTDIR", dirname(MFILE))
+
+# ── Reconstruct the run (mirrors analyze_trajectories.jl reconstruct) ──
+m = TOML.parsefile(MFILE)
+laser_p, cfg, setup = m["laser"], m["config"], m["setup"]
+
+λ = Float64(laser_p["wavelength"])
+w₀ = Float64(laser_p["w0"])
+pol = Symbol(laser_p["pol"])
+τ0 = Float64(laser_p["temporal_width"])
+a₀ = Float64(cfg["a0"])
+φ₀ = Float64(laser_p["phi0"])
+N = Int(cfg["N"])
+Rmax = Float64(setup["Rmax"])
+τi, τf = Float64(setup["τi"]), Float64(setup["τf"])
+Z = Float64(setup["Z"])
+N_samples = Int(cfg["N_samples"])
+spp = Int(cfg["samples_per_period"])
+HALFW = Float64(get(cfg, "screen_halfw", 25.0))   # pre-knob manifests: production framing
+reltol = Float64(get(cfg, "reltol", 1.0e-12))
+abstol = Float64(cfg["abstol"])
+interp_saveat = string(get(cfg, "interp_saveat", "adaptive"))
+ω = 2π * c / λ
+RUN_TAG = m["provenance"]["run_id"]
+
+# k = N·f² ⇒ r/Rmax ≈ f: radially uniform picks from the √k sunflower spiral.
+sel = if isempty(get(ENV, "EDM_TRACE_ELECTRONS", ""))
+    unique(clamp.([max(1, round(Int, N * f^2)) for f in (0.0, 0.25, 0.5, 0.75, 1.0)], 1, N))
+else
+    parse.(Int, split(ENV["EDM_TRACE_ELECTRONS"], ","))
+end
+all(1 .<= sel .<= N) || error("EDM_TRACE_ELECTRONS out of 1:$N")
+
+@info "pixel traces" MFILE RUN_TAG a₀ ω N sel RADII TRACE_TOTAL
+
+@named world = Worldline(:τ, :atomic)
+@named laser = LaguerreGaussLaser(;
+    wavelength = λ, a0 = a₀, beam_waist = w₀,
+    radial_index = Int(laser_p["p"]), azimuthal_index = Int(laser_p["m"]),
+    world, temporal_profile = Symbol(laser_p["profile"]), temporal_width = τ0,
+    focus_position = Float64(laser_p["focus_position"]), polarization = pol,
+    initial_phase = φ₀,
+)
+@named elec = ClassicalElectron(; laser)
+sys = mtkcompile(elec)
+
+prob = ODEProblem{false, SciMLBase.FullSpecialize}(
+    sys, [sys.x => [τi * c, 0.0, 0.0, 0.0], sys.u => [c, 0.0, 0.0, 0.0]], (τi, τf);
+    u0_constructor = SVector{8}, fully_determined = true
+)
+
+const ϕgold = (1 + √5) / 2
+function sunflower(n, α)
+    points = Vector{Vector{Float64}}()
+    b = round(Int, α * sqrt(n))
+    for k in 1:n
+        r = k > n - b ? 1.0 : sqrt(k - 0.5) / sqrt(n - (b + 1) / 2)
+        push!(points, [r * cos(k * 2π / ϕgold^2), r * sin(k * 2π / ϕgold^2)])
+    end
+    return points
+end
+
+R₀ = Rmax * sunflower(N, 2)
+xμ = [[τi * c, r..., 0.0] for r in R₀]
+r0 = [hypot(x[2], x[3]) for x in xμ]
+
+# Solve only what the traces need: the full ensemble when the coherent sum is on,
+# else just the selected electrons.
+solve_idx = TRACE_TOTAL ? collect(1:N) : sel
+set_x = setsym_oop(prob, [Initial(sys.x); Initial(sys.u)])
+function prob_func(prob, ctx)
+    i = solve_idx[ctx.sim_id]
+    u0, p = set_x(prob, SVector{8}(SVector{4}(xμ[i]...)..., SVector{4}(c, 0.0, 0.0, 0.0)...))
+    return remake(prob; u0, p)
+end
+saveat_kw = interp_saveat == "adaptive" ? (;) :
+    (; saveat = collect(τi:((2π / ω) / parse(Float64, interp_saveat)):τf))
+t_traj = @elapsed sol = solve(
+    EnsembleProblem(prob; prob_func, safetycopy = false), Vern9(), EnsembleThreads();
+    reltol, abstol, trajectories = length(solve_idx), saveat_kw...
+)
+@info "trajectories solved" t_traj length(solve_idx)
+
+trajs = trajectory_interpolants(sol)
+traj_of = Dict(zip(solve_idx, trajs))
+
+# ── Mini-screen: the requested pixels along +x (center first), production time window ──
+xs = [f * HALFW * w₀ for f in RADII]
+x⁰_samples = range(
+    start = c * τi + hypot(Z, HALFW * w₀ + Rmax), step = c * (2π / ω / spp),
+    length = N_samples,
+)
+screen = ObserverScreen(xs, [0.0], Z, x⁰_samples; c)   # Ny = 1: one y = 0 row of pixels
+
+# Retarded-time ODE tolerances (CPU reference path; the trajectories carry the production spline).
+ret_kw = (; reltol = 1.0e-10, abstol = 1.0e-12)
+
+E_sel = Array{Float64}(undef, length(sel), N_samples, 3, length(xs))
+for (ie, k) in enumerate(sel)
+    fld = accumulate_field([traj_of[k]], screen, Vern9(); mode = Val(:total), ret_kw...)
+    E_sel[ie, :, :, :] = fld.E[:, :, :, 1]
+end
+@info "per-electron traces done" length(sel)
+
+E_tot = nothing
+if TRACE_TOTAL
+    t_tot = @elapsed fld_all = accumulate_field(trajs, screen, Vern9(); mode = Val(:total), ret_kw...)
+    E_tot = fld_all.E[:, :, :, 1]
+    @info "full-N coherent sum done" t_tot N
+end
+
+# ── Plot: rows = pixels, cols = components; per-electron lines + total/N overlay.
+# Full-window figure (envelopes) + a ±EDM_TRACE_ZOOM_PERIODS zoom (carrier + relative phases —
+# the coherence content the traces exist for; invisible at the full window's scale). ──
+const ZOOM = parse(Float64, get(ENV, "EDM_TRACE_ZOOM_PERIODS", "3"))
+T_units = λ                     # x⁰ is a length (c·t): one laser period ⇔ one wavelength
+npix, ncomp = length(xs), 3
+colors = [Makie.cgrad(:viridis)[f] for f in range(0, 0.85, length = length(sel))]
+osc = get(cfg, "omega_scale", 1.0)
+
+function build_fig(xlim)
+    fig = Figure(size = (1560, 250 * npix + 110))
+    for (ip, xpix) in enumerate(xs)
+        R_pix = hypot(xpix, Z)
+        t_rel = (collect(x⁰_samples) .- R_pix) ./ T_units
+        for ic in 1:ncomp
+            ax = Axis(fig[ip, ic];
+                xlabel = ip == npix ? "(t − R_pix/c) / T_laser" : "",
+                ylabel = ic == 1 ? @sprintf("r = %.2f·halfw\nE (a.u.)", RADII[ip]) : "",
+                title = ip == 1 ? ("Ex", "Ey", "Ez")[ic] : "",
+                ytickformat = vs -> [@sprintf("%.1e", v) for v in vs])
+            for (ie, k) in enumerate(sel)
+                lines!(ax, t_rel, E_sel[ie, :, ic, ip]; color = colors[ie], linewidth = 1.0)
+            end
+            E_tot === nothing || lines!(ax, t_rel, E_tot[:, ic, ip] ./ N;
+                color = :black, linestyle = :dash, linewidth = 1.2)
+            xlim === nothing || xlims!(ax, -xlim, xlim)
+        end
+    end
+    leg_entries = [LineElement(; color = colors[ie]) for ie in eachindex(sel)]
+    leg_labels = [@sprintf("e#%d  (r₀ = %.2f Rmax)", k, r0[k] / Rmax) for k in sel]
+    if E_tot !== nothing
+        push!(leg_entries, LineElement(; color = :black, linestyle = :dash))
+        push!(leg_labels, "coherent sum / N")
+    end
+    Legend(fig[npix + 1, 1:ncomp], leg_entries, leg_labels; orientation = :horizontal, framevisible = false)
+    Label(fig[0, 1:ncomp],
+        @sprintf("Per-electron E(t) at screen pixels — %s  (a0=%g, ω-scale=%.4g, N=%d)%s",
+            RUN_TAG, a₀, osc, N, xlim === nothing ? "" : @sprintf("  [zoom ±%g T]", xlim));
+        fontsize = 18, font = :bold)
+    return fig
+end
+
+pngfile = joinpath(OUTDIR, "pixeltraces_$(RUN_TAG).png")
+save(pngfile, build_fig(nothing))
+println("saved → $pngfile")
+zoomfile = joinpath(OUTDIR, "pixeltraces_zoom_$(RUN_TAG).png")
+save(zoomfile, build_fig(ZOOM))
+println("saved → $zoomfile")
+
+# Derived sidecars (same schema as harmonic_products' derived_h*.toml) so the dashboard
+# stager/builder picks the traces up as chips of the parent run.
+repo_commit = try
+    readchomp(`git -C $(pkgdir(ElectronDynamicsModels)) rev-parse HEAD`)
+catch
+    "unknown"
+end
+idtag = first(RUN_TAG, 8)
+for (kind, label, png, extra) in (
+        ("pixeltraces", "per-electron E(t) traces",
+            basename(pngfile), "Full observation window (envelopes)."),
+        ("pixeltraces_zoom", "per-electron E(t) traces (zoom)",
+            basename(zoomfile), @sprintf("Zoom ±%g laser periods around the peak (carrier + relative phases).", ZOOM)),
+    )
+    sidecar = Dict(
+        "schema_version" => 1,
+        "derived" => Dict(
+            "depends_on" => [RUN_TAG],
+            "kind" => kind,
+            "label" => label,
+            "plot" => png,
+            "source" => basename(MFILE),
+            "description" => "Individual Liénard–Wiechert E(t) of $(length(sel)) electrons " *
+                "(r₀/Rmax ≈ $(join([@sprintf("%.2f", r0[k] / Rmax) for k in sel], ", "))) at pixels " *
+                "r/halfw = $(join(RADII, ", ")) along +x, with the full-N coherent sum scaled by 1/N. " * extra,
+        ),
+        "plot_params" => Dict(
+            "radii_frac" => RADII, "electrons" => sel,
+            "zoom_periods" => kind == "pixeltraces_zoom" ? ZOOM : 0.0,
+        ),
+        "provenance" => Dict(
+            "host" => readchomp(`hostname`), "repo_commit" => repo_commit,
+            "script" => "plot_pixel_traces.jl",
+            "timestamp" => string(Libc.strftime("%Y-%m-%dT%H:%M:%S", time())),
+        ),
+        "setup" => Dict("field" => "total"),
+    )
+    scfile = joinpath(OUTDIR, "derived_$(kind)_$(idtag).toml")
+    open(scfile, "w") do io
+        TOML.print(io, sidecar)
+    end
+    println("sidecar → $scfile")
+end
+
+jlsfile = joinpath(OUTDIR, "pixeltraces_$(RUN_TAG).jls")
+serialize(jlsfile, (; x⁰_samples = collect(x⁰_samples), xs, RADII, sel, r0_sel = r0[sel],
+    E_sel, E_tot, N, a₀, ω, λ, Z, HALFW, w₀, Rmax, run_id = RUN_TAG))
+println("serialized → $jlsfile")

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -6,6 +6,7 @@
 #
 # ENV knobs (defaults = full production): EDM_GPU_BACKEND (rocm|cuda), EDM_A0,
 # EDM_INITIAL_PHASE, EDM_NX, EDM_N, EDM_NSAMPLES, EDM_SPP, EDM_NSUBSTEPS,
+# EDM_OMEGA_SCALE (Doppler-equivalent ω upshift) + EDM_SCREEN_HALFW (screen half-extent, w₀ units),
 # EDM_GPU_SOLVER (rk4|newton) + EDM_NEWTON_ITERS,
 # EDM_POL (linear|circular[_plus]|circular_minus),
 # EDM_SYNC_PER_ELECTRON, EDM_OUTDIR. Writes the field .jls + per-harmonic PNGs +
@@ -73,14 +74,21 @@ FIELD_MODE in (:split, :total) || error("EDM_FIELD_MODE must be \"split\" or \"t
 const SKIP_POST = get(ENV, "EDM_SKIP_POSTPROCESS", "0") == "1"   # field-only: serialize cube + manifest, defer the (CPU/IO) reduction to an async step
 const RUN_TAG = get(ENV, "EDM_RUN_TAG", string(uuid4()))   # launcher may pin via EDM_RUN_TAG so .jls/log/manifest share one id
 mkpath(OUTDIR)
-@info "Thomson (field) run config" RUN_TAG GPU_BACKEND GPU_SOLVER ϕ₀ A0 SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS NEWTON_ITERS
+@info "Thomson (field) run config" RUN_TAG GPU_BACKEND GPU_SOLVER ϕ₀ A0 SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS NEWTON_ITERS OMEGA_SCALE HALFW
 const T_START = time()   # wall-clock start → [timing].total in the manifest
 
 # Laser parameters
-ω = 0.057
+# EDM_OMEGA_SCALE: Doppler-equivalent runs — upshift ω by γ(1+β) = γ+√(γ²−1), the frequency a
+# counter-propagating electron of that γ sees. The pulse keeps its cycle count (τ·ω = 150, phase
+# is boost-invariant) while the transverse/detector geometry stays pinned to the lab λ₀ = 2πc/0.057
+# layout (transverse lengths are boost-invariant). 1.0 ⇒ byte-identical to the production setup.
+const OMEGA_SCALE = parse(Float64, get(ENV, "EDM_OMEGA_SCALE", "1.0"))
+const ω₀_lab = 0.057
+ω = ω₀_lab * OMEGA_SCALE
 τ = 150 / ω
 λ = 2π * c / ω
-w₀ = 75λ
+const λ_lab = 2π * c / ω₀_lab
+w₀ = 75λ_lab
 Rmax = 3.25w₀
 
 a₀ = A0
@@ -184,11 +192,19 @@ t_trajectories = @elapsed solution = solve(
 trajs = trajectory_interpolants(solution)
 
 # Screen parameters
-const Z = 2.0e5λ
+# EDM_SCREEN_HALFW: screen half-extent in w₀ units (default 25 = production). Do NOT zoom
+# scaled-ω cells ∝ 1/OMEGA_SCALE: with the geometry pinned, the source Fraunhofer distance
+# a²/λ′ grows with the scale (≳Z beyond γ≈2), the screen enters the Fresnel zone, and the
+# pattern shrinks slower than 1/scale. Zoom only when the sampling window demands it — the
+# corner-anchored x⁰_start sits ~11λ_lab after the center-pixel arrival, so once that spread
+# (in scaled periods, ∝scale) exceeds the 8τ pulse half-span (γ≳10 at full frame) the window
+# would open after the peak passed the central pixels; ±8 w₀ suffices at γ=10 (gamma_equiv).
+const HALFW = parse(Float64, get(ENV, "EDM_SCREEN_HALFW", "25.0"))
+const Z = 2.0e5λ_lab
 const samples_per_period = SPP
 const δt = 2π / ω / samples_per_period
 const N_samples = NSAMPLES
-const x⁰_start = c * τi + hypot(Z, 25w₀ + Rmax)
+const x⁰_start = c * τi + hypot(Z, HALFW * w₀ + Rmax)
 
 Nx = NX
 Ny = NX
@@ -196,8 +212,8 @@ Ny = NX
 x⁰_samples = range(start = x⁰_start, step = c * δt, length = N_samples)
 
 screen = ObserverScreen(
-    LinRange(-25w₀, 25w₀, Nx),
-    LinRange(-25w₀, 25w₀, Ny),
+    LinRange(-HALFW * w₀, HALFW * w₀, Nx),
+    LinRange(-HALFW * w₀, HALFW * w₀, Ny),
     Z,
     x⁰_samples;
     c,
@@ -288,6 +304,8 @@ config = Dict{String, Any}(
     "mode" => string(FIELD_MODE),      # :split → (E,B,E_far,B_far) | :total → (E,B); mirrors lpwa.jl
     "sync_per_electron" => SYNC,       # replay input: run_spec_from_manifest reads this
     "observable" => "field",          # distinguishes this run from the 4-potential (_A) runs
+    "omega_scale" => OMEGA_SCALE,      # Doppler-equivalent ω upshift (1.0 = lab λ₀ production)
+    "screen_halfw" => HALFW,           # screen half-extent in w₀ units (25 = production framing)
 )
 
 outputs = Dict{String, Any}(


### PR DESCRIPTION
## What

- **`EDM_OMEGA_SCALE`** (thomson_scattering.jl, default-inert): runs standard Thomson at the wavelength a counter-propagating electron of a given γ sees — ω′ = (γ+√(γ²−1))·ω₀ — keeping the pulse cycle count (phase is boost-invariant) and pinning the transverse/detector geometry to the lab λ₀ layout (transverse lengths are boost-invariant; without pinning the run is exactly scale-invariant). Recorded in the manifest as `omega_scale`.
- **`EDM_SCREEN_HALFW`** (default 25 = production): screen half-extent knob. The in-code comment documents when a zoom is actually warranted: only when the corner-anchored `x⁰_start` would open the sampling window after the contracted pulse's peak (γ≳10 at full frame). The pattern itself does **not** shrink ∝1/scale — with geometry pinned, the source Fraunhofer distance a²/λ′ grows past Z and the screen enters the Fresnel zone (measured ×13.6 shrink at γ=10, not ×19.95).
- **`campaigns/gamma_equiv.sh`**: the γ = 2/5/10 ladder at a0 = 1e-2 + λ₀ base control (201²/N2000/Ns6000, ≈21 min/cell on the W7900). Published: runs `536b45f2` (g2), `d6065ad2` (g5), `689be285` (g10, ±8 w₀), `09c4945a` (base).
- **`plot_pixel_traces.jl`** (new): per-electron Liénard–Wiechert E(t) at the center pixel + pixels at chosen radii, reconstructed from any run manifest via the CPU reference `accumulate_field`, with the full-N coherent sum overlaid at 1/N. Emits `derived_pixeltraces[_zoom]` sidecars → dashboard chips. Knobs: `EDM_TRACE_RADII`, `EDM_TRACE_ELECTRONS`, `EDM_TRACE_TOTAL`, `EDM_TRACE_ZOOM_PERIODS`.
- **`harmonic_products.jl`**: phase-view test rings become screen-relative (4/25, 8/25, 12/25 of the half-extent) — legacy-identical on ±25 w₀ screens, and fixes the empty ∠F-vs-azimuth panels on zoomed screens (e.g. the `bunched_resolved` ±0.4 w₀ cells, republished).

## Validation

- `EDM_OMEGA_SCALE=1` reproduces the production laser/screen values exactly (all expressions reduce to the previous constants; the published `base` cell's manifest wavelength is digit-identical to the lowa0_maps corpus).
- γ=10 smoke + full cells: manifest wavelength = λ₀/(γ+√(γ²−1)) exactly, w₀/Rmax/Z pinned, envelope symmetric about t=0 on all pixels (window fix verified).
- Phase-ring fix re-rendered from hmaps caches for gamma_equiv + bunched_resolved/b35964ec: rings on-screen, azimuth winding fits populated.
- Per-electron traces reproduce expected physics: on-axis LG p=2/m=−2 null, |E| ∝ ω′ across the ladder, OAM cancellation of the coherent sum at the center pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)