### PR TITLE
Manifest [units]: display-unit declarations beside the raw solver values

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -25,6 +25,7 @@ export git_state, assert_committed, run_provenance, run_spec_from_manifest, expa
 export find_parent_manifest, find_parent_run, spp_from_manifest
 export write_derived, write_comparison, write_summary, write_run_manifest, write_solver_manifest, REQUIRED_CONFIG_KEYS
 export record_reduction!
+export units_section, units_from_manifest
 export MANIFEST_SCHEMA_VERSION, manifest_schema_version, check_schema_version
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -576,6 +577,93 @@ function write_solver_manifest(
     path = joinpath(dir, "run_$(run_id).toml")
     open(io -> TOML.print(io, m; sorted = true), path, "w")
     return path
+end
+
+# ───────────────────────── [units] — display-unit declarations ─────────────────────────
+# The manifest's raw numbers stay in the solver's NATIVE units; [units] is a declaration
+# layer beside them so consumers (chip renderers, the dashboard) can label axes without
+# run-type-specific knowledge (the `backscatter_n0` special case, "is ω₁ scaled?", …).
+# Additive optional section — no MANIFEST_SCHEMA_VERSION bump (stale readers ignore it).
+
+# Speed of light in Hartree atomic units — used only to SYNTHESIZE [units] for legacy
+# manifests (all of which are :atomic runs); new manifests carry their scales explicitly.
+const C_HARTREE = 137.03599908330932
+
+"""
+    units_section(ω, λ, w₀; system = "hartree_atomic", n0 = 1, omega_scale = 1.0,
+        transverse_length = "w0", extra_defs...) -> Dict
+
+Build the `[units]` manifest section: `defs` names scales (each a `value` in raw solver
+units + a `tex` display label); `preferred` picks which named scale each quantity kind is
+displayed in (`frequency`, `transverse_length`, and `wavelength_display = "si"` — the
+raw→SI anchor is fixed by `system`, e.g. hartree_atomic lengths are Bohr radii
+a₀ = 0.052917721 nm, so no numeric anchor is stored).
+
+Always defines `omega_laser`/`lambda_laser`/`w0` from this run's carrier. `n0 > 1`
+(backscatter runs) adds `omega_bs = n0·ω` and prefers it for frequencies — the [units]
+generalization of the legacy `backscatter_n0` key. `omega_scale ≠ 1` (Doppler-equivalent
+runs) adds the unscaled `omega_lab`/`lambda_lab` reference scales. Additional named scales
+append via keyword pairs: `moat = (value = …, tex = "r_F")`.
+
+Raw values in [config]/[laser]/[setup] are NEVER converted. Read back (with the legacy
+fallback) via [`units_from_manifest`](@ref).
+"""
+function units_section(ω::Real, λ::Real, w₀::Real; system = "hartree_atomic",
+        n0::Integer = 1, omega_scale::Real = 1.0, transverse_length = "w0", extra_defs...)
+    def(value, tex) = Dict{String, Any}("value" => Float64(value), "tex" => String(tex))
+    defs = Dict{String, Any}(
+        "omega_laser" => def(ω, "ω₁"),
+        "lambda_laser" => def(λ, "λ₁"),
+        "w0" => def(w₀, "w₀"),
+    )
+    frequency = "omega_laser"
+    if n0 > 1
+        defs["omega_bs"] = def(n0 * ω, "ω_bs")
+        frequency = "omega_bs"
+    end
+    if !isapprox(omega_scale, 1.0)
+        defs["omega_lab"] = def(ω / omega_scale, "ω₀")
+        defs["lambda_lab"] = def(λ * omega_scale, "λ₀")
+    end
+    for (k, v) in pairs(extra_defs)
+        defs[string(k)] = def(v.value, v.tex)
+    end
+    return Dict{String, Any}(
+        "system" => String(system),
+        "defs" => defs,
+        "preferred" => Dict{String, Any}(
+            "frequency" => frequency,
+            "transverse_length" => String(transverse_length),
+            "wavelength_display" => "si",
+        ),
+    )
+end
+
+"""
+    units_from_manifest(m::AbstractDict) -> (; system, defs, preferred, n0)
+
+Read a manifest's `[units]` section; for manifests that predate it, synthesize the same
+structure from what they do record (`[laser] wavelength/w0`, `[config] backscatter_n0/
+omega_scale`) so consumers have ONE code path. `n0` is the derived integer ratio
+preferred-frequency-scale / ω₁ (1 when frequencies are ω₁-preferred) — exactly the legacy
+`backscatter_n0` contract the powspec axis and harmonic-map labels consume.
+"""
+function units_from_manifest(m::AbstractDict)
+    u = get(m, "units", nothing)
+    if u === nothing
+        las = get(m, "laser", Dict{String, Any}())
+        cfg = get(m, "config", Dict{String, Any}())
+        λ = Float64(get(las, "wavelength", NaN))
+        u = units_section(
+            2π * C_HARTREE / λ, λ, Float64(get(las, "w0", NaN));
+            n0 = round(Int, get(cfg, "backscatter_n0", 1)),
+            omega_scale = Float64(get(cfg, "omega_scale", 1.0)),
+        )
+    end
+    defs, pref = u["defs"], u["preferred"]
+    fscale = get(defs, get(pref, "frequency", "omega_laser"), defs["omega_laser"])
+    n0 = round(Int, Float64(fscale["value"]) / Float64(defs["omega_laser"]["value"]))
+    return (; system = u["system"], defs, preferred = pref, n0)
 end
 
 end # module RunManifests

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -158,3 +158,52 @@ end
     # fewer than two sides is a hard error (a comparison needs something to compare).
     @test_throws ErrorException write_comparison(dir; label = "x", sides = [("a", "dirA")])
 end
+
+@testset "units_section ↔ units_from_manifest" begin
+    ω, λ, w₀ = 0.057, 2π * 137.03599908330932 / 0.057, 75 * 2π * 137.03599908330932 / 0.057
+
+    # plain rest-frame run: ω₁-preferred, roundtrips through TOML
+    u = units_section(ω, λ, w₀)
+    io = IOBuffer(); TOML.print(io, Dict("units" => u))
+    m = TOML.parse(String(take!(io)))
+    r = units_from_manifest(m)
+    @test r.n0 == 1
+    @test r.preferred["frequency"] == "omega_laser"
+    @test r.defs["lambda_laser"]["value"] ≈ λ
+    @test r.system == "hartree_atomic"
+
+    # backscatter run: ω_bs = n0·ω₁ preferred
+    ub = units_section(ω, λ, w₀; n0 = 398)
+    @test ub["preferred"]["frequency"] == "omega_bs"
+    @test ub["defs"]["omega_bs"]["value"] ≈ 398ω
+    @test units_from_manifest(Dict{String, Any}("units" => ub)).n0 == 398
+
+    # Doppler-equivalent run: scaled carrier + unscaled lab reference
+    s = 19.949874371066196
+    us = units_section(s * ω, λ / s, w₀; omega_scale = s)
+    @test us["defs"]["omega_lab"]["value"] ≈ ω
+    @test us["defs"]["lambda_lab"]["value"] ≈ λ
+    @test units_from_manifest(Dict{String, Any}("units" => us)).n0 == 1
+
+    # extra named scales pass through
+    ue = units_section(ω, λ, w₀; moat = (value = 22.4 * λ, tex = "r_F"))
+    @test ue["defs"]["moat"]["tex"] == "r_F"
+
+    # LEGACY manifests (no [units]): synthesized from laser/config — the backscatter_n0
+    # and omega_scale contracts consumers already rely on.
+    legacy = Dict{String, Any}(
+        "laser" => Dict{String, Any}("wavelength" => λ, "w0" => w₀),
+        "config" => Dict{String, Any}("backscatter_n0" => 398),
+    )
+    rl = units_from_manifest(legacy)
+    @test rl.n0 == 398
+    @test rl.defs["omega_laser"]["value"] ≈ ω
+    @test rl.preferred["frequency"] == "omega_bs"
+    legacy2 = Dict{String, Any}(
+        "laser" => Dict{String, Any}("wavelength" => λ / s, "w0" => w₀),
+        "config" => Dict{String, Any}("omega_scale" => s),
+    )
+    rl2 = units_from_manifest(legacy2)
+    @test rl2.n0 == 1
+    @test rl2.defs["omega_lab"]["value"] ≈ ω
+end

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -277,7 +277,10 @@ function write_harmonic_products(
     # machine without the multi-GB cube — the 2026-07-19 ω_bs restyle needed a full workstation
     # cube pass for 24 runs solely because this array used to be discarded after plotting.
     serialize(joinpath(outdir, "powspec_$(run_tag).jls"),
-        (; freqs = collect(freqs), ps, n0, harmonics = collect(harmonics), window = "none"))
+        (; freqs = collect(freqs), ps, n0, harmonics = collect(harmonics), window = "none",
+            # [units]-style name of the axis scale n0 encodes (future data-driven renderers
+            # relabel from this instead of guessing from n0):
+            freq_unit = n0 > 1 ? "omega_bs" : "omega_laser"))
     get(ENV, "EDM_REDUCTION_MARKER", "0") == "1" &&
         record_reduction!(outdir, run_tag, "powspec_$(run_tag).jls")
     if reduce_only
@@ -410,9 +413,10 @@ function recover_from_manifest(toml)
     # Envelope view geometry (inverse runs only): the blur grain needs the screen distance +
     # disk radius; both live in [setup]. `nothing` ⇒ no envelope chips (rest-electron runs).
     st = get(m, "setup", Dict())
-    # On-axis backscattered fundamental ω_bs = n0·ω₁ (≈4γ²): frequency unit for boosted runs'
-    # powspec axis + harmonic-map labels, and the envelope blur-grain wavelength.
-    n0 = round(Int, get(cfg, "backscatter_n0", 1))
+    # Preferred frequency scale from [units] (legacy manifests: synthesized from
+    # [config].backscatter_n0 by units_from_manifest). n0 = preferred-scale/ω₁ — the ω_bs
+    # unit for boosted runs' powspec axis + harmonic-map labels and the envelope blur grain.
+    n0 = units_from_manifest(m).n0
     envgeo = (inverse && haskey(st, "Z") && haskey(st, "Rmax")) ?
         (; Z = st["Z"], Rmax = st["Rmax"], λ = las["wavelength"], n0) : nothing
     envelope!(fields_h, harmonics, x_grid, y_grid, w₀) = envgeo === nothing ? nothing :

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -591,7 +591,12 @@ sharding = Dict{String, Any}("electrons" => ndev)
 # GPU telemetry → [gpu] (static device snapshot + power/util/VRAM stats over the field window).
 # `nothing` (no vendor extension / telemetry error) ⇒ the section is simply omitted.
 gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_telem)
