### PR TITLE
ci: run the RunManifests test suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,33 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+  # lib/RunManifests is its own package (manifests, sweep declarations, the dashboard
+  # client, ThomsonScatteringSpec) — the root runtest above never touches it, so it gets
+  # its own job. Registry deps only (JSON/Scratch + stdlibs): fast, no GPU stack.
+  runmanifests:
+    name: RunManifests - Julia ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+        with:
+          project: lib/RunManifests
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          project: lib/RunManifests
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Answering "does CI actually run the RunManifests tests?" — it did not: the `test` job runs `julia-runtest` on the root package only, so the declarations, the dashboard client, and ThomsonScatteringSpec have all been verified only by local runs so far.

Adds a `runmanifests` job using the same `project:` input pattern the dashboard repo's CI already uses for `builder/`. Registry deps only (JSON/Scratch + stdlibs) — fast, no GPU stack. The client tests are CI-safe by construction (file:// fixtures, no live network).

This PR's own CI run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)