### PR TITLE
inverse_thomson: open the :narrow window burst/2 before Z (burst-centering fix)

### DIFF
--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -227,10 +227,13 @@ Ny = NX
 #  :full   — legacy wide window. x⁰_start = c·τi + hypot(Z, screen_edge) (plain c·τi, NOT γc·τi: the boosted
 #            electron starts far behind at γc·τi but only radiates near t=0, whose light reaches the screen
 #            at x⁰≈Z; c·τi is a small lead-in — γc·τi would start ~γ× too early and miss it). N = EDM_NSAMPLES.
-#  :narrow — recentre on the burst: on-axis arrival ≈ Z (measured + ~0.003 T at γ=10); off-axis pixels
-#            arrive LATER by the flat-screen path excess |r_o−r_e|²/(2Z), up to ~(√2·screen_hw + Rmax)²/(2Z)
-#            at the corner (worst emitter). Window = lead + that spread + burst + tail; N_samples auto-sized
-#            to it, so raising EDM_SPP resolves ≈4γ²ω at a fixed/short window.
+#  :narrow — recentre on the burst: the observed burst is CENTERED on the on-axis arrival ≈ Z
+#            (emission at lab t from z = βct arrives at Z + (1−β)ct, so the early half arrives
+#            BEFORE Z; peak measured + ~0.003 T at γ=10). Off-axis pixels arrive LATER by the
+#            flat-screen path excess |r_o−r_e|²/(2Z), up to ~(√2·screen_hw + Rmax)²/(2Z) at the
+#            corner (worst emitter). Window = lead + burst + that spread + tail, opening burst/2
+#            before Z; N_samples auto-sized to it, so raising EDM_SPP resolves ≈4γ²ω at a
+#            fixed/short window.
 # The burst length is DERIVED, not frozen at a measurement: the ~τ-long interaction is observed
 # Doppler-compressed by (1−β)/(1+β) = 1/N0, so the 1%-field Gaussian width is 2√(ln 100)·cτ/N0
 # (= 0.257λ at γ=10 — matching the CPU-LW measured ~0.26 T to <1%); the ×1.4 margin reproduces the
@@ -256,7 +259,14 @@ const N_samples, x⁰_start = if WINDOW == :full
     NSAMPLES, c * τi + hypot(Z, screen_hw + Rmax)
 else
     lead = WINDOW_LEAD * λ; tail = WINDOW_TAIL * λ      # lead-in / tail (x⁰ lengths, 1λ = 1 T; env knobs)
-    x0 = Z - lead - bunch_early                         # arrival ≈ Z ⇒ burst sits ~`lead` into the window
+    # The burst is CENTERED at ≈Z, so open burst/2 before it: the 1%-rise then sits ~`lead` into
+    # the window. Anchoring at Z − lead (pre-fix) treated Z as the burst START and clipped the
+    # leading half — 39/28/17/8% of the center-pixel burst energy at γ = 1.5/2/2.5/3, invisible at
+    # the γ=10 validation point (burst/2 = 0.13λ < lead). The budget below already carries a full
+    # `burst`, so the shift re-spends the tail surplus on the rise: earliest content Z − burst/2
+    # (center pixel), latest Z + corner_spread + burst/2 ≤ window end with `tail` intact —
+    # N_samples is unchanged. (Narrow-window audit, 2026-08-30.)
+    x0 = Z - burst / 2 - lead - bunch_early
     ceil(Int, (lead + bunch_early + corner_spread + burst + tail) / (c * δt)), x0
 end
 BUNCH_NB > 0 && WINDOW == :narrow &&


### PR DESCRIPTION
The `:narrow` observer window anchored its start at `Z − lead`, assuming the backscatter burst *starts* at the on-axis arrival ≈ Z. It is *centered* there: emission at lab time t from z = βct arrives at Z + (1−β)ct, so the leading half arrives before the window opens.

**Measured impact** (rest_departure_bridge): center-pixel burst energy never sampled = **38.7 / 28.0 / 16.8 / 7.7 / 2.5%** at γ = 1.5 / 2 / 2.5 / 3 / 3.5; ≤0.5% at γ ≥ 4. Per-electron E(t) envelopes start at 87–92% of peak at the window's first sample, matching exp(−lead²/2σ_obs²) to a few percent. The bug was invisible at the γ=10 validation point (burst/2 = 0.13λ < the 0.5λ lead).

**Fix** is a pure shift — `x⁰_start = Z − burst/2 − lead − bunch_early` — with **N_samples unchanged**: the budget already spends a full `burst` after Z where only `burst/2` is needed, so the tail surplus pays exactly for the rise. Post-shift coverage is exact at every pixel: earliest content Z − burst/2 (center pixel, on-axis emitter), latest Z + corner_spread + burst/2, `tail` margin intact. `:full` windows are corner-anchored with ~191λ of lead and were never affected.

Synthetic single-burst check at exact γ=2 parameters: the current window recovers 4.1% of the true line amplitude (Hann-weighted); the shifted window recovers 98.5% with no taper and 69.7% under the global Hann (the 0.70 = the Hann weight at the burst's in-window position — see the audit's §6.2 on per-pixel aligned reduction, to follow separately).

Full write-up with figures: narrow-window audit report (dashboard publication pending). Tracked as dashboard known-issues entry `narrow-window` (EDM_results_dashboard#99) — its `fixed_commit`/`before` fields should be set from this PR's merge.

After merge: the γ ≤ 3.5 narrow cells (5 runs) need re-acquisition — the clipped samples were never taken; γ ≥ 4 cubes are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)