### PR TITLE
TrajectoryInterpolant: RHS-evaluated acceleration knots

### DIFF
--- a/src/radiation.jl
+++ b/src/radiation.jl
@@ -18,20 +18,22 @@ function TrajectoryInterpolant(sol::SciMLBase.AbstractODESolution, x_syms, u_sym
     x_idxs = SVector{4, Int}(variable_index.((sol,), collect(x_syms)))
     u_idxs = SVector{4, Int}(variable_index.((sol,), collect(u_syms)))
     itp = CubicSpline(sol.u, sol.t; extrapolation = ExtrapolationType.Extension)
-    # 4-acceleration 𝔞μ = duμ/dτ, sampled from the solver's OWN derivative
-    # interpolant at the knots (`sol(t, Val{1})`). Vern9's continuous extension is
-    # built to match the RHS D(u) = F_total/m, so these knot values are
-    # model-consistent — more accurate than differentiating `itp` afterwards,
-    # which would amplify the cubic spline's interpolation error. Storing them in
-    # a dedicated spline keeps evaluation a cheap, thread-safe lookup.
-    # ONLY valid for dense solutions: with `saveat` the solution interpolation is the
-    # stored-value LINEAR fallback, and `Val{1}` returns left-segment slopes ≈ a(t − h/2) —
-    # a half-knot delay that stamped a −n·π/16 global phase on every saveat-era harmonic
-    # map (root-caused 2026-07-24). On non-dense solutions differentiate the cubic spline
-    # instead: zero phase bias, mirroring lpwa.jl's a_itp construction.
-    a_knots = sol.dense ?
-        [SVector{4}(sol(t, Val{1})[u_idxs]) for t in sol.t] :
-        [SVector{4}(DataInterpolations.derivative(itp, t)[u_idxs]) for t in sol.t]
+    # 4-acceleration 𝔞μ = duμ/dτ: evaluate the model's OWN RHS at the saved states, so
+    # every knot is exact to the solver's state accuracy — for dense AND saveat solutions
+    # alike. Sampling AT the knot is phase-bias-free by construction (unlike the linear-
+    # fallback `Val{1}` slopes, whose half-knot delay stamped a −n·π/16 global phase on
+    # the saveat-era harmonic maps, root-caused 2026-07-24). This supersedes both earlier
+    # sources: `sol(t, Val{1})` (dense-only) and the cubic-spline derivative — the latter
+    # is one order below the state spline (O(h³) vs O(h⁴)) and its error was implicated
+    # in the small-a0 2ω floor's phase-locked aᶻ component. A spline through exact RHS
+    # samples restores O(h⁴), matching the state interpolant, and keeps evaluation a
+    # cheap, thread-safe lookup (the GPU path ships these coefficients unchanged).
+    f, p = sol.prob.f, sol.prob.p
+    a_knots = if SciMLBase.isinplace(sol.prob)
+        [SVector{4}((du = similar(u); f(du, u, p, t); du)[u_idxs]) for (u, t) in zip(sol.u, sol.t)]
+    else
+        [SVector{4}(f(u, p, t)[u_idxs]) for (u, t) in zip(sol.u, sol.t)]
+    end
     a_itp = CubicSpline(a_knots, sol.t; extrapolation = ExtrapolationType.Extension)
     sys = sol.prob.f.sys
     _world = _find_world(sys)


### PR DESCRIPTION
## What

`TrajectoryInterpolant(sol, …)` now builds the 4-acceleration knots by evaluating the model's own RHS (`sol.prob.f`) at the saved states — one code path for dense and `saveat` solutions — instead of differentiating an interpolant:

- **Exact knots**: acceleration at every knot is model-exact to the solver's state accuracy (~1e-12), replacing the cubic-spline derivative whose O(h³) error (one order below the state spline) was implicated in the small-a0 2ω floor's phase-locked aᶻ component.
- **Phase-clean by construction**: values are sampled *at* the knots — no half-knot delay of the kind that stamped the −n·π/16 harmonic-map phase (root-caused 2026-07-24). The existing regression test (`test/interp_saveat_acceleration.jl`) pins this.
- **Zero GPU changes**: the kernels ingest the a-spline's coefficients (`to_gpu` → `GPUCubicSpline(traj.a_itp)`), so the improvement flows through untouched.
- Handles both out-of-place (production `SVector{8}`) and in-place problems.

## Measured

Vern9, reltol 1e-12, production `saveat` 16 knots/period, against a dense-Vern9 + exact-RHS reference (a0 ∈ {0.01, 0.1}; r ∈ {0.5, 1, 2} w₀):

| metric | old (spline derivative) | new (RHS knots) | gain |
|--------|------------------------|-----------------|------|
| rms a(τ) error | 1.4e-8 … 2.6e-5 | 3.5e-9 … 6.3e-6 | **4×** |
| max a(τ) error | 7.9e-8 … 1.0e-4 | 2.5e-8 … 3.3e-5 | **~3×** |

The residual is now the a-spline's own between-knot O(h⁴) interpolation error; the next step past it would be query-time RHS evaluation, which on the GPU means compiling the field evaluation into the kernels — deliberately out of scope.

## Validation

- Full test suite green (Radiation Emission 233, GPU Radiation Accumulation 40, Lorenz Gauge, saveat-acceleration regression). One unrelated randomized-test flake appeared in a single run and did not reproduce.
- lpwa.jl's analytic-trajectory `a_itp` (dense 10k knots) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)