### PR TITLE
Capture publish-hook output; surface the log tail in failure alerts

### DIFF
--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -234,8 +234,7 @@ run_campaign() {
     # covers this path. Same contract as run_cell.sh: only if ≥1 cell left a manifest.
     if [ -n "${PUBLISH_HOOK:-}" ] && ls "$OUT/$CAMPAIGN"/run_*.toml >/dev/null 2>&1; then
         log "publish: $CAMPAIGN → PUBLISH_HOOK"
-        ( CAMP="$OUT/$CAMPAIGN"; eval "$PUBLISH_HOOK" ) \
-            || notify rotating_light high "EDM publish FAILED" "$CAMPAIGN: PUBLISH_HOOK failed on $(hostname)"
+        ( CAMP="$OUT/$CAMPAIGN"; _run_publish_hook )
     fi
     notify white_check_mark default "EDM hotaisle done" "$CAMPAIGN → $OUT/$CAMPAIGN ; VM $NAME KEPT WARM — run teardown."
     ledger "$NAME" campaign_done "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -368,8 +368,7 @@ monitor_and_download() {   # poll for DONE (crash = 3 consecutive dead liveness 
     # skips the RUNPOD_RSYNC_DOWNLOAD=0 volume path, where nothing lands in $OUT).
     if [ -n "${PUBLISH_HOOK:-}" ] && ls "$OUT/$CAMPAIGN"/run_*.toml >/dev/null 2>&1; then
         log "publish: $CAMPAIGN → PUBLISH_HOOK"
-        ( CAMP="$OUT/$CAMPAIGN"; eval "$PUBLISH_HOOK" ) \
-            || notify rotating_light high "EDM publish FAILED" "$CAMPAIGN: PUBLISH_HOOK failed on $(hostname)"
+        ( CAMP="$OUT/$CAMPAIGN"; _run_publish_hook )
     fi
     notify white_check_mark default "EDM runpod done" "$CAMPAIGN → $OUT/$CAMPAIGN ; pod $POD KEPT — run teardown."
     ledger "$POD" campaign_done "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -60,6 +60,29 @@ notify() {   # notify <tags> <priority> <title> <message>  — no-op unless NTFY
         || echo "[warn] ntfy post failed: $3" >&2
 }
 
+# Runs PUBLISH_HOOK with stdout+stderr captured to $CAMP/publish.log (appended — the log
+# travels with the campaign, the same way run_<uuid>.log does for reduces). On failure the
+# ntfy body carries the log tail so the alert says WHY, not just that it failed. Always
+# returns 0: a publish failure must not abort the campaign flow (backends run under set -e).
+# The name publish.log sits outside campaign-publish's metadata copy set
+# (run_*.toml/derived_*/comparison_*/summary_*/*.reduced/cells.tsv), so it never rides to
+# the union. Requires CAMP, CAMPAIGN, PUBLISH_HOOK in scope.
+_run_publish_hook() {
+    local plog="$CAMP/publish.log" tail3
+    # The eval runs in a SUBSHELL so a hook that calls `exit` cannot take the campaign
+    # shell down with it (the hook is untrusted config, not code we control).
+    if { echo "==== [$(date -u +%FT%TZ)] publish attempt: ${CAMPAIGN:-?} on $(hostname) ===="
+         ( eval "$PUBLISH_HOOK" ); } >>"$plog" 2>&1; then
+        return 0
+    fi
+    tail3=$(tail -n 3 "$plog" 2>/dev/null | cut -c1-400)   # size-capped; multi-line OK in the -d body
+    notify rotating_light high "EDM publish FAILED" \
+"${CAMPAIGN:-?}: PUBLISH_HOOK failed on $(hostname)
+log: $plog — last lines:
+${tail3:-<no output captured>}"
+    return 0
+}
+
 # Default reducer for overlap mode: turn a finished field cube into its products (the step the
 # solver does inline when EDM_SKIP_POSTPROCESS is unset). Runs BACKGROUNDED; appends to the cell's
 # run_<uuid>.log (so the reduce output travels with the run) and drops a <uuid>.reduced /
@@ -192,7 +215,6 @@ run_cells() {
     # (with $CAMP/$CAMPAIGN in scope) publishes just the verified cells (those with a .reduced marker).
     if [ -n "${PUBLISH_HOOK:-}" ] && [ "${CELLS_OK:-0}" -gt 0 ]; then
         echo "[$(date -u +%FT%TZ)] publish: $CAMPAIGN → PUBLISH_HOOK"
-        eval "$PUBLISH_HOOK" \
-            || notify rotating_light high "EDM publish FAILED" "${CAMPAIGN:-?}: PUBLISH_HOOK failed on $(hostname)"
+        _run_publish_hook
     fi
 }


### PR DESCRIPTION
The PUBLISH_HOOK error path only said *that* a publish failed; the hook's output went nowhere, so failures (e.g. `rest_departure`, 2026-07-30 09:42) required manual reproduction to diagnose.

- New `_run_publish_hook()` in `run_cell.sh` (both cloud backends source it): hook stdout+stderr append to **`$CAMP/publish.log`** with a timestamped attempt header; on failure the ntfy **body** carries the log path + `tail -n 3` (size-capped). Title stays single-line (HTTP header).
- Hardening: the eval runs in a subshell — a hook calling `exit` can no longer kill the campaign shell (latent in the old code). Always returns 0 under `set -e`.
- All three call sites (`run_cells`, hotaisle, runpod) delegate to the one helper — no drift.
- `publish.log` is outside `campaign-publish.sh`'s union copy set — verified it never ships.

Tested: failure path (notification body carries header+stdout+stderr tail; `set -e` flow continues), success path (silent append), `bash -n` on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)