### PR TITLE
RunManifests: ThomsonScatteringSpec — the typed run spec (PR 1 of 2)

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -31,6 +31,7 @@ import Scratch
 import Serialization
 
 export git_state, assert_committed, run_provenance, run_spec_from_manifest, expand_sweep
+export ThomsonScatteringSpec, load_spec, write_spec, spec_env, spec_from_manifest, config_dict
 export find_parent_manifest, find_parent_run, spp_from_manifest
 export write_derived, write_comparison, write_summary, write_run_manifest, write_solver_manifest, REQUIRED_CONFIG_KEYS
 export write_sweep_declaration, read_sweep_declarations
@@ -206,52 +207,21 @@ function run_spec_from_manifest(manifest::AbstractDict)
     prov = get(manifest, "provenance", Dict())
     commit = get(prov, "repo_commit", "unknown")
     cfg = get(manifest, "config", Dict())
-    # EDM_* knobs come from `config` (the input layer / echo of ENV — authoritative for
-    # replay, matching the dashboard's PARAM_SPEC); `gpu_backend` lives in `provenance`.
-    env = Dict{String, String}()
-    env["EDM_INITIAL_PHASE"] = string(cfg["initial_phase"])
-    env["EDM_A0"] = string(cfg["a0"])
-    env["EDM_NX"] = string(cfg["Nx"])
-    env["EDM_N"] = string(cfg["N"])
-    env["EDM_NSAMPLES"] = string(cfg["N_samples"])
-    env["EDM_SPP"] = string(cfg["samples_per_period"])
-    env["EDM_NSUBSTEPS"] = string(cfg["n_substeps"])
+    miss = [k for k in REQUIRED_CONFIG_KEYS if !haskey(cfg, k)]
+    isempty(miss) || error(
+        "run manifest [config] is missing replay key(s) $(join(miss, ", ")) — " *
+            "cannot reproduce this run."
+    )
+    # One knob ⇄ env mapping for the whole package: the manifest becomes a
+    # ThomsonScatteringSpec and the spec emits its transport (spec.jl). Guarded-knob
+    # semantics are the spec's nothing-means-script-default contract, so a legacy run
+    # still never grows env out of thin air — while knobs the old hand-rolled emission
+    # dropped (EDM_SYSTEM, EDM_OMEGA_SCALE, EDM_SCREEN_HALFW, EDM_POL, EDM_GAMMA_EPS)
+    # now replay faithfully.
+    env = spec_env(spec_from_manifest(manifest))
     env["EDM_GPU_BACKEND"] = string(prov["gpu_backend"])
