### PR TITLE
RunManifests: launch-time sweep declarations + EDM_SWEEP membership stamp

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -32,6 +32,7 @@ import Serialization
 export git_state, assert_committed, run_provenance, run_spec_from_manifest, expand_sweep
 export find_parent_manifest, find_parent_run, spp_from_manifest
 export write_derived, write_comparison, write_summary, write_run_manifest, write_solver_manifest, REQUIRED_CONFIG_KEYS
+export write_sweep_declaration, read_sweep_declarations
 export record_reduction!
 export units_section, units_from_manifest
 export MANIFEST_SCHEMA_VERSION, manifest_schema_version, check_schema_version
@@ -160,11 +161,15 @@ machines (e.g. the dashboard's known-issue cutoffs) should prefer it.
 
 The standard solver-run `[provenance]` block. `gpu_device` (e.g. `CUDA.name(CUDA.device())`)
 is recorded only when supplied — kept as an argument so this package stays free of any GPU
-backend dependency.
+backend dependency. `sweep_id` (default: `ENV["EDM_SWEEP"]`, as exported by
+`orchestration/run_cell.sh`) records the run's sweep-declaration membership — see
+[`write_sweep_declaration`](@ref); omitted entirely when unset, so runs outside a declared
+sweep look exactly as before.
 """
 function run_provenance(;
         run_id, gpu_backend, repo_dir,
-        script::AbstractString = abspath(PROGRAM_FILE), gpu_device = nothing
+        script::AbstractString = abspath(PROGRAM_FILE), gpu_device = nothing,
+        sweep_id = nothing
     )
     gs = git_state(repo_dir)
     prov = Dict{String, Any}(
@@ -181,6 +186,8 @@ function run_provenance(;
         "timestamp" => string(now()), "timestamp_utc" => string(now(UTC)) * "Z",
     )
     gpu_device === nothing || (prov["gpu_device"] = string(gpu_device))
+    sweep = sweep_id === nothing ? get(ENV, "EDM_SWEEP", "") : string(sweep_id)
+    isempty(sweep) || (prov["sweep_id"] = sweep)
     return prov
 end
 
@@ -545,6 +552,10 @@ function write_run_manifest(
     )
     _script_repo_dirty() && (prov["repo_dirty"] = true)
     derived_from === nothing || (prov["derived_from"] = derived_from)
+    # Analysis nodes launched under a declared sweep (EDM_SWEEP in scope) join it like
+    # solver runs do — same membership channel, same builder hook.
+    sweep = get(ENV, "EDM_SWEEP", "")
+    isempty(sweep) || (prov["sweep_id"] = sweep)
     outs = Dict{String, Any}("plots" => collect(plots))
     datafile === nothing || (outs["datafile"] = datafile)
     m = Dict{String, Any}("schema_version" => MANIFEST_SCHEMA_VERSION, "provenance" => prov, "outputs" => outs)
@@ -607,6 +618,117 @@ function write_solver_manifest(
     path = joinpath(dir, "run_$(run_id).toml")
     open(io -> TOML.print(io, m; sorted = true), path, "w")
     return path
+end
+
+# ───────────────────────── [sweep] — launch-time sweep declarations ─────────────────────
+# A sweep declaration records LAUNCH intent — which [config] knobs a campaign dir sweeps —
+# so the dashboard reads structure instead of re-detecting it from outcomes (the full
+# design lives in the dashboard repo: docs/sweep_declarations_design.md). Membership rides
+# provenance.sweep_id (stamped from EDM_SWEEP by run_cell.sh); runs without it fall to the
+# dir's default declaration for their script. The declared name is an IDENTIFIER: the
+# dashboard's stable sweep id is "<dir>:<name>", so renaming is a breaking act — `label`
+# exists for display.
+
+const SWEEP_NAME_RE = r"^[a-z0-9][a-z0-9_-]*$"
+const SWEEP_DESIGNS = ("grid", "oat")
+
+"""
+    write_sweep_declaration(dir; name, script, axes, design = "grid", hub = nothing,
+                            label = nothing) -> path
+
+Write the `sweep_<name>.toml` declaration into `dir` — the launch-time statement of a
+campaign's structure that the dashboard prefers over sweep auto-detection.
+
+  * `name` — a slug (`[a-z0-9_-]`, leading alphanumeric); becomes the stable dashboard id
+    `"<dir>:<name>"`.
+  * `script` — solver script basename; binds the default-membership rule for runs without
+    a `provenance.sweep_id`.
+  * `axes` — the swept **manifest `[config]` keys** (`"gamma"`, `"a0"`, …), NOT `EDM_*`
+    env names and NOT dashboard display names (the builder translates via its PARAM_SPEC).
+    `[]` declares an unstructured group (a card with only an extras line). Axis *values*
+    are never declared — they are recovered from the member runs, so intent cannot drift
+    from reality.
+  * `design` — `"grid"` (default; axes span a product) or `"oat"` (axes are
+    one-at-a-time arms sharing a hub cell).
+  * `hub` — optional run uuid overriding the inferred OAT hub.
+  * `label` — optional display label (defaults to `name` dashboard-side).
+
+Idempotent: rewrites `sweep_<name>.toml` in place (`run_cell.sh` calls this once per
+campaign, gated on the file's absence). Stamps `schema_version` like the other writers.
+"""
+function write_sweep_declaration(
+        dir::AbstractString; name, script, axes,
+        design = "grid", hub = nothing, label = nothing
+    )
+    n = string(name)
+    occursin(SWEEP_NAME_RE, n) || error(
+        "write_sweep_declaration: name $(repr(n)) is not a slug ([a-z0-9_-], leading " *
+            "alphanumeric) — it becomes the stable dashboard id \"<dir>:$n\"."
+    )
+    string(design) in SWEEP_DESIGNS || error(
+        "write_sweep_declaration: unknown design $(repr(string(design))) — use one of " *
+            join(SWEEP_DESIGNS, ", ") * "."
+    )
+    ax = String[string(a) for a in axes]
+    for a in ax
+        startswith(a, "EDM_") && error(
+            "write_sweep_declaration: axis $(repr(a)) uses the env spelling — axes name " *
+                "manifest [config] keys (e.g. \"gamma\", not \"EDM_GAMMA\")."
+        )
+    end
+    s = Dict{String, Any}(
+        "name" => n, "script" => string(script), "axes" => ax, "design" => string(design)
+    )
+    hub === nothing || (s["hub"] = string(hub))
+    label === nothing || (s["label"] = string(label))
+    m = Dict{String, Any}(
+        "schema_version" => MANIFEST_SCHEMA_VERSION,
+        "provenance" => Dict{String, Any}(
+            "script" => basename(PROGRAM_FILE), "repo_commit" => _script_repo_commit(),
+            "host" => gethostname(), "timestamp" => string(now()), "timestamp_utc" => string(now(UTC)) * "Z"
+        ),
+        "sweep" => s,
+    )
+    path = joinpath(dir, "sweep_$(n).toml")
+    open(io -> TOML.print(io, m; sorted = true), path, "w")
+    return path
+end
+
+"""
+    read_sweep_declarations(dir) -> Vector{NamedTuple}
+
+Parse every `sweep_*.toml` declaration in `dir` into
+`(; name, script, axes, design, hub, label, path)` rows, sorted by filename. TOMLs
+without a `[sweep]` table are skipped; a missing required key or a **duplicate name**
+errors loudly — declarations decide card structure, so ambiguity here must not pass.
+Returns an empty vector for a nonexistent `dir`.
+"""
+function read_sweep_declarations(dir::AbstractString)
+    out = NamedTuple[]
+    isdir(dir) || return out
+    seen = Set{String}()
+    for f in sort(readdir(dir))
+        (startswith(f, "sweep_") && endswith(f, ".toml")) || continue
+        m = TOML.parsefile(joinpath(dir, f))
+        haskey(m, "sweep") || continue
+        check_schema_version(m; source = f)
+        s = m["sweep"]
+        for k in ("name", "script", "axes")
+            haskey(s, k) || error("$f: [sweep] is missing $(repr(k))")
+        end
+        n = string(s["name"])
+        n in seen && error(
+            "$dir: duplicate sweep declaration name $(repr(n)) — names decide card " *
+                "structure; merge the declarations or rename one."
+        )
+        push!(seen, n)
+        push!(out, (;
+            name = n, script = string(s["script"]), axes = String.(s["axes"]),
+            design = string(get(s, "design", "grid")), hub = get(s, "hub", nothing),
+            label = get(s, "label", nothing), path = joinpath(dir, f),
+        ))
+    end
+    return out
 end
 
 # ───────────────────────── [units] — display-unit declarations ─────────────────────────

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -209,6 +209,77 @@ end
     @test rl2.defs["omega_lab"]["value"] ≈ ω
 end
 
+@testset "sweep declarations — write/read + membership stamp" begin
+    dir = mktempdir()
+    p = write_sweep_declaration(dir; name = "ll_gamma_ladder",
+        script = "inverse_thomson_scattering.jl", axes = ["gamma"], design = "oat",
+        label = "γ ladder")
+    @test basename(p) == "sweep_ll_gamma_ladder.toml"
+    m = TOML.parsefile(p)
+    @test m["schema_version"] == MANIFEST_SCHEMA_VERSION
+    @test m["sweep"]["axes"] == ["gamma"] && m["sweep"]["design"] == "oat"
+
+    # several named declarations in one dir (the γ-ladder + mini-ladder case)
+    write_sweep_declaration(dir; name = "n_iters",
+        script = "inverse_thomson_scattering.jl", axes = ["newton_iters"])
+    decls = read_sweep_declarations(dir)
+    @test [d.name for d in decls] == ["ll_gamma_ladder", "n_iters"]
+    @test decls[1].design == "oat" && decls[1].label == "γ ladder" && decls[1].hub === nothing
+    @test decls[2].design == "grid" && decls[2].label === nothing
+
+    # idempotent: rewriting a name replaces, never accumulates
+    write_sweep_declaration(dir; name = "n_iters",
+        script = "inverse_thomson_scattering.jl", axes = ["newton_iters", "gamma"])
+    decls = read_sweep_declarations(dir)
+    @test length(decls) == 2
+    @test only(filter(d -> d.name == "n_iters", decls)).axes == ["newton_iters", "gamma"]
+
+    # axes = [] declares a legitimate unstructured group (extras-only card)
+    write_sweep_declaration(dir; name = "probe-extras", script = "x.jl", axes = String[])
+    @test only(filter(d -> d.name == "probe-extras", read_sweep_declarations(dir))).axes ==
+          String[]
+
+    # validation: slug names, known designs, config-key (not env-spelled) axes
+    @test_throws ErrorException write_sweep_declaration(dir; name = "Bad Name",
+        script = "x.jl", axes = ["a0"])
+    @test_throws ErrorException write_sweep_declaration(dir; name = "x",
+        script = "x.jl", axes = ["a0"], design = "star")
+    @test_throws ErrorException write_sweep_declaration(dir; name = "x",
+        script = "x.jl", axes = ["EDM_GAMMA"])
+
+    # duplicate names across files error loudly — declarations decide card structure
+    dup = mktempdir()
+    write_sweep_declaration(dup; name = "s", script = "a.jl", axes = ["a0"])
+    mv(joinpath(dup, "sweep_s.toml"), joinpath(dup, "sweep_s2.toml"))
+    write_sweep_declaration(dup; name = "s", script = "b.jl", axes = ["gamma"])
+    @test_throws ErrorException read_sweep_declarations(dup)
+
+    # membership stamp: EDM_SWEEP → provenance.sweep_id on solver AND analysis nodes;
+    # omitted entirely when unset (legacy manifests stay byte-identical).
+    withenv("EDM_SWEEP" => "ll_gamma_ladder") do
+        prov = run_provenance(; run_id = "sw", gpu_backend = "cuda",
+            repo_dir = pkgdir(RunManifests))
+        @test prov["sweep_id"] == "ll_gamma_ladder"
+        d2 = mktempdir()
+        write_run_manifest(d2; run_id = "sw", script = "x.jl")
+        @test TOML.parsefile(joinpath(d2, "run_sw.toml"))["provenance"]["sweep_id"] ==
+              "ll_gamma_ladder"
+    end
+    withenv("EDM_SWEEP" => nothing) do
+        prov = run_provenance(; run_id = "sw2", gpu_backend = "cuda",
+            repo_dir = pkgdir(RunManifests))
+        @test !haskey(prov, "sweep_id")
+        @test run_provenance(; run_id = "sw3", gpu_backend = "cuda",
+            repo_dir = pkgdir(RunManifests), sweep_id = "explicit")["sweep_id"] == "explicit"
+        d3 = mktempdir()
+        write_run_manifest(d3; run_id = "sw4", script = "x.jl")
+        @test !haskey(TOML.parsefile(joinpath(d3, "run_sw4.toml"))["provenance"], "sweep_id")
+    end
+
+    # a nonexistent dir reads as no declarations (callers probe dirs freely)
+    @test isempty(read_sweep_declarations(joinpath(dir, "nope")))
+end
+
 @testset "dashboard client — browse + lazy load" begin
     # A file:// dashboard fixture: index.json + data/<uuid>/<file>, the same layout the
     # live hosts serve — libcurl's file protocol stands in for Caddy.

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -30,6 +30,13 @@
 #             multi-cell win). Reaped (+ cube policy) by reap_reduces ⇒ requires the run_cells path.
 #   REDUCE_HOOK optional command (receives the uuid as $1) replacing the default cube→products
 #             reducer used in overlap mode (default: harmonic_products.jl + plot_screen_observables.jl)
+#   SWEEP_AXES  optional: declares the campaign's sweep — comma/space-separated manifest
+#             [config] keys (e.g. "gamma" or "a0,interp_saveat"; NOT EDM_* spellings).
+#             When set, the first cell writes $CAMP/sweep_<name>.toml (idempotent) and every
+#             cell is stamped with provenance.sweep_id = <name> via EDM_SWEEP (a per-cell
+#             EDM_SWEEP=other override wins — that's how one dir hosts several named sweeps).
+#   SWEEP_NAME  declaration name, a slug (default: $CAMPAIGN, else basename $CAMP)
+#   SWEEP_DESIGN grid (default) | oat        SWEEP_LABEL optional display label
 # Usage: run_cell <label> [EDM_VAR=val ...]   (per-cell overrides win — env is last-wins)
 : "${SCRIPT:=scripts/thomson_scattering.jl}"
 
@@ -115,10 +122,32 @@ _reduce_cell() {
     fi
 }
 
+# Materialize the campaign's sweep declaration (launch intent → the dashboard's card
+# structure; see RunManifests.write_sweep_declaration). Called from run_cell so it works on
+# every backend path (run_cells loop AND per-task SLURM cells) — first cell writes it,
+# later cells hit the [ -f ] gate. Failure degrades to detection, never aborts a campaign.
+_write_sweep_decl() {
+    [ -n "${SWEEP_AXES:-}" ] || return 0
+    : "${SWEEP_NAME:=${CAMPAIGN:-$(basename "$CAMP")}}"
+    [ -f "$CAMP/sweep_${SWEEP_NAME}.toml" ] && return 0
+    ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} \
+          SWEEP_DECL_DIR="$CAMP" SWEEP_DECL_NAME="$SWEEP_NAME" SWEEP_DECL_AXES="$SWEEP_AXES" \
+          SWEEP_DECL_SCRIPT="$(basename "$SCRIPT")" SWEEP_DECL_DESIGN="${SWEEP_DESIGN:-grid}" \
+          SWEEP_DECL_LABEL="${SWEEP_LABEL:-}" \
+          "${JL[@]}" --project=scripts -e 'using RunManifests
+              write_sweep_declaration(ENV["SWEEP_DECL_DIR"];
+                  name = ENV["SWEEP_DECL_NAME"], script = ENV["SWEEP_DECL_SCRIPT"],
+                  axes = split(replace(ENV["SWEEP_DECL_AXES"], "," => " ")),
+                  design = ENV["SWEEP_DECL_DESIGN"],
+                  label = isempty(ENV["SWEEP_DECL_LABEL"]) ? nothing : ENV["SWEEP_DECL_LABEL"])' ) \
+        || echo "[warn] sweep declaration write failed — campaign continues (dashboard falls back to detection)" >&2
+}
+
 run_cell() {
     local label=$1; shift
     local uuid; uuid=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
     mkdir -p "$CAMP"
+    _write_sweep_decl
     # Disk gate (adaptive, KEEP_CUBE campaigns): container-disk quotas are enforced LAZILY —
     # a cube write into a full disk "succeeds" and only surfaces as EOFError at reduce time
     # (2026-07-19 incident). Cell 1 sets the scale; later cells wait until free space ≥ 1.25×
@@ -144,6 +173,7 @@ run_cell() {
     echo "[$(date -u +%FT%TZ)] cell $label  [$(basename "$SCRIPT") ${BACKEND:-?}]  keep=${KEEP_CUBE:-0} overlap=${REDUCE_OVERLAP:-0}  $uuid :: ${*:-<baseline>}"
     # shellcheck disable=SC2086
     ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} ${BASE[@]+"${BASE[@]}"} $skip \
+          ${SWEEP_NAME:+EDM_SWEEP="$SWEEP_NAME"} \
           EDM_GPU_BACKEND="$BACKEND" EDM_CLOUD_PROVIDER="$PROVIDER" EDM_OUTDIR="$CAMP" EDM_RUN_TAG="$uuid" "$@" \
           "${JL[@]}" --project=scripts "$SCRIPT" ) > "$log" 2>&1
     local rc=$?


### PR DESCRIPTION
Slice 1 of the sweep-declaration design (SebastianM-C/EDM_results_dashboard#84 has the design doc; backfill tracking in SebastianM-C/EDM_results_dashboard#83).

## Summary
- `write_sweep_declaration` / `read_sweep_declarations` in RunManifests own the `sweep_<name>.toml` schema: slug `name` (dashboard id = `<dir>:<name>`), `script`, `axes` as manifest `[config]` keys (`EDM_*` spellings rejected; axis values never declared), `design = grid|oat` (+ optional `hub`, `label`). Duplicate names per dir error loudly; `axes = []` declares an unstructured group.
- Membership via `provenance.sweep_id` (the dormant hook the dashboard builder already parses): `run_provenance` and `write_run_manifest` stamp it from `EDM_SWEEP`, omitted entirely when unset — legacy manifests stay byte-identical.
- `run_cell.sh`: campaigns set `SWEEP_AXES` (comma/space config keys) and optionally `SWEEP_NAME`/`SWEEP_DESIGN`/`SWEEP_LABEL`; the first cell writes the declaration idempotently (works for both the `run_cells` loop and per-task SLURM cells; a write failure warns and degrades to detection), and every cell exports `EDM_SWEEP` with per-cell overrides winning — one dir can host several named sweeps.

## Test plan
- `Pkg.test()` green: 19 new tests — write/read roundtrip, multiple named declarations per dir, idempotent rewrite, empty axes, slug/design/env-spelling validation, duplicate-name error, `EDM_SWEEP` stamping on solver + analysis provenance (and its absence when unset).
- `bash -n` on run_cell.sh + end-to-end `_write_sweep_decl` through the scripts env: comma axes split, oat design honored, second call is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)