### PR TITLE
Fix Bz parity of the reversed LaguerreGauss beam + γ=1 crosscheck harness

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -355,11 +355,11 @@ The first call writes the header (`run_id`/`reduced_at`/`host`/`reduce_commit` +
 `reduction` array); later calls append. The orchestration renames `.partial` →
 `<run_id>.reduced` atomically once every reducer for the cell succeeds, so the marker's PRESENCE
 is the drainer's "reduce complete" handshake and its CONTENTS enumerate the caches that must land
-durably on the storagebox for the run to be re-renderable WITHOUT the cube (publish-autonomy).
+durably on the archive store for the run to be re-renderable WITHOUT the cube (publish-autonomy).
 
 Invariant: every product a drain-path reducer emits must be re-renderable from a cache recorded
 here. A plot rendered directly from the cube with NO cache is invisible to this marker and breaks
-publish-autonomy — add a cache instead of relying on the cube (which is only on the workstation).
+publish-autonomy — add a cache instead of relying on the cube (which only exists where it was produced/archived).
 Today's drain-path reducers (harmonic_products, plot_screen_observables) cache every product.
 """
 function record_reduction!(dir::AbstractString, run_id, file::AbstractString)

--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -77,6 +77,18 @@ function _script_repo_commit()
     end
 end
 
+# Dirty-tree marker for the same repo — write_run_manifest/write_derived record it so
+# standalone analysis nodes carry the SAME honesty flag as solver runs (a verifier node
+# produced from an uncommitted tree used to look clean while the solver runs beside it
+# were repo_dirty = true; spotted 2026-07-30 during the γ=1 crosscheck).
+function _script_repo_dirty()
+    return try
+        !isempty(readchomp(Cmd(["git", "-C", @__DIR__, "status", "--porcelain"])))
+    catch
+        false
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Git provenance + clean-tree guard (shared by thomson_scattering.jl / _A / lpwa.jl,
 # which each previously carried their own copy). The model/laser parameter dict stays
@@ -331,9 +343,10 @@ function write_derived(
     description === nothing || (d["description"] = description)
     m = Dict{String, Any}(
         "schema_version" => MANIFEST_SCHEMA_VERSION,
-        "provenance" => Dict(
+        "provenance" => Dict{String, Any}(
             "script" => basename(PROGRAM_FILE), "repo_commit" => _script_repo_commit(),
-            "host" => gethostname(), "timestamp" => string(now())
+            "host" => gethostname(), "timestamp" => string(now()),
+            (_script_repo_dirty() ? ("repo_dirty" => true,) : ())...,
         ),
         "derived" => d,
     )
@@ -514,6 +527,7 @@ function write_run_manifest(
         "run_id" => run_id, "script" => script, "repo_commit" => _script_repo_commit(),
         "host" => gethostname(), "timestamp" => string(now())
     )
+    _script_repo_dirty() && (prov["repo_dirty"] = true)
     derived_from === nothing || (prov["derived_from"] = derived_from)
     outs = Dict{String, Any}("plots" => collect(plots))
     datafile === nothing || (outs["datafile"] = datafile)

--- a/orchestration/backends/local.sh
+++ b/orchestration/backends/local.sh
@@ -12,6 +12,12 @@ CAMPAIGN_FILE="${1:?usage: local.sh <campaign.sh>}"
 . "$CAMPAIGN_FILE"                                      # sets CAMPAIGN, SCRIPT, BASE, CELLS
 
 BACKEND="${LOCAL_BACKEND:-cuda}"
+# Local runs keep their cubes by default: the cube enables post-hoc analysis (new harmonic
+# bins, forensics) without a GPU rerun, and the only cost is local disk — archive big ones
+# to a bulk store outside runs/ (a PUBLISH_HOOK, if configured, should cap oversized
+# uploads). Campaigns and the environment can still override (KEEP_CUBE=0); the cloud
+# backends keep their drain-gated retention flow.
+KEEP_CUBE="${KEEP_CUBE:-1}"
 JL=(julia +"${JULIA_CHANNEL:-release}" --startup=no -t "${LOCAL_JL_THREADS:-auto}")
 PREENV=(); [ -n "${LOCAL_PREENV:-}" ] && read -r -a PREENV <<< "$LOCAL_PREENV"
 CAMP="$REPO/runs/$CAMPAIGN"

--- a/orchestration/campaigns/gamma1_crosscheck_direct.sh
+++ b/orchestration/campaigns/gamma1_crosscheck_direct.sh
@@ -1,0 +1,26 @@
+# campaigns/gamma1_crosscheck_direct.sh — γ=1 direct/inverse consistency check, DIRECT arm.
+# Companion of gamma1_crosscheck_inverse.sh (same CAMPAIGN ⇒ one runs/ dir; launch both).
+# The check: at γ=1 the inverse script's electron is at rest and only its laser direction
+# differs (−z vs +z), so direct(laser +z, screen +Z) must reproduce inverse(laser −z,
+# screen −Z) up to a definite transverse mirror (helicity/m are NOT parity-mapped by the
+# reversed laser — the residual transform is what compare_mirror_runs.jl detects), and
+# inverse(+Z vs −Z) shows the physical forward/backward asymmetry as the control.
+# Geometry mirrors bunched_resolved base_a03 (a0=0.3, ±0.4 w₀ screen) at REST-FRAME
+# sampling: SPP 16 (no upshift at γ=1; the bunched 2048 was for the 4γ² line), Ns 6000
+# (375-period window ⊇ the 143λ signal), 201² (consistency metric, not coherence res).
+# Windows align EXACTLY across the arms: both scripts reduce to
+# x⁰_start = c·τi + hypot(Z, 0.4w₀ + Rmax) at these knobs — no phase offset in the diff.
+CAMPAIGN=gamma1_crosscheck
+SCRIPT=scripts/thomson_scattering.jl
+KEEP_CUBE=1                      # keep cubes: a mismatch needs forensics, not a rerun
+BASE=(
+  EDM_NX=201 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12 EDM_ABSTOL=1.7e-9
+  EDM_A0=0.3
+  EDM_INTERP_SAVEAT=16
+  EDM_INITIAL_PHASE=-1.5707963267948966
+  EDM_SCREEN_HALFW=0.4
+)
+CELLS=(
+  "direct|"
+)

--- a/orchestration/campaigns/gamma1_crosscheck_inverse.sh
+++ b/orchestration/campaigns/gamma1_crosscheck_inverse.sh
@@ -1,0 +1,23 @@
+# campaigns/gamma1_crosscheck_inverse.sh — γ=1 direct/inverse consistency check, INVERSE arm.
+# Companion of gamma1_crosscheck_direct.sh (same CAMPAIGN ⇒ one runs/ dir) — see its header
+# for the full rationale. γ=1 ⇒ electron at rest (β=0), laser reversed to −z:
+#   inv_mz (screen −Z, transmission side) ↔ the direct run's +Z screen;
+#   inv_pz (screen +Z, backscatter side)  — the forward/backward asymmetry control.
+# EDM_TSPAN_TAU=8 restores thomson tspan parity (the bunched 1.6 fit only the γ=10
+# compressed burst); EDM_WINDOW=full is the thomson-equivalent window and lands on the
+# identical x⁰_start at these knobs. Tolerances matched to the direct arm explicitly.
+CAMPAIGN=gamma1_crosscheck
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_NX=201 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12 EDM_ABSTOL=1.7e-9
+  EDM_A0=0.3
+  EDM_INTERP_SAVEAT=16
+  EDM_INITIAL_PHASE=-1.5707963267948966
+  EDM_GAMMA=1 EDM_TSPAN_TAU=8 EDM_WINDOW=full EDM_SCREEN_HW=0.4
+)
+CELLS=(
+  "inv_mz|EDM_SCREEN_ZSIGN=-1"
+  "inv_pz|EDM_SCREEN_ZSIGN=1"
+)

--- a/orchestration/cube_drain.sh
+++ b/orchestration/cube_drain.sh
@@ -2,14 +2,14 @@
 # cube_drain.sh — run ON a cloud VM: continuously push reduced field cubes to the rsync-jailed
 # store, overlapping uploads with the campaign's GPU compute (needs KEEP_CUBE=1 so cubes survive
 # their reduce). Local copies are KEPT (cheap on the VM's NVMe) so a bad upload is never fatal;
-# the store is a staging buffer the workstation later drains at its leisure (no VM billing).
+# the store is a staging buffer the archive host later drains at its leisure (no VM billing).
 #
 # A cube is eligible once its <uuid>.reduced marker exists — the reduce read the whole cube, so
 # it is complete and consistent on disk. Verify = a second checksum dry-run pass transfers
 # nothing; only then is the .drained sentinel written. Failures just retry next sweep.
 #
 # Env: DRAIN_STORE (user@host of the jailed store), DRAIN_KEY (default ~/.ssh/depot_key),
-#      DRAIN_PORT (default 22; Hetzner storage-box DIRECT access = port 23 + sub-account —
+#      DRAIN_PORT (default 22; some providers offer DIRECT storage access on another port + sub-account —
 #      each machine then gets its own stream instead of sharing the VPS sshfs write pipe).
 set -u
 STORE="${DRAIN_STORE:?set DRAIN_STORE (user@host of the jailed store)}"

--- a/orchestration/drain.sh
+++ b/orchestration/drain.sh
@@ -2,7 +2,7 @@
 # DRAIN — pull a campaign's reduced products (and optionally the big field cubes) from a RunPod
 # network VOLUME to THIS machine over the S3 API. Data-plane only: needs the [runpod] S3 profile in
 # ~/.aws + awscli — NOT the RunPod API token, a pod, or SSH — so it runs from ANY configured box
-# (poincare / workstation / VPS). The volume persists after teardown, so drain any time, repeatedly.
+# (any driving or archive machine). The volume persists after teardown, so drain any time, repeatedly.
 #
 #   bash orchestration/drain.sh <campaign> [dest] [--cubes]
 #     --cubes   also download field_*.jls cubes (present only if the run used KEEP_CUBE=1)

--- a/scripts/analyze_trajectories.jl
+++ b/scripts/analyze_trajectories.jl
@@ -31,8 +31,7 @@
 #
 # ENV knobs (all optional):
 #   EDM_ANALYSIS         "trajectories" (default) or "spline-error"
-#   EDM_SOURCE_CAMPAIGN  dir of run_*.toml to take parameters from
-#                        (default /storage/pool/smc/thomson_runs/field_campaign_cm_phi0)
+#   EDM_SOURCE_CAMPAIGN  dir of run_*.toml to take parameters from (required)
 #   EDM_SOURCE_RUN       substring of the manifest filename to select specific run(s); "" = all.
 #                        Useful for spline-error on campaigns like floor_probe whose manifests
 #                        differ only in [config].interp_saveat (ignored on reconstruction).
@@ -94,7 +93,7 @@ const c = 137.03599908330932
 # ── Configuration (ENV-overridable) ──
 const ANALYSIS = get(ENV, "EDM_ANALYSIS", "trajectories")      # "trajectories" | "spline-error"
 ANALYSIS in ("trajectories", "spline-error") || error("EDM_ANALYSIS must be \"trajectories\" or \"spline-error\", got \"$ANALYSIS\"")
-const SOURCE_CAMPAIGN = get(ENV, "EDM_SOURCE_CAMPAIGN", "/storage/pool/smc/thomson_runs/field_campaign_cm_phi0")
+const SOURCE_CAMPAIGN = get(ENV, "EDM_SOURCE_CAMPAIGN", "")   # campaign dir of run_*.toml (required)
 const SOURCE_RUN = get(ENV, "EDM_SOURCE_RUN", "")              # manifest-filename substring filter; "" = all
 const PHASE_SPEC = get(ENV, "EDM_INITIAL_PHASE", "manifest")   # "manifest" ⇒ each run's own φ₀; or a numeric override
 const COORDS = get(ENV, "EDM_COORDS", "absolute")                  # "absolute" | "displacement"
@@ -878,6 +877,7 @@ function analyze_spline_error(mfile)
 end
 
 # ── Drive over the source campaign ──
+isempty(SOURCE_CAMPAIGN) && error("set EDM_SOURCE_CAMPAIGN to the campaign dir holding the run_*.toml manifests")
 isdir(SOURCE_CAMPAIGN) || error("EDM_SOURCE_CAMPAIGN is not a directory: $SOURCE_CAMPAIGN")
 manifests = sort([joinpath(SOURCE_CAMPAIGN, f) for f in readdir(SOURCE_CAMPAIGN)
                   if startswith(f, "run_") && endswith(f, ".toml") && contains(f, SOURCE_RUN)])

--- a/scripts/compare_mirror_runs.jl
+++ b/scripts/compare_mirror_runs.jl
@@ -1,0 +1,150 @@
+# Quantitative comparison of two field runs that should agree up to a transverse mirror —
+# built for the γ=1 direct/inverse crosscheck (thomson_scattering.jl laser +z, screen +Z
+# vs inverse_thomson_scattering.jl laser −z, screen ∓Z), but generic over any two runs on
+# the same grid. The reversed laser keeps its helicity/m labels rather than parity-mapping
+# them, so the two screens are expected to agree up to one of {identity, x-mirror,
+# y-mirror, xy-flip} — DETECTED here (best transform on the |h1| maps), never assumed.
+#
+#   julia +release --project=scripts scripts/compare_mirror_runs.jl RUN_A.toml RUN_B.toml
+#
+# Per harmonic × component it reports the relative L2/L∞ difference of the |amplitude|
+# maps under the winning transform (magnitudes are insensitive to the component sign
+# flips a mirror induces), plus the transverse-E phase windings ℓ of both runs (a mirror
+# or conjugation flips the sign — the winding pair diagnoses the convention relation),
+# and the powspec caches' relative difference where present. Products: one diff PNG +
+# 2-parent derived sidecar per harmonic (kind mirror_h<n>, harmonic selector), overlay
+# powspec PNG + sidecar. EDM_OUTDIR overrides the output dir (default: RUN_A's dir).
+
+using TOML, Serialization, LinearAlgebra, Statistics, Printf
+using RunManifests: check_schema_version, write_derived
+using ElectronDynamicsModels: ring_pixels, phase_winding_fit
+using CairoMakie
+
+length(ARGS) == 2 || error("usage: compare_mirror_runs.jl RUN_A.toml RUN_B.toml")
+const toml_a, toml_b = abspath(ARGS[1]), abspath(ARGS[2])
+const OUTDIR = get(ENV, "EDM_OUTDIR", dirname(toml_a))
+
+run_id(m) = m["provenance"]["run_id"]
+function load_side(path)
+    m = TOML.parsefile(path)
+    check_schema_version(m; source = basename(path))
+    hm = get(m["outputs"], "harmonic_maps", "hmaps_$(run_id(m)).jls")
+    h = deserialize(joinpath(dirname(path), hm))
+    return (; m, h, id = run_id(m))
+end
+A, B = load_side(toml_a), load_side(toml_b)
+
+size(A.h.fields_h) == size(B.h.fields_h) ||
+    error("grid/harmonic mismatch: $(size(A.h.fields_h)) vs $(size(B.h.fields_h))")
+collect(A.h.harmonics) == collect(B.h.harmonics) ||
+    error("harmonic sets differ: $(A.h.harmonics) vs $(B.h.harmonics)")
+harmonics = collect(A.h.harmonics)
+
+const COMPLABELS = ("Eˣ", "Eʸ", "Eᶻ", "Bˣ", "Bʸ", "Bᶻ")
+const TRANSFORMS = (
+    ("identity", M -> M),
+    ("mirror-x", M -> reverse(M; dims = 1)),
+    ("mirror-y", M -> reverse(M; dims = 2)),
+    ("flip-xy", M -> reverse(M)),
+)
+
+relL2(x, y) = norm(x .- y) / max(norm(x), eps())
+relL∞(x, y) = maximum(abs.(x .- y)) / max(maximum(abs.(x)), eps())
+
+# ── Transform detection on the |h1| maps, summed over all six components ──
+k1 = 1
+scores = map(TRANSFORMS) do (name, T)
+    s = sum(relL2(abs.(A.h.fields_h[k1, c, :, :]), T(abs.(B.h.fields_h[k1, c, :, :]))) for c in 1:6)
+    (name, s)
+end
+best = argmin(last.(scores))
+Tname, Tbest = TRANSFORMS[best]
+println("transform scores (Σ_comp rel-L2 of |h$(harmonics[k1])| maps):")
+foreach(((n, s),) -> @printf("   %-9s %.6f%s\n", n, s, n == Tname ? "   ← best" : ""), scores)
+
+# ── Per-harmonic metrics under the winning transform + diff figures + sidecars ──
+w₀ = A.h.w₀
+for (k, n) in enumerate(harmonics)
+    errs2 = zeros(6); errsI = zeros(6)
+    fig = Figure(size = (1980, 720))
+    for c in 1:6
+        Ma = abs.(A.h.fields_h[k, c, :, :])
+        Mb = Tbest(abs.(B.h.fields_h[k, c, :, :]))
+        errs2[c] = relL2(Ma, Mb); errsI[c] = relL∞(Ma, Mb)
+        for (row, M, ttl) in ((1, Ma, "A"), (2, Mb, "B∘$(Tname)"), (3, Ma .- Mb, "A − B∘T"))
+            ax = Axis(fig[row, c]; title = row == 1 ? COMPLABELS[c] : "",
+                ylabel = c == 1 ? ttl : "", xticklabelsvisible = false, yticklabelsvisible = false)
+            heatmap!(ax, collect(A.h.x_grid) ./ w₀, collect(A.h.y_grid) ./ w₀, M;
+                colormap = row == 3 ? :balance : :viridis)
+        end
+    end
+    Label(fig[0, 1:6], @sprintf("|A(h%d)| — %s vs %s under %s   (rel-L2: %s)",
+            n, first(A.id, 8), first(B.id, 8), Tname,
+            join((@sprintf("%s=%.1e", COMPLABELS[c], errs2[c]) for c in 1:6), " "));
+        fontsize = 16, font = :bold)
+    out = joinpath(OUTDIR, "mirror_h$(n)_$(first(A.id, 8))-$(first(B.id, 8)).png")
+    save(out, fig)
+    println("saved → $out")
+    @printf("h%-4d rel-L2 %s\n", n, join((@sprintf("%s=%.2e", COMPLABELS[c], errs2[c]) for c in 1:6), "  "))
+    write_derived(
+        OUTDIR; kind = "mirror_h$n", label = "mirror check h$n ($Tname)",
+        run_id = [A.id, B.id], plot = basename(out), setup = Dict("harmonic" => n),
+        plot_params = Dict(
+            "transform" => Tname,
+            (("relL2 " * COMPLABELS[c]) => round(errs2[c]; sigdigits = 3) for c in 1:6)...,
+            (("relLinf " * COMPLABELS[c]) => round(errsI[c]; sigdigits = 3) for c in 1:6)...,
+        ),
+        description = "|amplitude| maps of both runs at $(n)ω₁ under the detected transform " *
+            "($Tname) and their difference. Magnitudes are mirror-sign-insensitive; the " *
+            "winding table in the log carries the phase-convention diagnosis.",
+    )
+end
+
+# ── Phase windings on the transverse E components (ring at 0.3× the half-extent) ──
+hw = maximum(abs, A.h.x_grid)
+R = 0.3hw
+tol = 0.75 * (A.h.x_grid[2] - A.h.x_grid[1])
+idxs, az = ring_pixels(A.h.x_grid, A.h.y_grid, R; tol)
+println("\nphase windings ℓ (ring R = $(round(R / w₀; sigdigits = 3)) w₀; mirror/conjugation flips the sign):")
+for (k, n) in enumerate(harmonics), c in 1:2
+    fa = phase_winding_fit(az, angle.(A.h.fields_h[k, c, :, :][idxs]);
+        weights = abs.(A.h.fields_h[k, c, :, :][idxs]))
+    fb = phase_winding_fit(az, angle.(B.h.fields_h[k, c, :, :][idxs]);
+        weights = abs.(B.h.fields_h[k, c, :, :][idxs]))
+    @printf("   h%-4d %s   ℓ_A = %+.3f   ℓ_B = %+.3f\n", n, COMPLABELS[c], fa.slope, fb.slope)
+end
+
+# ── Powspec caches (present when the runs were reduced by current harmonic_products) ──
+psa = joinpath(dirname(toml_a), "powspec_$(A.id).jls")
+psb = joinpath(dirname(toml_b), "powspec_$(B.id).jls")
+if isfile(psa) && isfile(psb)
+    pa, pb = deserialize(psa), deserialize(psb)
+    fig = Figure(size = (1400, 700))
+    ax = Axis(fig[1, 1]; xlabel = "frequency / ω₁", ylabel = "Σ_pixels |Â|²", yscale = log10,
+        title = "power spectra — $(first(A.id, 8)) (solid) vs $(first(B.id, 8)) (dashed)")
+    # Nyquist = spp/2 in ω₁ multiples ⇒ n(f) = f/fmax · spp/2 (same normalization as the
+    # peak-finding convention; robust to the cache's raw frequency units).
+    spp = Int(A.m["config"]["samples_per_period"])
+    x = collect(pa.freqs) ./ maximum(pa.freqs) .* (spp / 2)
+    for c in 1:6
+        lines!(ax, x, max.(pa.ps[:, c], 1e-300); linewidth = 1.4, label = COMPLABELS[c])
+        lines!(ax, x, max.(pb.ps[:, c], 1e-300); linewidth = 1.4, linestyle = :dash)
+    end
+    axislegend(ax; position = :rt, nbanks = 2)
+    out = joinpath(OUTDIR, "mirror_powspec_$(first(A.id, 8))-$(first(B.id, 8)).png")
+    save(out, fig)
+    println("saved → $out")
+    rel = [relL2(pa.ps[:, c], pb.ps[:, c]) for c in 1:6]
+    @printf("powspec rel-L2 per comp: %s\n",
+        join((@sprintf("%s=%.2e", COMPLABELS[c], rel[c]) for c in 1:6), "  "))
+    write_derived(
+        OUTDIR; kind = "mirror_powspec", label = "mirror check powspec",
+        run_id = [A.id, B.id], plot = basename(out),
+        plot_params = Dict(("relL2 " * COMPLABELS[c]) => round(rel[c]; sigdigits = 3) for c in 1:6),
+        description = "Un-windowed power spectra of both runs overlaid (solid vs dashed). " *
+            "Integrated spectra are transform-invariant, so any disagreement here is a real " *
+            "physics/convention mismatch, not a mirror artifact.",
+    )
+else
+    println("powspec caches not found beside both manifests — skipping the spectrum overlay")
+end

--- a/scripts/compare_mirror_runs.jl
+++ b/scripts/compare_mirror_runs.jl
@@ -148,3 +148,23 @@ if isfile(psa) && isfile(psb)
 else
     println("powspec caches not found beside both manifests — skipping the spectrum overlay")
 end
+
+# ── comparison-tab declaration: the [comparison] sidecar groups the pair and labels the
+# entry in the dashboard's comparison view (the 2-parent mirror_* chips above are routed
+# there automatically; this adds the human-readable framing, mirroring compare_lpwa's). ──
+using RunManifests: write_comparison
+let script_of(m) = get(m["provenance"], "script", "?"),
+        out = write_comparison(
+        OUTDIR; label = "mirror crosscheck: $(first(A.id, 8)) vs $(first(B.id, 8))",
+        differs = "propagation direction + screen side (z-mirror pair)",
+        sides = [
+            (label = "A: $(script_of(A.m))", dir = basename(dirname(toml_a)),
+                script = script_of(A.m), where = Dict("run" => first(A.id, 8))),
+            (label = "B: $(script_of(B.m))", dir = basename(dirname(toml_b)),
+                script = script_of(B.m), where = Dict("run" => first(B.id, 8))),
+        ],
+        filename = "comparison_mirror_$(first(A.id, 8))-$(first(B.id, 8)).toml",
+    )
+
+    println("comparison → ", basename(out))
+end

--- a/scripts/gammatau_backfill.jl
+++ b/scripts/gammatau_backfill.jl
@@ -8,7 +8,7 @@
 #   • the classical|LL γ(τ)/γ₀ comparison chips (ll_system_chips.gamma_drain_product)
 # and enrich each run's .reduced marker with the new caches (atomic tmp+mv; these runs'
 # reduce already finished, so appending to the final marker is safe), so stage_products
-# ships them to the storagebox and build_status tracks them.
+# ships them to the archive store and build_status tracks them.
 #
 #   julia +release --project=scripts -t auto scripts/gammatau_backfill.jl <campaign_dir>
 #

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -274,7 +274,7 @@ function write_harmonic_products(
     # raw leakage floor (apodizing it would hide the very thing it diagnoses).
     ps = power_spectrum(fld; window = nothing)
     # Cache the spectrum (~640 KB) next to the hmaps: the PNG is then re-renderable on any
-    # machine without the multi-GB cube — the 2026-07-19 ω_bs restyle needed a full workstation
+    # machine without the multi-GB cube — the 2026-07-19 ω_bs restyle needed a full local
     # cube pass for 24 runs solely because this array used to be discarded after plotting.
     serialize(joinpath(outdir, "powspec_$(run_tag).jls"),
         (; freqs = collect(freqs), ps, n0, harmonics = collect(harmonics), window = "none",

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -66,7 +66,7 @@ include(joinpath(@__DIR__, "harmonic_products.jl"))   # write_harmonic_products 
 include(joinpath(@__DIR__, "trajectory_products.jl"))   # gamma_trace + write_ic_products (shared with gammatau_backfill.jl)
 include(joinpath(@__DIR__, "gpu_telemetry.jl"))   # with_gpu_sampler + gpu_manifest_section → the manifest [gpu] section
 
-# GPU backend selected via ENV: "rocm" (workstation default) or "cuda" (issaf H200).
+# GPU backend selected via ENV: "rocm" (default) or "cuda" (e.g. an H200 cluster node).
 const GPU_BACKEND = lowercase(get(ENV, "EDM_GPU_BACKEND", "rocm"))
 if GPU_BACKEND == "cuda"
     using CUDA
@@ -119,6 +119,13 @@ FIELD_MODE in (:split, :total) || error("EDM_FIELD_MODE must be \"split\" or \"t
 # cube (VRAM ∝ N_samples). Pair :narrow with EDM_SPP≈2048.
 const WINDOW = Symbol(get(ENV, "EDM_WINDOW", "full"))
 WINDOW in (:full, :narrow) || error("EDM_WINDOW must be \"full\" or \"narrow\", got \"$WINDOW\"")
+# Screen side: +1 = +Z (backscatter side, the production default); −1 = −Z (transmission
+# side). Only the ObserverScreen z-coordinate is signed — every timing/window formula uses
+# Z as a DISTANCE (arrival ≈ Z, hypot, corner spread), which is side-independent.
+# −1 exists for the γ=1 crosscheck against thomson_scattering.jl (laser +z, screen +Z):
+# with this laser reversed to −z, the transmission-side screen is the direct-run analogue.
+const SCREEN_ZSIGN = parse(Int, get(ENV, "EDM_SCREEN_ZSIGN", "1"))
+SCREEN_ZSIGN in (-1, 1) || error("EDM_SCREEN_ZSIGN must be 1 or -1, got $SCREEN_ZSIGN")
 const SCREEN_HW = parse(Float64, get(ENV, "EDM_SCREEN_HW", "25"))   # screen half-width in w₀; shrink (e.g. 5)
 #   in :narrow mode to cut the flat-screen geometric arrival spread (∝ hw²/Z) ⇒ shorter window ⇒ less VRAM.
 const WINDOW_LEAD = parse(Float64, get(ENV, "EDM_WINDOW_LEAD", "0.5"))   # :narrow lead-in before the burst (λ units)
@@ -145,7 +152,7 @@ BUNCH_NB >= 0 || error("EDM_BUNCH_NB must be ≥ 0, got $BUNCH_NB")
 const SKIP_POST = get(ENV, "EDM_SKIP_POSTPROCESS", "0") == "1"   # field-only: serialize cube + manifest, defer the (CPU/IO) reduction to an async step
 const RUN_TAG = get(ENV, "EDM_RUN_TAG", string(uuid4()))   # launcher may pin via EDM_RUN_TAG so .jls/log/manifest share one id
 mkpath(OUTDIR)
-@info "Inverse-Thomson (field) run config" RUN_TAG GPU_BACKEND ϕ₀ A0 GAMMA TSPAN_TAU WINDOW SCREEN_HW WINDOW_LEAD WINDOW_TAIL BUNCH_NB BUNCH_L SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS
+@info "Inverse-Thomson (field) run config" RUN_TAG GPU_BACKEND ϕ₀ A0 GAMMA TSPAN_TAU WINDOW SCREEN_HW SCREEN_ZSIGN WINDOW_LEAD WINDOW_TAIL BUNCH_NB BUNCH_L SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS
 const T_START = time()   # wall-clock start → [timing].total in the manifest
 
 # Laser parameters
@@ -432,7 +439,7 @@ x⁰_samples = range(start = x⁰_start, step = c * δt, length = N_samples)
 screen = ObserverScreen(
     LinRange(-screen_hw, screen_hw, Nx),
     LinRange(-screen_hw, screen_hw, Ny),
-    Z,
+    SCREEN_ZSIGN * Z,   # signed coordinate; Z stays a distance in every window formula
     x⁰_samples;
     c,
 )
@@ -541,6 +548,7 @@ config = Dict{String, Any}(
     "bunch_chirp" => BUNCH_CHIRP,      # EDM_BUNCH_CHIRP knob (ponderomotive pre-compensation scale)
     "harmonics" => collect(HARMONICS), # harmonic bins the maps extract (≈4γ²ω for :narrow)
     "backscatter_n0" => N0,            # on-axis backscatter fundamental ω_s/ω = (1+β)/(1−β) ≈ 4γ²
+    "screen_zsign" => SCREEN_ZSIGN,    # screen side: +1 backscatter (+Z), −1 transmission (−Z)
     "accumulation_alg" => (ACCUM_ALG == "newton" ? "GPUKernelNewton" : "GPUKernelRK4"),   # dashboard canonical name
     "newton_iters" => NEWTON_ITERS,    # recorded UNCONDITIONALLY (rk4 runs too): a mixed rk4/newton
     #   pool otherwise turns newton_iters into a sweep axis whose rk4 members lack the key, and the
@@ -574,7 +582,7 @@ setup = Dict{String, Any}(
     "τi" => τi,
     "τf" => τf,
     "Rmax" => Rmax,
-    "Z" => Z,
+    "Z" => SCREEN_ZSIGN * Z,   # signed screen z-coordinate (the distance is |Z|)
     "screen_hw" => screen_hw,          # screen half-width (a.u.); = SCREEN_HW·w₀
     "x0_start" => x⁰_start,            # observer-time window start (a.u.); Z-relative offset ⇒ [config].window
 )   # input knobs (Nx/Ny/N/N_samples/spp) live in [config]; setup is the integration window + screen geometry

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -31,7 +31,7 @@ include(joinpath(@__DIR__, "manifest.jl"))   # RunManifests: run_provenance, wri
 include(joinpath(@__DIR__, "harmonic_products.jl"))   # write_harmonic_products (shared with the recovery path)
 include(joinpath(@__DIR__, "gpu_telemetry.jl"))   # with_gpu_sampler + gpu_manifest_section → the manifest [gpu] section
 
-# GPU backend selected via ENV: "rocm" (workstation default) or "cuda" (issaf H200).
+# GPU backend selected via ENV: "rocm" (default) or "cuda" (e.g. an H200 cluster node).
 const GPU_BACKEND = lowercase(get(ENV, "EDM_GPU_BACKEND", "rocm"))
 if GPU_BACKEND == "cuda"
     using CUDA

--- a/scripts/thomson_scattering_A.jl
+++ b/scripts/thomson_scattering_A.jl
@@ -15,7 +15,7 @@ using UUIDs
 
 include(joinpath(@__DIR__, "manifest.jl"))   # RunManifests: run_provenance, write_solver_manifest
 
-# GPU backend selected via ENV: "rocm" (workstation default) or "cuda" (issaf H200).
+# GPU backend selected via ENV: "rocm" (default) or "cuda" (e.g. an H200 cluster node).
 # The `using` for the unused backend never executes, so each platform only needs its own.
 const GPU_BACKEND = lowercase(get(ENV, "EDM_GPU_BACKEND", "rocm"))
 if GPU_BACKEND == "cuda"

--- a/scripts/trajectory_products.jl
+++ b/scripts/trajectory_products.jl
@@ -42,7 +42,7 @@ end
 # from [config], but the cache pins the EXACT as-run xμ₀/u₀ (reconstruction drift becomes
 # visible instead of silent) and lets the IC chip re-render anywhere without an EDM solve —
 # the same publish-autonomy contract as the γ(τ) trace (both are enumerated in the .reduced
-# marker at reduce time). `datafile` on the sidecar ships the cache to the storagebox and
+# marker at reduce time). `datafile` on the sidecar ships the cache to the archive store and
 # puts a /data download URL on the chip. Cheap (N×6 floats ≈ 100 KB at N = 2000): always on.
 #
 # The chip is MODE-AWARE, because unbunched runs (nb = 0, most campaigns) have Δz ≡ 0 and a

--- a/scripts/verify_lorenz_gauge.jl
+++ b/scripts/verify_lorenz_gauge.jl
@@ -447,7 +447,7 @@ end
 
 main()
 
-# ── derived-artifact metadata for the results dashboard (research.314159265.dev) ──
+# ── derived-artifact metadata for the results dashboard ──
 # Standalone analysis node: the N=2000 screens are recomputed (not read from a run), so the
 # parent run it verifies is passed via EDM_DERIVED_FROM to draw the lineage link. The run_id
 # is deterministic in the verification's params, so re-runs overwrite rather than duplicate.

--- a/scripts/verify_maxwell_beam.jl
+++ b/scripts/verify_maxwell_beam.jl
@@ -1,0 +1,200 @@
+# Verify the INCIDENT beam satisfies vacuum Maxwell — the analytic-laser sibling of
+# verify_lorenz_gauge.jl (which checks the *radiated* 4-potential). The LG/Gauss lasers
+# are closed-form paraxial-corrected fields, so two kinds of residual coexist:
+#
+#   • paraxial TRUNCATION — genuine to the model, scales down with (λ/w₀)ⁿ;
+#   • convention BUGS — sign/term errors that do NOT scale away with w₀/λ.
+#
+# The two diagnostics here separate them:
+#   1. residual maps  — |∇·E|, |∇·B|, |∇×E + ∂B/∂t|, |∇×B − (1/c²)∂E/∂t| (central
+#      differences) over the transverse plane, one row per beam configuration
+#      (k = ±ẑ × σ∓/linear). A bug lights up specific configurations/components.
+#   2. scaling plot   — worst residual vs w₀/λ on log-log axes with a (λ/w₀)² guide.
+#      Truncation follows the guide; a bug plateaus. The 2026-07-30 Bz parity error
+#      (overall kz_sign on B[3] made every k=−ẑ beam non-Maxwellian, |∇·B| ~ 2e-3 of
+#      the gradient scale vs ~1e-5 for +ẑ) is exactly the class this catches — it was
+#      found by the γ=1 direct/inverse crosscheck and would sit flat in panel 2.
+#
+# Residuals are normalized by the configuration's max field-gradient magnitude, so
+# every number is dimensionless and comparable across configs and beam sizes.
+#
+#   julia --project=scripts scripts/verify_maxwell_beam.jl
+#
+# ENV: EDM_OUTDIR (default .), EDM_MAXWELL_NGRID (map resolution/side, default 61),
+#      EDM_MAXWELL_W0S (comma-sep w₀/λ list for the scaling panel, default 15,37.5,75,150),
+#      EDM_ASSERT_DIVB (fail with nonzero exit if any config's |∇·B|/scale exceeds this;
+#      "" = report only). EDM_DERIVED_FROM optionally links the dashboard node to a run.
+
+using ElectronDynamicsModels
+using ModelingToolkit
+using StaticArrays
+using LinearAlgebra
+using Statistics
+using Printf
+using CairoMakie
+
+const c = 137.03599908330932
+const OUTDIR = get(ENV, "EDM_OUTDIR", ".")
+const NGRID = parse(Int, get(ENV, "EDM_MAXWELL_NGRID", "61"))
+const W0S = parse.(Float64, split(get(ENV, "EDM_MAXWELL_W0S", "15,37.5,75,150"), ","))
+const ASSERT_DIVB = get(ENV, "EDM_ASSERT_DIVB", "")
+mkpath(OUTDIR)
+
+ω = 0.057
+λ = 2π * c / ω
+
+const CONFIGS = (
+    (label = "k+ σ−", kdir = [0, 0, 1], pol = :circular_minus),
+    (label = "k− σ−", kdir = [0, 0, -1], pol = :circular_minus),
+    (label = "k− σ+", kdir = [0, 0, -1], pol = :circular_plus),
+    (label = "k+ lin", kdir = [0, 0, 1], pol = :linear),
+    (label = "k− lin", kdir = [0, 0, -1], pol = :linear),
+)
+
+function make_evaluator(kdir, pol, w₀)
+    @named world = Worldline(:τ, :atomic)
+    @named laser = LaguerreGaussLaser(; wavelength = λ, a0 = 0.3, beam_waist = w₀,
+        radial_index = 2, azimuthal_index = -2, world, temporal_profile = :gaussian,
+        temporal_width = 150 / ω, focus_position = 0.0, polarization = pol,
+        initial_phase = -π / 2, k_direction = kdir)
+    return FieldEvaluator(laser)
+end
+
+# Central-difference Maxwell residuals at one spacetime point p = [t, x, y, z]
+# (FieldEvaluator's first coordinate is TIME, in the solver's time units — the envelope
+# argument is (t − t₀) − kz_sign·z/c). Spatial step h (length), temporal step ht (time).
+# All residuals are expressed in E-gradient units (Ampère's is rescaled by c) and
+# normalized by the local max gradient, so every number is dimensionless.
+function residuals(fe, p::SVector{4, Float64}, h::Float64, ht::Float64)
+    ev(dp) = fe(p .+ dp)
+    step(i) = SVector{4}(ntuple(j -> j == i ? (i == 1 ? ht : h) : 0.0, 4))
+    rp = ntuple(i -> ev(step(i)), 4)
+    rm = ntuple(i -> ev(-step(i)), 4)
+    dE = ntuple(i -> (rp[i].E .- rm[i].E) ./ (i == 1 ? 2ht : 2h), 4)   # ∂E/∂(t,x,y,z)
+    dB = ntuple(i -> (rp[i].B .- rm[i].B) ./ (i == 1 ? 2ht : 2h), 4)
+    divE = dE[2][1] + dE[3][2] + dE[4][3]
+    divB = dB[2][1] + dB[3][2] + dB[4][3]
+    curlE = SVector(dE[3][3] - dE[4][2], dE[4][1] - dE[2][3], dE[2][2] - dE[3][1])
+    curlB = SVector(dB[3][3] - dB[4][2], dB[4][1] - dB[2][3], dB[2][2] - dB[3][1])
+    faraday = curlE .+ dB[1]                     # ∇×E + ∂B/∂t
+    ampere = c .* (curlB .- dE[1] ./ c^2)        # c·(∇×B − (1/c²)∂E/∂t) → E-gradient units
+    scale = max(maximum(x -> maximum(abs, x), dE[2:4]),
+        c * maximum(x -> maximum(abs, x), dB[2:4]))
+    return (; divE = abs(divE), divB = abs(divB) * c,   # c·|∇·B| → E-gradient units
+        faraday = norm(faraday), ampere = norm(ampere), scale)
+end
+
+const RES_KEYS = (:divE, :divB, :faraday, :ampere)
+const RES_LABELS = ("|∇·E|", "|∇·B|", "|∇×E + ∂B/∂t|", "|∇×B − ∂E/∂t/c²|")
+
+# ── 1. residual maps on the transverse plane (z = 0.2λ, mid-pulse) ──
+w₀_map = 75λ
+h = λ / 50                     # spatial stencil
+const T = 2π / ω
+ht = T / 64                    # temporal stencil (FieldEvaluator's first coordinate is TIME)
+t₀p = 5T                       # pulse-center time (LaguerreGaussLaser n_cycles = 5 default)
+xs = range(-1.5w₀_map, 1.5w₀_map; length = NGRID)
+fig = Figure(size = (380 * 4 + 140, 300 * length(CONFIGS) + 90))
+worst_map = Dict{String, Dict{Symbol, Float64}}()
+for (ic, cfg) in enumerate(CONFIGS)
+    fe = make_evaluator(cfg.kdir, cfg.pol, w₀_map)
+    maps = Dict(k => Matrix{Float64}(undef, NGRID, NGRID) for k in RES_KEYS)
+    smax = 0.0
+    for (i, x) in enumerate(xs), (j, y) in enumerate(xs)
+        r = residuals(fe, SVector(t₀p + 0.1T, x, y, 0.2λ), h, ht)
+        for k in RES_KEYS
+            maps[k][i, j] = getproperty(r, k)
+        end
+        smax = max(smax, r.scale)
+    end
+    worst_map[cfg.label] = Dict(k => maximum(maps[k]) / smax for k in RES_KEYS)
+    for (kk, k) in enumerate(RES_KEYS)
+        ax = Axis(fig[ic, kk]; title = ic == 1 ? RES_LABELS[kk] : "",
+            ylabel = kk == 1 ? cfg.label : "",
+            xticklabelsvisible = ic == length(CONFIGS), yticklabelsvisible = kk == 1)
+        hm = heatmap!(ax, xs ./ w₀_map, xs ./ w₀_map, log10.(maps[k] ./ smax .+ 1e-16);
+            colormap = :inferno, colorrange = (-8, -1))
+        ic == length(CONFIGS) && kk == length(RES_KEYS) &&
+            Colorbar(fig[1:length(CONFIGS), 5], hm; label = "log₁₀ residual / max|∇F|")
+    end
+end
+Label(fig[0, 1:4], "Incident-beam Maxwell residuals — LG p=2 m=−2, w₀ = 75λ, a0 = 0.3 (normalized)";
+    fontsize = 18, font = :bold)
+mapfile = joinpath(OUTDIR, "maxwell_beam_maps.png")
+save(mapfile, fig)
+println("saved → $mapfile")
+
+# ── 2. scaling with w₀/λ: truncation falls as (λ/w₀)², a convention bug stays flat ──
+scal = Dict(cfg.label => Dict(k => Float64[] for k in RES_KEYS) for cfg in CONFIGS)
+for w0f in W0S
+    w₀ = w0f * λ
+    probes = (SVector(t₀p + 0.1T, 0.7w₀, 0.3w₀, 0.2λ), SVector(t₀p + 0.4T, 1.2w₀, -0.5w₀, -1.5λ),
+        SVector(t₀p - 0.7T, 0.4w₀, 0.9w₀, 2.2λ))
+    for cfg in CONFIGS
+        fe = make_evaluator(cfg.kdir, cfg.pol, w₀)
+        rs = [residuals(fe, p, h, ht) for p in probes]
+        smax = maximum(r -> r.scale, rs)
+        for k in RES_KEYS
+            push!(scal[cfg.label][k], maximum(r -> getproperty(r, k), rs) / smax)
+        end
+    end
+end
+fig2 = Figure(size = (420 * 4, 400))
+for (kk, k) in enumerate(RES_KEYS)
+    ax = Axis(fig2[1, kk]; title = RES_LABELS[kk], xlabel = "w₀ / λ",
+        ylabel = kk == 1 ? "residual / max|∇F|" : "", xscale = log10, yscale = log10)
+    for cfg in CONFIGS
+        scatterlines!(ax, W0S, max.(scal[cfg.label][k], 1e-16); label = cfg.label)
+    end
+    guide = (W0S[1] ./ W0S) .^ 2 .* maximum(scal[CONFIGS[1].label][k][1])
+    lines!(ax, W0S, guide; color = :gray, linestyle = :dash, label = "(λ/w₀)²")
+    kk == length(RES_KEYS) && axislegend(ax; position = :lb, labelsize = 10)
+end
+Label(fig2[0, 1:4], "Maxwell residual scaling — paraxial truncation follows the guide; a convention bug plateaus";
+    fontsize = 16, font = :bold)
+scalfile = joinpath(OUTDIR, "maxwell_beam_scaling.png")
+save(scalfile, fig2)
+println("saved → $scalfile")
+
+# ── report + optional assertion ──
+println("\nworst residual / scale on the w₀ = 75λ map:")
+@printf("%-8s %12s %12s %12s %12s\n", "config", RES_KEYS...)
+for cfg in CONFIGS
+    w = worst_map[cfg.label]
+    @printf("%-8s %12.2e %12.2e %12.2e %12.2e\n", cfg.label, (w[k] for k in RES_KEYS)...)
+end
+if !isempty(ASSERT_DIVB)
+    thr = parse(Float64, ASSERT_DIVB)
+    bad = [cfg.label for cfg in CONFIGS if worst_map[cfg.label][:divB] > thr]
+    isempty(bad) || error("∇·B residual above $(thr) for: $(join(bad, ", "))")
+    println("assert: all configs satisfy |∇·B|/scale ≤ $thr")
+end
+
+# ── dashboard metadata (standalone verification node, deterministic id) ──
+using UUIDs
+using RunManifests
+let V = string(uuid5(UUID("0000000e-d42a-4000-8000-000000000000"),
+            "maxwell_beam_$(NGRID)_$(join(W0S, '-'))")),
+        parent = get(ENV, "EDM_DERIVED_FROM", "")
+
+    write_run_manifest(OUTDIR; run_id = V, script = basename(PROGRAM_FILE),
+        derived_from = isempty(parent) ? nothing : parent,
+        config = Dict("a0" => 0.3, "initial_phase" => -π / 2, "N" => 0, "N_samples" => 0,
+            "samples_per_period" => 0, "n_substeps" => 0),
+        laser = Dict("wavelength" => λ, "a0" => 0.3, "w0" => w₀_map, "p" => 2, "m" => -2,
+            "pol" => "all", "profile" => "gaussian", "temporal_width" => 150 / ω,
+            "focus_position" => 0.0, "phi0" => -π / 2),
+        setup = Dict("ngrid" => NGRID, "w0_scan" => W0S))
+    write_derived(OUTDIR; kind = "maxwell_maps", label = "Maxwell residual maps",
+        run_id = V, plot = basename(mapfile), source = basename(mapfile),
+        plot_params = Dict("worst divB $(cfg.label)" => round(worst_map[cfg.label][:divB]; sigdigits = 3)
+            for cfg in CONFIGS),
+        description = "Normalized |∇·E|, |∇·B|, Faraday and Ampère residuals of the incident " *
+            "LG beam over the transverse plane, one row per (k̂, polarization) configuration.")
+    write_derived(OUTDIR; kind = "maxwell_scaling", label = "Maxwell residual scaling",
+        run_id = V, plot = basename(scalfile), source = basename(scalfile),
+        description = "Worst normalized Maxwell residuals vs w₀/λ: paraxial truncation follows " *
+            "the (λ/w₀)² guide; convention bugs plateau (how the 2026-07-30 reversed-beam Bz " *
+            "parity error would present).")
+    println("dashboard metadata → verification node $V", isempty(parent) ? "" : " (derived_from $parent)")
+end

--- a/src/external_fields.jl
+++ b/src/external_fields.jl
@@ -558,9 +558,16 @@ Reference: Allen et al., Phys. Rev. A 45, 8185 (1992)
         B[1] ~ -kz_sign * E[2] / c
         B[2] ~ kz_sign * E[1] / c
 
-        # Bz component: longitudinal magnetic field along k̂; lab z-component
-        # picks up an overall kz_sign analogously to Ez.
-        B[3] ~ kz_sign * real(
+        # Bz component: longitudinal magnetic field. Unlike Ez (polar vector — its lab
+        # z-component flips under k̂ → −ẑ), B is an AXIAL vector: the parity image keeps
+        # +Bz while (Bx, By) flip via k̂ × E above, and ∇·B = 0 then fixes Bz's sign with
+        # NO overall kz_sign. The former overall kz_sign here made the reversed beam
+        # non-Maxwellian (|∇·B| ~ 2e-3 of the local gradient scale vs ~1e-5 for +ẑ,
+        # measured 2026-07-30) — caught by the γ=1 direct/inverse crosscheck, where the
+        # radiated Ez/Bz maps disagreed at O(1) while every transverse channel matched.
+        # The internal z → kz_sign·z curvature/Gouy substitutions below stay — they ARE
+        # the correct mirroring of the beam structure.
+        B[3] ~ real(
             -im / ω * (
                 # Term 1: m-dependent term
                 -(

--- a/test/laguerre_gauss.jl
+++ b/test/laguerre_gauss.jl
@@ -341,14 +341,17 @@ end
         @test rd.B ≈ rp.B
     end
 
-    # Sign-flip relations between +ẑ and −ẑ propagation.
-    # The substitution z → kz_sign·z + overall sign on E_z, B_x, B_y, B_z gives:
+    # Sign-flip relations between +ẑ and −ẑ propagation: the PARITY image of the +ẑ
+    # beam. E is a polar vector, B is axial, so under z → −z:
     #   E_x_neg(x,y,z,t) =  E_x_pos(x,y,−z,t)
     #   E_y_neg(x,y,z,t) =  E_y_pos(x,y,−z,t)
     #   E_z_neg(x,y,z,t) = −E_z_pos(x,y,−z,t)
     #   B_x_neg(x,y,z,t) = −B_x_pos(x,y,−z,t)
     #   B_y_neg(x,y,z,t) = −B_y_pos(x,y,−z,t)
-    #   B_z_neg(x,y,z,t) = −B_z_pos(x,y,−z,t)
+    #   B_z_neg(x,y,z,t) = +B_z_pos(x,y,−z,t)   # axial: NO flip (∇·B = 0 fixes it)
+    # This test previously pinned B_z_neg = −B_z_pos — a parity error that made the
+    # reversed beam non-Maxwellian (∇·B ≠ 0 at the longitudinal-correction order);
+    # caught by the γ=1 direct/inverse crosscheck 2026-07-30.
     # Use circular polarization so E_y is nontrivial → exercises the B_x sign too.
     @named world_pc = Worldline(:τ, :atomic)
     @named laser_pos_c = LaguerreGaussLaser(;
@@ -379,6 +382,35 @@ end
         @test r_neg.E[3] ≈ -r_pos_at_neg.E[3] atol = 1e-10
         @test r_neg.B[1] ≈ -r_pos_at_neg.B[1] atol = 1e-10
         @test r_neg.B[2] ≈ -r_pos_at_neg.B[2] atol = 1e-10
-        @test r_neg.B[3] ≈ -r_pos_at_neg.B[3] atol = 1e-10
+        @test r_neg.B[3] ≈ +r_pos_at_neg.B[3] atol = 1e-10
+    end
+end
+
+@testset "beam is Maxwellian: ∇·B = 0 numerically, both k̂ and helicities" begin
+    # Guard for the 2026-07-30 Bz parity bug class: an overall kz_sign on B[3] made every
+    # k = −ẑ beam violate ∇·B at the longitudinal-correction order (~2e-3 of the local
+    # B-gradient scale) while +ẑ sat at the finite-difference floor (~1e-5). Central
+    # differences, normalized by the max |∂B| over the stencil — dimensionless.
+    for kd in ([0, 0, 1], [0, 0, -1]), pol in (:circular_minus, :circular_plus)
+        @named world_mx = Worldline(:τ, :atomic)
+        @named laser_mx = LaguerreGaussLaser(;
+            wavelength = 1.0, a0 = 0.5, beam_waist = 75.0,
+            radial_index = 2, azimuthal_index = -2, world = world_mx,
+            temporal_profile = :constant, polarization = pol, k_direction = kd)
+        fe_mx = FieldEvaluator(laser_mx)
+        h = 0.02
+        for (x0, x, y, z) in ((0.1, 52.5, 22.5, 0.2), (0.5, 30.0, 67.5, -1.5))
+            divB = 0.0
+            scale = 0.0
+            for i in 1:3
+                dp = zeros(4)
+                dp[i + 1] = h
+                rp = fe_mx([x0, x, y, z] .+ dp)
+                rm = fe_mx([x0, x, y, z] .- dp)
+                divB += (rp.B[i] - rm.B[i]) / 2h
+                scale = max(scale, maximum(abs.(rp.B .- rm.B)) / 2h)
+            end
+            @test abs(divB) / scale < 5e-4
+        end
     end
 end

--- a/test/laguerre_gauss.jl
+++ b/test/laguerre_gauss.jl
@@ -391,7 +391,7 @@ end
     # k = −ẑ beam violate ∇·B at the longitudinal-correction order (~2e-3 of the local
     # B-gradient scale) while +ẑ sat at the finite-difference floor (~1e-5). Central
     # differences, normalized by the max |∂B| over the stencil — dimensionless.
-    for kd in ([0, 0, 1], [0, 0, -1]), pol in (:circular_minus, :circular_plus)
+    for kd in ([0, 0, 1], [0, 0, -1]), pol in (:circular_minus, :circular_plus, :linear)
         @named world_mx = Worldline(:τ, :atomic)
         @named laser_mx = LaguerreGaussLaser(;
             wavelength = 1.0, a0 = 0.5, beam_waist = 75.0,


### PR DESCRIPTION
## The bug

`B[3]` of the LaguerreGauss laser carried an overall `kz_sign` "analogously to Ez". But **E is a polar vector and B is axial**: under the mirror that maps the +ẑ beam onto its −ẑ counterpart, Ez flips and B⊥ flips (via k̂×E) — Bz does **not** (∇·B = 0 fixes its sign). The extra sign made every `k_direction = [0,0,−1]` beam non-Maxwellian at the longitudinal-correction order: |∇·B| ≈ 2e-3 of the local gradient scale vs ~1e-5 for +ẑ. The sign-relation test had faithfully pinned the buggy relation.

## How it was found (γ=1 crosscheck, kept as tooling in this PR)

At γ=1 the inverse script's electron is at rest and only the laser direction differs, so direct(laser +z, screen +Z) must be the z-mirror of inverse(laser −z, screen −Z). The radiation-level comparison showed an irreconcilable split — transverse channels matched under one polarization pairing while the radiated Ez/Bz maps matched under the other — which meant the incident beam itself was internally inconsistent. A numerical Maxwell battery then isolated ∇·B, and the term-level audit found the sign.

## Validation

- **Field-level parity probe**: after the fix, `E/B` of the reversed beam equal the mirror image of the forward beam to **machine precision (~1e-15)** at off-axis probe points, for (p,m) ∈ {(2,−2),(0,1),(2,2)} × {σ⁻, σ⁺, linear} — same-label pairing, as parity demands.
- **Maxwell residual battery** (`verify_maxwell_beam.jl`, new): ∇·E/∇·B at the paraxial floor (3–5e-5) and Faraday/Ampère at the slow-envelope truncation level (~1e-3), uniform across k̂ and polarization; truncation-vs-bug scaling panel included. `EDM_ASSERT_DIVB` gates CI-style use.
- **Radiation-level crosscheck** (γ=1, a0=0.3, 201², N=2000): with the fixed laser the transverse h1 channels of direct(+Z) vs inverse(−Z) agree to **3.3e-5** and the E-field power spectra to **3e-8** (B to 1e-11). The final all-channel closure run (σ⁻ mirror twin) is on the GPU; verdict will follow as a PR comment.
- **Test suite**: green (16,028 LaguerreGauss assertions). The sign-relation test now asserts the parity-correct relations, and a new numerical ∇·B = 0 guard covers both k̂ directions × {σ⁻, σ⁺, linear} — implementation-independent protection for the whole bug class.

## Impact

Every `k_direction = [0,0,−1]` run (all inverse-Thomson campaigns) used the non-Maxwellian incident Bz, an error of order λ/(πw₀) ≈ 4e-3 relative. Transverse-dominated observables (backscatter line, chirp band, powspec-B) are expected to be robust; longitudinal/spin-orbit-sensitive quantities may shift at the 1e-3–1e-2 level. A spot-rerun of one archived γ=10 cell to quantify is planned as follow-up.

## Also in this PR

- `EDM_SCREEN_ZSIGN` (inverse script): screen on the transmission side (−Z); window formulas keep Z as a distance.
- `campaigns/gamma1_crosscheck_{direct,inverse}.sh`: the reusable crosscheck (windows of the two scripts align exactly at these knobs).
- `compare_mirror_runs.jl`: transform-detecting map/winding/powspec comparison; 2-parent chips + a `[comparison]` declaration for the dashboard's comparison tab.
- `local.sh`: local runs default `KEEP_CUBE=1`.
- `RunManifests`: standalone analysis nodes now record `repo_dirty` like solver runs.
- Environment-specific comments generalized (public-repo hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)