-    env["EDM_SYNC_PER_ELECTRON"] = string(cfg["sync_per_electron"])
-    env["EDM_FIELD_MODE"] = string(get(cfg, "mode", "split"))   # default keeps pre-mode manifests replaying as before
-    # Inverse-Thomson knobs (inverse_thomson_scattering.jl) — guarded: absent in rest-electron
-    # manifests. Without these a "reproduce" of a boosted/narrow run silently reran the γ=10
-    # :full defaults (and misused the narrow-mode auto-sized N_samples as a :full window length).
-    haskey(cfg, "gamma") && (env["EDM_GAMMA"] = string(cfg["gamma"]))
-    haskey(cfg, "window") && (env["EDM_WINDOW"] = string(cfg["window"]))
-    haskey(cfg, "screen_hw_w0") && (env["EDM_SCREEN_HW"] = string(cfg["screen_hw_w0"]))
-    haskey(cfg, "harmonics") && (env["EDM_HARMONICS"] = join(cfg["harmonics"], ","))
-    haskey(cfg, "tspan_tau") && (env["EDM_TSPAN_TAU"] = string(cfg["tspan_tau"]))
-    haskey(cfg, "window_lead") && (env["EDM_WINDOW_LEAD"] = string(cfg["window_lead"]))
-    haskey(cfg, "window_tail") && (env["EDM_WINDOW_TAIL"] = string(cfg["window_tail"]))
-    haskey(cfg, "bunch_nb") && (env["EDM_BUNCH_NB"] = string(cfg["bunch_nb"]))
-    haskey(cfg, "bunch_l") && (env["EDM_BUNCH_L"] = string(cfg["bunch_l"]))
-    haskey(cfg, "bunch_chirp") && (env["EDM_BUNCH_CHIRP"] = string(cfg["bunch_chirp"]))
-    # Retarded-time kernel: manifest stores the dashboard-canonical type name; replay re-emits the knob.
-    if get(cfg, "accumulation_alg", "") == "GPUKernelNewton"
-        env["EDM_ACCUM_ALG"] = "newton"
-        haskey(cfg, "newton_iters") && (env["EDM_NEWTON_ITERS"] = string(cfg["newton_iters"]))
-    end
-    haskey(cfg, "reltol") && (env["EDM_RELTOL"] = string(cfg["reltol"]))
-    haskey(cfg, "abstol") && (env["EDM_ABSTOL"] = string(cfg["abstol"]))
-    # Retarded-time GPU solver — guarded: absent in pre-Newton manifests (⇒ rk4 default).
-    # The manifest records the dashboard-canonical kernel name; emit BOTH knob spellings so
-    # replay works on any pinned commit (EDM_ACCUM_ALG = canonical, EDM_GPU_SOLVER = the
-    # legacy alias the first newton-campaign scripts read).
-    solver_env = Dict("GPUKernelRK4" => "rk4", "GPUKernelNewton" => "newton")
-    alg = get(cfg, "accumulation_alg", nothing)
-    if haskey(solver_env, alg)
-        env["EDM_ACCUM_ALG"] = solver_env[alg]
-        env["EDM_GPU_SOLVER"] = solver_env[alg]
-    end
-    haskey(cfg, "newton_iters") && (env["EDM_NEWTON_ITERS"] = string(cfg["newton_iters"]))
-    sv = get(cfg, "interp_saveat", "adaptive")
-    sv != "adaptive" && (env["EDM_INTERP_SAVEAT"] = string(sv))
+    # Pre-mode manifests replay as :split — the scripts' default then and now.
+    get!(env, "EDM_FIELD_MODE", "split")
     return (; commit, env)
 end
 
@@ -819,6 +789,7 @@ function units_from_manifest(m::AbstractDict)
     return (; system = u["system"], defs, preferred = pref, n0)
 end
 
+include("spec.jl")
 include("remote.jl")
 
 end # module RunManifests