-extra = Dict{String, Any}("timing" => timing, "sharding" => sharding)
+extra = Dict{String, Any}(
+    "timing" => timing, "sharding" => sharding,
+    # [units]: n0 = N0 declares ω_bs = N0·ω₁ as the preferred frequency scale — the
+    # declaration-layer generalization of [config].backscatter_n0 (kept for legacy readers).
+    "units" => units_section(ω, λ, w₀; n0 = N0),
+)
 gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(
     OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs, extra,

--- a/scripts/lpwa.jl
+++ b/scripts/lpwa.jl
@@ -320,7 +320,10 @@ sharding = Dict{String, Any}("electrons" => ndev)
 # GPU telemetry → [gpu] (static device snapshot + power/util/VRAM stats over the field window).
 # `nothing` (no vendor extension / telemetry error) ⇒ the section is simply omitted.
 gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_telem)
-extra = Dict{String, Any}("model" => model_params, "timing" => timing, "sharding" => sharding)
+extra = Dict{String, Any}(
+    "model" => model_params, "timing" => timing, "sharding" => sharding,
+    "units" => units_section(ω, λ, w₀),   # display-unit declarations (RunManifests.units_section)
+)
 gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(
     OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs, extra,

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -349,7 +349,12 @@ sharding = Dict{String, Any}("electrons" => ndev)
 # GPU telemetry → [gpu] (static device snapshot + power/util/VRAM stats over the field window).
 # `nothing` (no vendor extension / telemetry error) ⇒ the section is simply omitted.
 gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_telem)
