### PR TITLE
Clean cloud provenance: timestamp_utc + pristine pod checkouts

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -142,6 +142,11 @@ end
     run_provenance(; run_id, gpu_backend, repo_dir, script=abspath(PROGRAM_FILE),
                    gpu_device=nothing) -> Dict{String,Any}
 
+Timestamps: `timestamp` is machine-LOCAL wall clock (legacy, timezone-less — cloud VMs
+stamp UTC, the workstation its own zone) and stays for back-compat; `timestamp_utc`
+(with an explicit `Z`) is the unambiguous instant — consumers that compare times across
+machines (e.g. the dashboard's known-issue cutoffs) should prefer it.
+
 The standard solver-run `[provenance]` block. `gpu_device` (e.g. `CUDA.name(CUDA.device())`)
 is recorded only when supplied — kept as an argument so this package stays free of any GPU
 backend dependency.
@@ -162,7 +167,7 @@ function run_provenance(;
         "cloud_provider" => get(ENV, "EDM_CLOUD_PROVIDER", "local"),
         "gpu_backend" => gpu_backend,
         "julia_version" => string(VERSION),
-        "timestamp" => string(now()),
+        "timestamp" => string(now()), "timestamp_utc" => string(now(UTC)) * "Z",
     )
     gpu_device === nothing || (prov["gpu_device"] = string(gpu_device))
     return prov
@@ -345,7 +350,7 @@ function write_derived(
         "schema_version" => MANIFEST_SCHEMA_VERSION,
         "provenance" => Dict{String, Any}(
             "script" => basename(PROGRAM_FILE), "repo_commit" => _script_repo_commit(),
-            "host" => gethostname(), "timestamp" => string(now()),
+            "host" => gethostname(), "timestamp" => string(now()), "timestamp_utc" => string(now(UTC)) * "Z",
             (_script_repo_dirty() ? ("repo_dirty" => true,) : ())...,
         ),
         "derived" => d,
@@ -449,7 +454,7 @@ function write_comparison(
         "schema_version" => MANIFEST_SCHEMA_VERSION,
         "provenance" => Dict(
             "script" => basename(PROGRAM_FILE), "repo_commit" => _script_repo_commit(),
-            "host" => gethostname(), "timestamp" => string(now())
+            "host" => gethostname(), "timestamp" => string(now()), "timestamp_utc" => string(now(UTC)) * "Z"
         ),
         "comparison" => comp,
     )
@@ -498,7 +503,7 @@ function write_summary(
         "schema_version" => MANIFEST_SCHEMA_VERSION,
         "provenance" => Dict(
             "script" => basename(PROGRAM_FILE), "repo_commit" => _script_repo_commit(),
-            "host" => gethostname(), "timestamp" => string(now())
+            "host" => gethostname(), "timestamp" => string(now()), "timestamp_utc" => string(now(UTC)) * "Z"
         ),
         "summary" => d,
     )
@@ -525,7 +530,7 @@ function write_run_manifest(
     )
     prov = Dict{String, Any}(
         "run_id" => run_id, "script" => script, "repo_commit" => _script_repo_commit(),
-        "host" => gethostname(), "timestamp" => string(now())
+        "host" => gethostname(), "timestamp" => string(now()), "timestamp_utc" => string(now(UTC)) * "Z"
     )
     _script_repo_dirty() && (prov["repo_dirty"] = true)
     derived_from === nothing || (prov["derived_from"] = derived_from)

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using RunManifests
 using TOML
+using Dates
 
 @testset "expand_sweep — run matrix" begin
     # single axis: NX fixed, A0 swept over two values
@@ -206,4 +207,20 @@ end
     rl2 = units_from_manifest(legacy2)
     @test rl2.n0 == 1
     @test rl2.defs["omega_lab"]["value"] ≈ ω
+end
+
+@testset "timestamp_utc in every provenance block" begin
+    prov = run_provenance(; run_id = "ts", gpu_backend = "rocm", repo_dir = pkgdir(RunManifests))
+    @test haskey(prov, "timestamp_utc")
+    @test endswith(prov["timestamp_utc"], "Z")
+    # parseable after stripping the explicit-UTC suffix, and within a minute of now(UTC)
+    t = DateTime(chop(prov["timestamp_utc"]))
+    @test abs(Dates.value(now(UTC) - t)) < 60_000
+    dir = mktempdir()
+    write_run_manifest(dir; run_id = "ts", script = "x.jl")
+    m = TOML.parsefile(joinpath(dir, "run_ts.toml"))
+    @test endswith(m["provenance"]["timestamp_utc"], "Z")
+    write_derived(dir; kind = "k", label = "l", run_id = "ts", plot = "p.png", source = "s")
+    d = TOML.parsefile(joinpath(dir, only(filter(f -> startswith(f, "derived_"), readdir(dir)))))
+    @test endswith(d["provenance"]["timestamp_utc"], "Z")
 end

--- a/orchestration/backends/hotaisle.sh
+++ b/orchestration/backends/hotaisle.sh
@@ -89,9 +89,12 @@ set -e
 [ -x "$HOME/.juliaup/bin/julia" ] || curl -fsSL https://install.julialang.org | sh -s -- --yes
 export PATH="$HOME/.juliaup/bin:$PATH"   # no JULIA_PKG_SERVER: the VM uses Julia's public default (registries also ride the depot cache)
 rm -rf EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" EDM
-# VM-local config.env (gitignored ⇒ not cloned): rocm local backend, no ntfy on the VM, and
+# VM-local config.env in ~/edm-orch — orchestration lives OUTSIDE the repo (driver-pushed)
+# so the clone stays pristine and cloud runs stop tripping the repo-dirty advisory;
+# EDM_REPO points run_cell back at the clone. rocm local backend, no ntfy on the VM, and
 # REDUCE_OVERLAP=1 so each cell's reduction overlaps the next cell's GPU compute (paid-time win).
-printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\nREDUCE_OVERLAP=1\nLOCAL_CLOUD_PROVIDER=hotaisle\n' > EDM/orchestration/config.env
+mkdir -p "$HOME/edm-orch"
+printf 'LOCAL_BACKEND=rocm\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=\nREDUCE_OVERLAP=1\nLOCAL_CLOUD_PROVIDER=hotaisle\nEDM_REPO=%s\n' "$HOME/EDM" > "$HOME/edm-orch/config.env"
 BK=rocm REPO_DIR="$HOME/EDM"; . EDM/orchestration/depot_cache.sh   # julia-actions/cache semantics (default ~/.julia depot)
 depot_cache_restore   # → DC_RESTORED = exact | prefix (instantiate tops it up) | miss (fresh build)
 ok=0; for i in 1 2 3; do
@@ -108,8 +111,8 @@ vm_reachable() { [ -f "$STATE" ] && read -r NAME IP PROV_TS MIN_MIN < "$STATE" &
 
 # Overlay the driver's current orchestration/ onto the VM clone (keeping the VM's own config.env),
 # so the VM runs THIS machine's framework + campaign files — even ones not yet pushed to BRANCH.
-push_orchestration() {
-    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS" --exclude='config.env' "$ORCH/" hotaisle@"$IP":EDM/orchestration/
+push_orchestration() {   # the driver's orchestration/ → ~/edm-orch (outside the repo; VM's config.env kept)
+    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS" --exclude='config.env' "$ORCH/" hotaisle@"$IP":edm-orch/
 }
 
 # Integrity-check the downloaded reduced products: md5 each non-cube file VM-vs-local; alert on any
@@ -212,7 +215,7 @@ run_campaign() {
     # juliaup's PATH lives in .bashrc/.profile, which a non-interactive ssh shell never sources — export
     # it here or every julia invocation dies rc=127. The { …; } grouping keeps the pidfile write INSIDE
     # the cd (a bare `A && B & C` backgrounds A&&B and runs C in the ssh cwd = $HOME).
-    ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
+    ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && { nohup bash \$HOME/edm-orch/backends/local.sh \$HOME/edm-orch/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
     start_drainer || notify warning high "EDM drainer NOT started" "$CAMPAIGN on $NAME: cubes stay on the VM only; teardown gate will hold them"
     log "polling for completion (DONE marker, or driver-death = crash so we don't poll forever while billing)…"
     until ssh_vm "grep -q '\\] ${CAMPAIGN} DONE' EDM/runs/${CAMPAIGN}.out 2>/dev/null"; do

--- a/orchestration/backends/runpod.sh
+++ b/orchestration/backends/runpod.sh
@@ -238,8 +238,12 @@ export PATH="$HOME/.juliaup/bin:$PATH"   # no JULIA_PKG_SERVER: fresh pod uses J
 rm -rf ~/EDM && git clone --quiet --branch "$BRANCH" "$REPO_URL" ~/EDM   # fresh clone = always current
 if [ -n "$HAS_VOL" ]; then mkdir -p /workspace/runs && ln -sfn /workspace/runs ~/EDM/runs   # cubes persist on the volume
 else mkdir -p ~/EDM/runs; fi
-printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=%s\nREDUCE_OVERLAP=1\nLOCAL_CLOUD_PROVIDER=runpod\n' \
-    "$BK" "$JULIA_DEPOT_PATH" > ~/EDM/orchestration/config.env
+# Orchestration lives OUTSIDE the repo (~/edm-orch, driver-pushed) so the clone stays
+# pristine and cloud runs stop tripping the repo-dirty advisory; EDM_REPO points run_cell
+# back at the clone (config.env's documented override).
+mkdir -p ~/edm-orch
+printf 'LOCAL_BACKEND=%s\nLOCAL_JL_THREADS=auto\nLOCAL_PREENV=JULIA_DEPOT_PATH=%s\nREDUCE_OVERLAP=1\nLOCAL_CLOUD_PROVIDER=runpod\nEDM_REPO=%s\n' \
+    "$BK" "$JULIA_DEPOT_PATH" "$HOME/EDM" > ~/edm-orch/config.env
 REPO_DIR=~/EDM; . ~/EDM/orchestration/depot_cache.sh   # julia-actions/cache semantics over the rsync store
 depot_cache_restore   # → DC_RESTORED = exact | prefix (instantiate tops it up) | miss (fresh build)
 ok=0; for i in 1 2 3; do
@@ -261,8 +265,8 @@ pod_reachable() {
     ssh_vm true 2>/dev/null
 }
 
-push_orchestration() {   # overlay the driver's orchestration/ (keeping the pod's config.env)
-    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='config.env' "$ORCH/" root@"$IP":EDM/orchestration/
+push_orchestration() {   # the driver's orchestration/ → ~/edm-orch (outside the repo; pod's config.env kept)
+    /usr/bin/rsync -az -e "/usr/bin/ssh $SSHOPTS -p $PORT" --exclude='config.env' "$ORCH/" root@"$IP":edm-orch/
 }
 
 download_verify() {   # md5 each non-cube product pod-vs-local (subdirs included); alert on mismatch/missing
@@ -408,7 +412,7 @@ run_campaign() {
         notify hourglass_flowing_sand default "EDM runpod started" "$CAMPAIGN on $POD ($BACKEND @$DC)"
         ledger "$POD" campaign_start "campaign=$CAMPAIGN dir=$OUT/$CAMPAIGN"
         log "launching $CAMPAIGN on the pod via the local backend ($BACKEND), detached…"
-        ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && rm -f runs/${CAMPAIGN}.out runs/${CAMPAIGN}.pid && { nohup bash orchestration/backends/local.sh orchestration/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
+        ssh_vm "export PATH=\"\$HOME/.juliaup/bin:\$PATH\"; cd EDM && mkdir -p runs && rm -f runs/${CAMPAIGN}.out runs/${CAMPAIGN}.pid && { nohup bash \$HOME/edm-orch/backends/local.sh \$HOME/edm-orch/campaigns/$cname > runs/${CAMPAIGN}.out 2>&1 < /dev/null & echo \$! > runs/${CAMPAIGN}.pid; }"
     fi
     start_drainer || notify warning high "EDM drainer NOT started" "$CAMPAIGN on $POD: cubes stay on the pod only; teardown gate will hold them"
     monitor_and_download


### PR DESCRIPTION
Two provenance fixes prompted by the known-issues rollout:

1. **`timestamp_utc` in every provenance block** (RunManifests): manifest `timestamp` is machine-local with no zone — pods stamp UTC, the workstation +03 — which made cross-machine time comparisons ambiguous (the known-issue cutoff mis-tagged post-fix pod runs in a 3 h window). The new field carries an explicit `Z`; `timestamp` stays for back-compat. Dashboard-side preference for it rides PR #77 over there.
2. **Pristine pod checkouts** (runpod + hotaisle backends): the driver's `orchestration/` overlay now lands in `~/edm-orch` outside the repo (with `EDM_REPO=$HOME/EDM` in its config.env — `run_cell.sh`'s documented override) instead of overwriting the clone's tracked files. Cloud runs stop recording `repo_dirty = true` for rsync dirt, so the repo-dirty advisory keeps its signal. Outputs still land in the gitignored `EDM/runs`.

Verified: RunManifests suite green (new timestamp_utc testset); `bash -n` both backends; a full local simulation of the pod layout (out-of-repo orchestration + `EDM_REPO` override) runs a campaign with outputs in the repo's `runs/` and zero writes inside the checkout. First real validation will be the next cloud campaign — worth a smoke cell before anything big.

🤖 Generated with [Claude Code](https://claude.com/claude-code)