--- a/lib/RunManifests/src/spec.jl
+++ b/lib/RunManifests/src/spec.jl
@@ -1,0 +1,261 @@
+# ───────────────────────── ThomsonScatteringSpec — the typed run spec ────────────────────
+# The shared physical + numerical STARTING POINT of every run: all scripts (thomson_
+# scattering / lpwa / inverse_thomson_scattering / analyze_trajectories) are operations
+# applied to the same scattering problem, so one spec type serves authoring (campaign
+# recipes), provenance (the manifest [config] echo), and analysis (the dashboard client).
+# The executor is deliberately NOT part of the spec — the same spec can be run by the
+# numeric solver or the LPWA analytic path (that's what the clincher comparisons do);
+# `SCRIPT` stays orchestration, and provenance records which one ran.
+#
+# Field vocabulary = manifest [config] keys (the same vocabulary sweep declarations use),
+# NOT `EDM_*` env spellings. `nothing` means "the script decides": defaults — including
+# computed ones like the inverse script's γ-derived N_samples — stay script-side, and the
+# manifest records the RESOLVED values, exactly as before. Knobs without a field (script-
+# owned keys like `scattering`, analysis-only `err_*`, derived `backscatter_n0`) ride the
+# `extra` dict, so no context is ever dropped.
+
+Base.@kwdef struct ThomsonScatteringSpec
+    initial_phase::Union{Nothing, Float64} = nothing
+    a0::Union{Nothing, Float64} = nothing
+    Nx::Union{Nothing, Int} = nothing
+    N::Union{Nothing, Int} = nothing
+    N_samples::Union{Nothing, Int} = nothing
+    samples_per_period::Union{Nothing, Int} = nothing
+    n_substeps::Union{Nothing, Int} = nothing
+    sync_per_electron::Union{Nothing, Bool} = nothing
+    mode::Union{Nothing, String} = nothing              # split | total
+    accumulation_alg::Union{Nothing, String} = nothing  # canonical: GPUKernelRK4 | GPUKernelNewton
+    newton_iters::Union{Nothing, Int} = nothing
+    reltol::Union{Nothing, Float64} = nothing
+    abstol::Union{Nothing, Float64} = nothing           # nothing ⇒ the script's abserr(a0)
+    interp_saveat::Union{Nothing, String} = nothing     # "adaptive" | knots-per-period as string
+    pol::Union{Nothing, String} = nothing
+    omega_scale::Union{Nothing, Float64} = nothing
+    screen_halfw::Union{Nothing, Float64} = nothing
+    gamma::Union{Nothing, Float64} = nothing
+    gamma_eps::Union{Nothing, Float64} = nothing        # ε = γ−1; wins over gamma at emission
+    system::Union{Nothing, String} = nothing            # classical | ll
+    window::Union{Nothing, String} = nothing            # full | narrow
+    screen_hw_w0::Union{Nothing, Float64} = nothing
+    tspan_tau::Union{Nothing, Float64} = nothing
+    window_lead::Union{Nothing, Float64} = nothing
+    window_tail::Union{Nothing, Float64} = nothing
+    harmonics::Union{Nothing, Vector{Float64}} = nothing
+    bunch_nb::Union{Nothing, Int} = nothing
+    bunch_l::Union{Nothing, Int} = nothing
+    bunch_chirp::Union{Nothing, Float64} = nothing
+    extra::Dict{String, Any} = Dict{String, Any}()
+end
+
+# field ⇄ env transport, for the straightforward knobs. The special cases — abstol's
+# ""-means-derived, interp_saveat's adaptive skip, the accumulation_alg value map + legacy
+# alias, the γ/ε exclusivity — are handled explicitly in load_spec/spec_env below.
+const _SPEC_ENV = (
+    (:initial_phase, "EDM_INITIAL_PHASE"), (:a0, "EDM_A0"), (:Nx, "EDM_NX"),
+    (:N, "EDM_N"), (:N_samples, "EDM_NSAMPLES"), (:samples_per_period, "EDM_SPP"),
+    (:n_substeps, "EDM_NSUBSTEPS"), (:sync_per_electron, "EDM_SYNC_PER_ELECTRON"),
+    (:mode, "EDM_FIELD_MODE"), (:newton_iters, "EDM_NEWTON_ITERS"),
+    (:reltol, "EDM_RELTOL"), (:abstol, "EDM_ABSTOL"),
+    (:interp_saveat, "EDM_INTERP_SAVEAT"),
+    (:pol, "EDM_POL"), (:omega_scale, "EDM_OMEGA_SCALE"),
+    (:screen_halfw, "EDM_SCREEN_HALFW"), (:gamma, "EDM_GAMMA"),
+    (:gamma_eps, "EDM_GAMMA_EPS"), (:system, "EDM_SYSTEM"), (:window, "EDM_WINDOW"),
+    (:screen_hw_w0, "EDM_SCREEN_HW"), (:tspan_tau, "EDM_TSPAN_TAU"),
+    (:window_lead, "EDM_WINDOW_LEAD"), (:window_tail, "EDM_WINDOW_TAIL"),
+    (:harmonics, "EDM_HARMONICS"), (:bunch_nb, "EDM_BUNCH_NB"),
+    (:bunch_l, "EDM_BUNCH_L"), (:bunch_chirp, "EDM_BUNCH_CHIRP"),
+)
+
+const _ALG_TO_ENV = Dict("GPUKernelRK4" => "rk4", "GPUKernelNewton" => "newton")
+const _ENV_TO_ALG = Dict(v => k for (k, v) in _ALG_TO_ENV)
+
+_spec_fieldtype(f::Symbol) = fieldtype(ThomsonScatteringSpec, f)
+_base_type(::Type{Union{Nothing, T}}) where {T} = T
+
+# Coerce a TOML/manifest value into a field's base type (Int → Float64, Vector{Int} →
+# Vector{Float64}, …). Loud on genuinely wrong shapes — a spec typo must not run.
+_coerce(::Type{Float64}, v::Real) = Float64(v)
+_coerce(::Type{Int}, v::Integer) = Int(v)
+_coerce(::Type{Bool}, v::Bool) = v
+_coerce(::Type{Bool}, v::Integer) = v == 1 ? true : v == 0 ? false :
+    error("spec: cannot use $v for a Bool field (want true/false or 0/1)")
+_coerce(::Type{String}, v) = string(v)
+_coerce(::Type{Vector{Float64}}, v::AbstractVector) = Float64[Float64(x) for x in v]
+_coerce(::Type{T}, v) where {T} =
+    error("spec: cannot use $(repr(v)) ($(typeof(v))) for a $(T) field")
+
+# Parse an env-var string into a field's base type.
+_parse_env(::Type{Float64}, s) = parse(Float64, s)
+_parse_env(::Type{Int}, s) = parse(Int, s)
+_parse_env(::Type{Bool}, s) = parse(Bool, lowercase(s))
+_parse_env(::Type{String}, s) = String(s)
+_parse_env(::Type{Vector{Float64}}, s) = Float64[parse(Float64, x) for x in split(s, ",")]
+
+# Rebuild a spec with some fields replaced (specs are immutable; `extra` is copied).
+function _respec(s::ThomsonScatteringSpec; kw...)
+    vals = Dict{Symbol, Any}(f => getfield(s, f) for f in fieldnames(ThomsonScatteringSpec))
+    vals[:extra] = copy(s.extra)
+    for (k, v) in kw
+        haskey(vals, k) || error("spec: unknown field $(repr(k)) — fields use manifest " *
+                                 "[config] names (e.g. :gamma, :samples_per_period)")
+        vals[k] = v === nothing ? nothing : _coerce(_base_type(_spec_fieldtype(k)), v)
+    end
+    return ThomsonScatteringSpec(; vals...)
+end
+
+"""
+    write_spec(path, spec::ThomsonScatteringSpec) -> path
+
+Write a spec TOML: top-level `schema_version` + a `[spec]` table holding every set field
+(manifest `[config]` vocabulary) with `extra` entries inlined. The inverse of
+[`load_spec`](@ref) without its env layer.
+"""
+function write_spec(path::AbstractString, spec::ThomsonScatteringSpec)
+    s = Dict{String, Any}(string(k) => v for (k, v) in pairs(spec.extra))
+    for f in fieldnames(ThomsonScatteringSpec)
+        f === :extra && continue
+        v = getfield(spec, f)
+        v === nothing || (s[string(f)] = v)
+    end
+    m = Dict{String, Any}("schema_version" => MANIFEST_SCHEMA_VERSION, "spec" => s)
+    open(io -> TOML.print(io, m; sorted = true), path, "w")
+    return path
+end
+
+"""
+    load_spec(path = get(ENV, "EDM_SPEC", nothing); env = ENV) -> ThomsonScatteringSpec
+
+The solver-side entry point: read the spec file (skipped when `path === nothing` — the
+env-only legacy path) and apply `EDM_*` overrides on top, env winning — the same
+last-wins ergonomics `run_cell`'s per-cell overrides rely on. Unknown `[spec]` keys land
+in `extra`; unknown `EDM_*` vars are ignored (infra: `EDM_OUTDIR`, `EDM_RUN_TAG`, …).
+Env special cases mirror the scripts: `EDM_ABSTOL=""` means "derive from a0" (nothing),
+`EDM_INTERP_SAVEAT=""` means adaptive, `EDM_ACCUM_ALG`/legacy `EDM_GPU_SOLVER` carry
+`rk4|newton` and store the canonical kernel name.
+"""
+function load_spec(path = get(ENV, "EDM_SPEC", nothing); env = ENV)
+    spec = ThomsonScatteringSpec()
+    if path !== nothing
+        m = TOML.parsefile(String(path))
+        check_schema_version(m; source = basename(String(path)))
+        s = get(m, "spec", Dict{String, Any}())
+        kw = Dict{Symbol, Any}()
+        for (k, v) in s
+            f = Symbol(k)
+            if f !== :extra && hasfield(ThomsonScatteringSpec, f)
+                kw[f] = _coerce(_base_type(_spec_fieldtype(f)), v)
+            else
+                spec.extra[String(k)] = v
+            end
+        end
+        spec = _respec(spec; kw...)
+    end
+    kw = Dict{Symbol, Any}()
+    for (f, key) in _SPEC_ENV
+        haskey(env, key) || continue
+        raw = env[key]
+        if isempty(raw) && f in (:abstol, :interp_saveat)
+            kw[f] = nothing            # the scripts' ""-means-default contract
+        else
+            kw[f] = _parse_env(_base_type(_spec_fieldtype(f)), raw)
+        end
+    end
+    alg = lowercase(get(env, "EDM_ACCUM_ALG", get(env, "EDM_GPU_SOLVER", "")))
+    isempty(alg) || (kw[:accumulation_alg] = get(_ENV_TO_ALG, alg) do
+        error("EDM_ACCUM_ALG must be \"rk4\" or \"newton\", got $(repr(alg))")
+    end)
+    return _respec(spec; kw...)
+end
+
+"""
+    spec_env(spec::ThomsonScatteringSpec) -> Dict{String,String}
+
+The `EDM_*` environment that transports this spec to the current (env-reading) scripts —
+set fields only, so a legacy run never grows env out of thin air. Special cases:
+`interp_saveat = "adaptive"` is the scripts' default and is omitted; `accumulation_alg`
+emits both the canonical `EDM_ACCUM_ALG` and the legacy `EDM_GPU_SOLVER` alias (pinned
+old commits read only the latter); `gamma_eps` wins over `gamma` (the scripts reject
+both being set — and ε is the higher-fidelity form near rest). `extra` does not emit:
+it has no env transport by construction.
+"""
+function spec_env(spec::ThomsonScatteringSpec)
+    env = Dict{String, String}()
+    for (f, key) in _SPEC_ENV
+        v = getfield(spec, f)
+        v === nothing && continue
+        f === :interp_saveat && v == "adaptive" && continue
+        f === :gamma && spec.gamma_eps !== nothing && continue   # ε wins; scripts reject both
+        # Integral harmonics emit without the ".0" — byte-identical to the old
+        # join-the-manifest-Ints emission (display/filenames re-integerize either way).
+        env[key] = v isa Vector ?
+            join((isinteger(x) ? string(Int(x)) : string(x) for x in v), ",") : string(v)
+    end
+    if spec.accumulation_alg !== nothing
+        alg = get(_ALG_TO_ENV, spec.accumulation_alg) do
+            error("spec: unknown accumulation_alg $(repr(spec.accumulation_alg)) — " *
+                  "use the canonical kernel name (GPUKernelRK4 | GPUKernelNewton)")
+        end
+        env["EDM_ACCUM_ALG"] = alg
+        env["EDM_GPU_SOLVER"] = alg
+    end
+    return env
+end
+
+"""
+    spec_from_manifest(manifest) -> ThomsonScatteringSpec
+
+The spec a stored run manifest attests: typed fields from `[config]` (coerced), every
+unmapped `[config]` key preserved in `extra` (script-owned keys like `scattering`,
+derived ones like `backscatter_n0`, analysis knobs). Reads `[config]` only — `[laser]`
+and `[setup]` are DERIVED quantities the scripts compute from these inputs.
+"""
+function spec_from_manifest(manifest::AbstractDict)
+    cfg = get(manifest, "config", Dict{String, Any}())
+    spec = ThomsonScatteringSpec()
+    kw = Dict{Symbol, Any}()
+    for (k, v) in cfg
+        f = Symbol(k)
+        if f !== :extra && hasfield(ThomsonScatteringSpec, f)
+            kw[f] = _coerce(_base_type(_spec_fieldtype(f)), v)
+        else
+            spec.extra[String(k)] = v
+        end
+    end
+    return _respec(spec; kw...)
+end
+
+"""
+    config_dict(spec::ThomsonScatteringSpec) -> Dict{String,Any}
+
+The manifest `[config]` section this spec resolves to: set fields under their config
+keys, `extra` merged in. `spec_from_manifest ∘ write_solver_manifest ∘ config_dict`
+round-trips — the write side of the spec ⇄ manifest contract the pilot script will use.
+"""
+function config_dict(spec::ThomsonScatteringSpec)
+    d = Dict{String, Any}(k => v for (k, v) in pairs(spec.extra))
+    for f in fieldnames(ThomsonScatteringSpec)
+        f === :extra && continue
+        v = getfield(spec, f)
+        v === nothing || (d[string(f)] = v)
+    end
+    return d
+end
+
+"""
+    expand_sweep(base::ThomsonScatteringSpec, vary) -> Vector{ThomsonScatteringSpec}
+
+The spec-native sweep expansion: `vary` maps FIELD names (manifest vocabulary — `:gamma`,
+`"samples_per_period"`) to value lists; returns one spec per cartesian-product point,
+`base` carried through. Pure — materialize cells with [`write_spec`](@ref) and hand them
+to `run_cell` via `EDM_SPEC=<path>` in the existing per-cell overrides. The env-dict
+method (knob spellings, e.g. `"A0"`) remains for the legacy launcher path.
+"""
+function expand_sweep(base::ThomsonScatteringSpec, vary::AbstractDict)
+    ks = sort(Symbol.(collect(keys(vary))))
+    vals = [vary[k] for k in sort(collect(keys(vary)); by = k -> Symbol(k))]
+    out = ThomsonScatteringSpec[]
+    for point in Iterators.product(vals...)
+        push!(out, _respec(base; (k => v for (k, v) in zip(ks, point))...))
+    end
+    return out
+end

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -209,6 +209,86 @@ end
     @test rl2.defs["omega_lab"]["value"] ≈ ω
 end
 