-extra = Dict{String, Any}("timing" => timing, "sharding" => sharding)
+extra = Dict{String, Any}(
+    "timing" => timing, "sharding" => sharding,
+    # [units]: display-unit declarations beside the raw atomic-unit values (ω₁/λ₁/w₀ scales;
+    # omega_scale ≠ 1 adds the unscaled ω₀/λ₀ lab reference) — see RunManifests.units_section.
+    "units" => units_section(ω, λ, w₀; omega_scale = OMEGA_SCALE),
+)
 gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(
     OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs, extra,

--- a/scripts/thomson_scattering_A.jl
+++ b/scripts/thomson_scattering_A.jl
@@ -285,6 +285,9 @@ setup = Dict{String, Any}(
 )   # input knobs (Nx/Ny/N/N_samples/spp) live in [config]; setup is just the integration window + screen depth
 
 manifestfile = write_solver_manifest(
-    OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs
+    OUTDIR; run_id = RUN_TAG, provenance, config, laser = laser_params, setup, outputs,
+    extra = Dict{String, Any}(
+        "units" => units_section(ω, λ, w₀),   # display-unit declarations (RunManifests.units_section)
+    ),
 )
 println("manifest → $manifestfile")


### PR DESCRIPTION
## What

Adds an additive, optional `[units]` section to run manifests so consumers (chip renderers, the dashboard) can label axes and quantities without run-type-specific knowledge — generalizing the `backscatter_n0` special case and the `omega_scale` ambiguity ("is ω₁ the scaled carrier?").

```toml
[units]
system = "hartree_atomic"          # what the RAW values mean (never converted)
[units.defs.omega_laser]           # named scales: value in raw units + display label
value = 0.057
tex = "ω₁"
# … lambda_laser, w0; + omega_bs (n0>1 runs), omega_lab/lambda_lab (omega_scale≠1 runs)
[units.preferred]                  # which named scale each quantity kind displays in
frequency = "omega_bs"
transverse_length = "w0"
wavelength_display = "si"          # hartree_atomic ⇒ Bohr-radius lengths ⇒ nm needs no stored anchor
```

- **`RunManifests.units_section`** — the single schema owner, used by all four solver scripts (`thomson_scattering`, `thomson_scattering_A`, `inverse_thomson_scattering`, `lpwa`). Extra named scales attach via keywords.
- **`RunManifests.units_from_manifest`** — reader with **legacy synthesis**: pre-`[units]` manifests get the identical structure derived from `[laser] wavelength/w0` + `[config] backscatter_n0/omega_scale`, so consumers have exactly one code path. Returns the derived `n0` (preferred-frequency scale / ω₁).
- **`harmonic_products.jl`** consumes `n0` through `units_from_manifest` (drops the bespoke `backscatter_n0` lookup); the powspec cache `.jls` now records `freq_unit` — the stepping stone for data-driven (unit-toggleable) spectrum rendering.
- No `MANIFEST_SCHEMA_VERSION` bump: the section is optional and stale readers ignore it. `backscatter_n0`/`omega_scale` keep being written for older readers.

## Validation

- 16 new tests in `lib/RunManifests/test` (TOML roundtrip, backscatter/omega-scale/extra-defs shapes, legacy synthesis for both `backscatter_n0` and `omega_scale` manifests) — full suite green.
- Fresh GPU smoke: manifest carries `[units]` with the production ω₁/λ₁/w₀ values.
- Legacy fallback exercised on a real pre-`[units]` manifest with `omega_scale = 19.95` (gamma_equiv g10): recolor re-render end-to-end clean, labels unchanged.

## Follow-up (dashboard repo)

Surface `[units]` in `index.json` run entries: λ displayed in nm on run cards, harmonic labels rendered from the declared scales, and eventually a client-side ω₁/ω_bs/eV axis toggle once the powspec ships as data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)