### PR TITLE
backends: optional soft-key pins for headless cloud drivers

### DIFF
--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -38,7 +38,9 @@ DEPOT_CACHE="${DEPOT_CACHE:-}"; DEPOT_CACHE_KEY="${DEPOT_CACHE_KEY:-$HOME/.confi
 # share a master socket: ssh multiplexes on ControlPath alone, so a fixed path sends the second
 # VM's commands to the first VM (its warm's `rm -rf EDM` then kills that VM's running campaign).
 CM="$HOME/.ssh/cm-hotaisle-%C.sock"
-SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600"
+# HOTAISLE_SSH_KEY (optional): private key pinned with -i/IdentitiesOnly for headless drivers
+# (no ssh agent) — its pubkey must be on the Hot Aisle ACCOUNT before the VM is provisioned.
+SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600${HOTAISLE_SSH_KEY:+ -i $HOTAISLE_SSH_KEY -o IdentitiesOnly=yes}"
 
 api()       { curl -fsS -X "$1" -H "Authorization: Token $TOK" "${@:3}" "$API$2"; }
 ssh_vm()    { /usr/bin/ssh $SSHOPTS hotaisle@"$IP" "$@"; }

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -23,7 +23,9 @@
 # config.env: RUNPOD_DC, RUNPOD_ROCM_IMAGE/RUNPOD_CUDA_IMAGE, RUNPOD_VOLUME_NAME/GB,
 # RUNPOD_REPO_URL/BRANCH, RUNPOD_DEPOT_CACHE/RUNPOD_DEPOT_KEY. Secrets external: API token at
 # ~/.config/runpod/token; ntfy via NTFY_ENV. The pod authorizes $RUNPOD_SSH_PUBKEY (a key you can
-# auth as — e.g. your YubiKey pubkey; ControlMaster ⇒ one touch/run).
+# auth as, e.g. served by your ssh agent; ControlMaster ⇒ one auth/run). RUNPOD_SSH_KEY (optional)
+# pins the matching PRIVATE key via -i/IdentitiesOnly — required for headless drivers (no ssh
+# agent): key files outside the default names are never offered unless pinned.
 set -Eeuo pipefail
 ORCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."; ORCH="$(cd "$ORCH" && pwd)"
 # Caller-env overrides must survive config.env (sourced via run_cell.sh below, where a plain
@@ -54,7 +56,7 @@ STATE="${RUNPOD_STATE:-$HOME/.config/runpod/campaign_pod}"; OUT="${RUNPOD_OUT:-$
 POLL="${RUNPOD_POLL_SEC:-120}"; MAXTRIES="${RUNPOD_MAX_TRIES:-240}"
 PUBKEY="$(cat "${RUNPOD_SSH_PUBKEY:-$HOME/.config/runpod/ssh_pubkey}" 2>/dev/null || ssh-add -L 2>/dev/null | head -1)"
 CM="$HOME/.ssh/cm-runpod-$(basename "$STATE").sock"   # per-STATE: concurrent drivers must not remux onto one socket
-SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600"
+SSHOPTS="-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=$CM -o ControlPersist=600${RUNPOD_SSH_KEY:+ -i $RUNPOD_SSH_KEY -o IdentitiesOnly=yes}"
 
 rp()      { curl -fsS -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" "$@"; }
 ssh_vm()  { /usr/bin/ssh $SSHOPTS -p "$PORT" root@"$IP" "$@"; }

--- a/orchestration/config.env.example
+++ b/orchestration/config.env.example
@@ -30,12 +30,16 @@ HOTAISLE_GPUS=1                    # 1 ⇒ per-minute billing (1-min minimum); 2
 HOTAISLE_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git   # PUBLIC clone URL
 HOTAISLE_BRANCH=main
 # token lives at ~/.config/hotaisle/token  (NOT here)
+# HOTAISLE_SSH_KEY=                  # optional PRIVATE key pinned with -i/IdentitiesOnly for headless
+#                                    # drivers (no ssh agent); pubkey must be on the Hot Aisle account
 
 # ── RunPod backend (cloud MI300X / CUDA) ─────────────────────────────────────
 RUNPOD_DC=EU-RO-1                   # datacenter (only RO DC; supports network volumes; MI300X lands here)
 RUNPOD_REPO_URL=https://github.com/SebastianM-C/ElectronDynamicsModels.jl.git   # PUBLIC clone URL
 RUNPOD_BRANCH=main
-RUNPOD_SSH_PUBKEY="${HOME}/.config/runpod/ssh_pubkey"
+RUNPOD_SSH_PUBKEY="${HOME}/.config/runpod/ssh_pubkey"   # pubkey the pod authorizes (agent-served posture)
+# RUNPOD_SSH_KEY=                    # optional PRIVATE key pinned with -i/IdentitiesOnly — set both to a
+#                                    # dedicated soft keypair for headless drivers (no ssh agent)
 # RUNPOD_ROCM_IMAGE / RUNPOD_CUDA_IMAGE override the pinned defaults; token lives at ~/.config/runpod/token
 # Network volume — OPT-IN, for cube persistence past the pod (S3 drain). NOT for the depot (FUSE
 # is pathological for many tiny files). Volumes GROW-not-shrink and bill (~$0.07/GB-mo) even idle.


### PR DESCRIPTION
Both cloud backends' `SSHOPTS` relied on the ambient ssh agent for pod/VM SSH — a headless driver could inject a pubkey but never authenticate as it, since suffixed key files are never offered by default.

This adds two optional, empty-safe knobs (unset ⇒ byte-identical to the current agent posture):

- `RUNPOD_SSH_KEY` (`runpod.sh`) — appends `-i $RUNPOD_SSH_KEY -o IdentitiesOnly=yes` to `SSHOPTS`; pairs with `RUNPOD_SSH_PUBKEY` pointing at the matching `.pub` (injected per-pod, no account-side registration).
- `HOTAISLE_SSH_KEY` (`hotaisle.sh`) — same mechanics; the pubkey must be registered on the Hot Aisle **account** before the VM is provisioned (keys land on VMs at provision time).

`IdentitiesOnly=yes` makes the pinned key the only one offered, so a set knob also opts out of agent fallback — deliberate, to keep unattended behavior deterministic. `config.env.example` documents both. Every `rsync -e "ssh $SSHOPTS"` (depot warm, product download) inherits the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)