+@testset "ThomsonScatteringSpec — file ⇄ env ⇄ manifest" begin
+    dir = mktempdir()
+
+    # write_spec / load_spec roundtrip: typed coercion, extra passthrough, schema stamp.
+    s0 = ThomsonScatteringSpec(; a0 = 2, gamma = 10, samples_per_period = 2048,
+        accumulation_alg = "GPUKernelNewton", harmonics = [199, 299],
+        extra = Dict{String, Any}("scattering" => "inverse"))
+    @test s0.a0 === 2.0 && s0.harmonics == [199.0, 299.0]     # Int → Float64 coercion
+    p = write_spec(joinpath(dir, "spec_cell.toml"), s0)
+    m = TOML.parsefile(p)
+    @test m["schema_version"] == MANIFEST_SCHEMA_VERSION
+    @test m["spec"]["scattering"] == "inverse"                 # extra inlined
+    s1 = load_spec(p; env = Dict{String, String}())
+    @test s1.a0 == 2.0 && s1.gamma == 10.0 && s1.accumulation_alg == "GPUKernelNewton"
+    @test s1.extra["scattering"] == "inverse"
+    @test s1.N === nothing                                     # unset stays script-default
+
+    # env overrides win over the file; special cases mirror the scripts.
+    env = Dict("EDM_A0" => "0.5", "EDM_SYNC_PER_ELECTRON" => "true",
+        "EDM_ABSTOL" => "", "EDM_INTERP_SAVEAT" => "16",
+        "EDM_GPU_SOLVER" => "rk4",                             # legacy alias honored
+        "EDM_HARMONICS" => "1,2.5", "EDM_OUTDIR" => "/ignored")
+    s2 = load_spec(p; env)
+    @test s2.a0 == 0.5 && s2.gamma == 10.0                     # override + carry-through
+    @test s2.sync_per_electron === true && s2.abstol === nothing
+    @test s2.interp_saveat == "16" && s2.harmonics == [1.0, 2.5]
+    @test s2.accumulation_alg == "GPUKernelRK4"
+    @test load_spec(nothing; env).a0 == 0.5                    # env-only legacy path
+
+    # spec_env emission: dual alg knobs, integral harmonics without ".0", ε beats γ,
+    # adaptive omitted, unset fields never emit.
+    e = spec_env(ThomsonScatteringSpec(; a0 = 1.0, gamma = 1.001, gamma_eps = 0.001,
+        accumulation_alg = "GPUKernelNewton", harmonics = [199, 1.0936],
+        interp_saveat = "adaptive", sync_per_electron = false))
+    @test e["EDM_GAMMA_EPS"] == "0.001" && !haskey(e, "EDM_GAMMA")
+    @test e["EDM_ACCUM_ALG"] == "newton" && e["EDM_GPU_SOLVER"] == "newton"
+    @test e["EDM_HARMONICS"] == "199,1.0936"
+    @test e["EDM_SYNC_PER_ELECTRON"] == "false"
+    @test !haskey(e, "EDM_INTERP_SAVEAT") && !haskey(e, "EDM_NX")
+
+    # config_dict → manifest → spec_from_manifest roundtrip; unmapped keys ride extra.
+    cfg = config_dict(s0)
+    @test cfg["a0"] == 2.0 && cfg["scattering"] == "inverse"
+    for k in REQUIRED_CONFIG_KEYS
+        get!(cfg, k, 1)                                        # writer contract
+    end
+    prov = run_provenance(; run_id = "sp", gpu_backend = "cuda", repo_dir = pkgdir(RunManifests))
+    path = write_solver_manifest(dir; run_id = "sp", provenance = prov, config = cfg,
+        laser = Dict(), setup = Dict(), outputs = Dict("plots" => String[]))
+    s3 = spec_from_manifest(TOML.parsefile(path))
+    @test s3.a0 == 2.0 && s3.gamma == 10.0 && s3.harmonics == [199.0, 299.0]
+    @test s3.extra["scattering"] == "inverse"
+
+    # run_spec_from_manifest is table-driven now: previously-dropped knobs replay, and
+    # ε-manifests emit EDM_GAMMA_EPS instead of a rounded EDM_GAMMA.
+    cfg2 = Dict{String, Any}(k => 1 for k in REQUIRED_CONFIG_KEYS)
+    cfg2["gamma_eps"] = 0.001
+    cfg2["gamma"] = 1.001
+    cfg2["system"] = "ll"
+    cfg2["omega_scale"] = 19.9
+    path2 = write_solver_manifest(dir; run_id = "sp2", provenance = prov, config = cfg2,
+        laser = Dict(), setup = Dict(), outputs = Dict("plots" => String[]))
+    env2 = run_spec_from_manifest(TOML.parsefile(path2)).env
+    @test env2["EDM_GAMMA_EPS"] == "0.001" && !haskey(env2, "EDM_GAMMA")
+    @test env2["EDM_SYSTEM"] == "ll" && env2["EDM_OMEGA_SCALE"] == "19.9"
+    @test env2["EDM_FIELD_MODE"] == "split"                    # pre-mode default preserved
+    # missing required keys fail loudly, not with a KeyError deep in emission
+    @test_throws ErrorException run_spec_from_manifest(Dict{String, Any}(
+        "schema_version" => 1, "config" => Dict{String, Any}("a0" => 1)))
+
+    # spec-native sweep expansion: cartesian product, base carried, field vocabulary.
+    cells = expand_sweep(ThomsonScatteringSpec(; a0 = 1.0),
+        Dict("gamma" => [10, 100], "newton_iters" => [1, 2]))
+    @test length(cells) == 4
+    @test all(c -> c.a0 == 1.0, cells)
+    @test Set((c.gamma, c.newton_iters) for c in cells) ==
+          Set([(10.0, 1), (10.0, 2), (100.0, 1), (100.0, 2)])
+    @test_throws ErrorException expand_sweep(ThomsonScatteringSpec(), Dict("nope" => [1]))
+end
+
 @testset "sweep declarations — write/read + membership stamp" begin
     dir = mktempdir()
     p = write_sweep_declaration(dir; name = "ll_gamma_ladder",


### PR DESCRIPTION
First of the two RunSpec PRs agreed in discussion (design recap below; pilot-script migration is PR 2).

## Design (as agreed)
- `ThomsonScatteringSpec` = the shared physical + numerical **starting point**; recompute vs analyze is orthogonal, so the executor script is deliberately NOT a spec field (the clincher/floor_probe comparisons run one spec under two solvers).
- Field vocabulary = manifest `[config]` keys (same vocabulary as sweep declarations); `nothing` = "script decides" — computed defaults (inverse's γ-derived `N_samples`) stay script-side and the manifest records the **resolved** values, preserving the guarded-knob replay contract at the type level. Unmapped knobs ride `extra` so no context drops.
- Precedence: `EDM_SPEC` file < `EDM_*` env (last-wins ergonomics kept — per-cell overrides and one-off tweaks work unchanged); `EDM_SPEC` travels through the existing `run_cell` overrides mechanism, zero orchestration changes.

## Surface
`load_spec` / `write_spec` / `spec_env` / `spec_from_manifest` / `config_dict` + spec-native `expand_sweep(base, vary) -> Vector{Spec}` (pure; materialize with `write_spec`). Env special cases mirror the scripts: `EDM_ABSTOL=""` ⇒ derived, adaptive `interp_saveat` omitted, `EDM_ACCUM_ALG`/legacy `EDM_GPU_SOLVER` ⇄ canonical kernel names (dual-emitted for pinned old commits), integral harmonics emit without `.0`.

## Replay fixes (found by making the mapping total)
The hand-rolled `run_spec_from_manifest` emission silently **dropped** `EDM_SYSTEM`, `EDM_OMEGA_SCALE`, `EDM_SCREEN_HALFW`, `EDM_POL`, `EDM_GAMMA_EPS` — an LL-system, Doppler-equivalent, or ε-ladder reproduce reran script defaults for those knobs. Now table-driven on the spec: those replay faithfully, ε-manifests emit `EDM_GAMMA_EPS` rather than a rounded `EDM_GAMMA` (the scripts reject both being set), and missing required keys error loudly with the key list.

## Test plan
- The existing 19-assert `write_solver_manifest ↔ run_spec_from_manifest` contract testset passes **unchanged** on the new implementation.
- 27 new asserts: file⇄env⇄manifest roundtrips with typed coercion (Int→Float64, 0/1→Bool, Vector{Int}→Vector{Float64}), env-beats-file precedence incl. the ""-cases and the legacy alias, ε-beats-γ emission, dual alg knobs, `config_dict`→manifest→`spec_from_manifest` roundtrip with extra preservation, spec-native sweep expansion (product, base carry, unknown-field error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)