### PR TITLE
plot_pixel_traces: include the screen-edge pixel by default

### DIFF
--- a/scripts/plot_pixel_traces.jl
+++ b/scripts/plot_pixel_traces.jl
@@ -10,7 +10,7 @@
 # so coherent structure lands on the per-electron amplitude) is overlaid for comparison.
 #
 # ENV knobs:
-#   EDM_TRACE_RADII      pixel radii as fractions of the screen half-extent, default "0,0.25,0.5,0.75"
+#   EDM_TRACE_RADII      pixel radii as fractions of the screen half-extent, default "0,0.25,0.5,0.75,1.0"
 #   EDM_TRACE_ELECTRONS  sunflower indices (csv); default 5 electrons at r/Rmax ≈ 0, ¼, ½, ¾, 1
 #                        (k = N·f² since the sunflower radius grows as √k)
 #   EDM_TRACE_TOTAL      1 (default) → also accumulate the full-N sum; 0 → skip (much faster)
@@ -36,7 +36,7 @@ length(ARGS) == 1 || error("usage: plot_pixel_traces.jl <run_manifest.toml>")
 const MFILE = abspath(ARGS[1])
 isfile(MFILE) || error("no manifest at $MFILE")
 
-const RADII = parse.(Float64, split(get(ENV, "EDM_TRACE_RADII", "0,0.25,0.5,0.75"), ","))
+const RADII = parse.(Float64, split(get(ENV, "EDM_TRACE_RADII", "0,0.25,0.5,0.75,1.0"), ","))
 all(0 .<= RADII .<= 1) || error("EDM_TRACE_RADII are fractions of the screen half-extent (0…1)")
 const TRACE_TOTAL = get(ENV, "EDM_TRACE_TOTAL", "1") == "1"
 const OUTDIR = get(ENV, "EDM_OUTDIR", dirname(MFILE))


### PR DESCRIPTION
The default trace row stopped at r = 0.75·halfw, so the pixel whose arrival offset anchors the narrow-window corner budget was never shown. Add r = 1.0·halfw to the `EDM_TRACE_RADII` default (the electron selection already reaches r₀ = 1.0·Rmax).

Motivated by the window audit of the rest_departure_bridge narrow-window runs: the regenerated 5-row traces for run f2f08ad4 (γ=2) show the edge pixel's burst arriving ~4λ late and fully contained, while r = 0 / 0.25·halfw are clipped at the window start — the evidence figure for the burst-centering bug in the :narrow window budget (report to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)