### PR TITLE
EDM_APODIZATION knob (hann|none) + rest_departure_bridge_refix campaign

### DIFF
--- a/orchestration/campaigns/rest_departure_bridge_refix.sh
+++ b/orchestration/campaigns/rest_departure_bridge_refix.sh
@@ -15,6 +15,11 @@
 # original recipe rows). Same BASE as rest_departure_bridge otherwise.
 CAMPAIGN=rest_departure_bridge_refix
 SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1          # archive the cubes (R2 drain) — also arms the hotaisle backend's drainer,
+#   whose start gate reads the CAMPAIGN file on the driver; without it the VM-side KEEP_CUBE=1
+#   default keeps cubes that never drain and the teardown cube-gate blocks.
+SWEEP_AXES=gamma_eps # declared ladder axis (the builder no longer derives axes; SPP/tspan/hw
+#   co-vary with γ here, so an undeclared dir would shatter into standalone runs)
 BASE=(
   EDM_NX=601 EDM_FIELD_MODE=total
   EDM_N=2000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-13

--- a/orchestration/campaigns/rest_departure_bridge_refix.sh
+++ b/orchestration/campaigns/rest_departure_bridge_refix.sh
@@ -1,0 +1,34 @@
+# campaigns/rest_departure_bridge_refix.sh — re-acquire the 5 clipped bridge rungs (γ = 1.5 … 3.5)
+# after the burst-centering window fix (PR #82). The pre-fix :narrow window opened at Z − lead,
+# treating Z as the burst START; the burst is CENTERED there, so its leading half was never
+# sampled — 39/28/17/8/2.5% of the center-pixel burst energy at γ = 1.5/2/2.5/3/3.5
+# (narrow-window audit 2026-08-30; dashboard known-issue "narrow-window"). The γ ≥ 4 rungs were
+# clip-free (≤0.5%): they keep their archived cubes and get a re-reduce only, not a re-acquire.
+#
+# Reduction taper: EDM_APODIZATION=none — with the burst contained by the fixed window the bare
+# rfft is unbiased (synthetic γ=2: 98.5% of the true line amplitude, leakage skirt 2e-7 of the
+# line) and imprints NO radial taper mask on the maps, unlike the shared-axis Hann whose weight
+# varied 0.02–0.83 across the screen. The power spectrum is un-windowed by design either way.
+#
+# Cells reproduce the AS-RUN rows of rest_departure_bridge cells.tsv (label ⇆ overrides,
+# including the e2e0 SPP=256 + line-anchored EDM_HARMONICS refinements that superseded the
+# original recipe rows). Same BASE as rest_departure_bridge otherwise.
+CAMPAIGN=rest_departure_bridge_refix
+SCRIPT=scripts/inverse_thomson_scattering.jl
+BASE=(
+  EDM_NX=601 EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-13
+  EDM_A0=0.3
+  EDM_INTERP_SAVEAT=16
+  EDM_INITIAL_PHASE=-1.5707963267948966
+  EDM_WINDOW=narrow
+  EDM_APODIZATION=none
+  EDM_DIRECT_READ=1
+)
+CELLS=(
+  "e5em1|EDM_GAMMA_EPS=0.5 EDM_SPP=32 EDM_TSPAN_TAU=10.666666666666666 EDM_SCREEN_HW=16.7 EDM_HARMONICS=6,6.8542,8,13.7084"
+  "e1e0|EDM_GAMMA_EPS=1 EDM_SPP=64 EDM_TSPAN_TAU=8 EDM_SCREEN_HW=12.5 EDM_HARMONICS=13,13.9282,15,27.8564"
+  "e1p5e0|EDM_GAMMA_EPS=1.5 EDM_SPP=128 EDM_TSPAN_TAU=6.4 EDM_SCREEN_HW=10 EDM_HARMONICS=22,22.9564,24,45.9128"
+  "e2e0|EDM_GAMMA_EPS=2 EDM_SPP=256 EDM_TSPAN_TAU=5.333333333333333 EDM_SCREEN_HW=8.3 EDM_HARMONICS=33,33.9706,35,67.9412"
+  "e2p5e0|EDM_GAMMA_EPS=2.5 EDM_SPP=256 EDM_TSPAN_TAU=4.571428571428571 EDM_SCREEN_HW=7.0 EDM_HARMONICS=46,46.9788,48,93.9576"
+)

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -440,6 +440,12 @@ function recover_from_manifest(toml)
         # A split cube carries E_far/B_far — keep them so write_harmonic_products also emits the
         # far-field maps the φ0/LPWA comparison needs; a total cube has only E/B.
         fld = hasproperty(raw, :E_far) ? raw : (; E = raw.E, B = raw.B)
+        # Taper parity with the inline path: [config].apodization (the EDM_APODIZATION knob;
+        # pre-knob manifests reduce with the legacy hann). An explicit EDM_APODIZATION on a
+        # recovery/recolor invocation overrides the manifest — that's the re-reduce path.
+        apod = lowercase(get(ENV, "EDM_APODIZATION", get(cfg, "apodization", "hann")))
+        apod in ("hann", "none") ||
+            error("apodization must be \"hann\" or \"none\", got \"$apod\"")
         hprod = write_harmonic_products(
             fld, x_grid, y_grid, ω, δt;
             w₀ = las["w0"], run_tag, outdir = dir,
@@ -447,6 +453,7 @@ function recover_from_manifest(toml)
             # The run's own bins (≈4γ²ω for inverse :narrow) — a deferred reduction must produce
             # exactly what the inline (non-SKIP_POST) path would have; legacy default (1,2,3,4).
             harmonics = Tuple(get(cfg, "harmonics", (1, 2, 3, 4))),
+            window = apod == "none" ? nothing : hann,
         )
         isfile(joinpath(dir, ".reduce_only")) || get(ENV, "EDM_REDUCE_ONLY", "0") == "1" ||
             envelope!(hprod.fields_h, Tuple(get(cfg, "harmonics", (1, 2, 3, 4))), x_grid, y_grid, las["w0"])

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -461,11 +461,23 @@ function recover_from_manifest(toml)
         # must ALSO declare what it produced, so [outputs] is complete for resolve_hmaps + the
         # dashboard hmaps download. `sorted` keeps [timing] last (the ops timing-append relies on it).
         outs = m["outputs"]
-        if get(outs, "harmonic_maps", nothing) === nothing
-            outs["harmonic_maps"] = basename(hprod.hmapsfile)
-            outs["plots"] = basename.(hprod.plots)
+        declare = get(outs, "harmonic_maps", nothing) === nothing
+        # Stamp the APPLIED taper: an env-override re-reduce (e.g. hann→none on an archived cube)
+        # must leave the manifest describing the products actually on disk — otherwise the next
+        # recovery without the env var silently reverts them to hann, and nothing records that
+        # the published maps changed convention.
+        restamp = get(cfg, "apodization", nothing) != apod
+        if declare || restamp
+            if declare
+                outs["harmonic_maps"] = basename(hprod.hmapsfile)
+                outs["plots"] = basename.(hprod.plots)
+            end
+            restamp && (cfg["apodization"] = apod)
             open(io -> TOML.print(io, m; sorted = true), toml, "w")
-            println("declared harmonic_maps + plots in $(basename(toml))")
+            println(
+                "updated $(basename(toml)):" * (declare ? " declared harmonic_maps + plots" : "") *
+                    (restamp ? " stamped apodization = $apod" : "")
+            )
         end
         return hprod
     end

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -141,6 +141,15 @@ const WINDOW_TAIL = parse(Float64, get(ENV, "EDM_WINDOW_TAIL", "0.5"))   # :narr
 #   arrivals are budgeted separately — see `bunch_early` below — so a thin lead stays safe.)
 (WINDOW_LEAD > 0 && WINDOW_TAIL > 0) ||
     error("EDM_WINDOW_LEAD/EDM_WINDOW_TAIL must be > 0, got $WINDOW_LEAD/$WINDOW_TAIL")
+# Time→frequency taper for the harmonic-map reduction: hann (default — leakage suppression) |
+# none (bare rfft — unbiased line amplitudes with NO radial taper mask once the :narrow window
+# contains the burst; the narrow-window audit's pick for line-anchored |maps|. Synthetic γ=2
+# check: 98.5% of the true line amplitude, skirt 2e-7 of the line). Recorded in [config] so the
+# deferred (EDM_SKIP_POSTPROCESS / REDUCE_OVERLAP) reduction applies the SAME taper — the async
+# reducer reads the manifest, not the cell env. The power spectrum stays un-windowed by design.
+const APODIZATION = lowercase(get(ENV, "EDM_APODIZATION", "hann"))
+APODIZATION in ("hann", "none") ||
+    error("EDM_APODIZATION must be \"hann\" or \"none\", got \"$APODIZATION\"")
 const ACCUM_ALG = lowercase(get(ENV, "EDM_ACCUM_ALG", "rk4"))   # retarded-time kernel: rk4 (marching, the
 #   PR-29-validated default) | newton (per-slot light-cone root solve, PR #31 — equal-or-better accuracy
 #   at neutral-to-1.3× field cost; the better default once cross-validated on an inverse cell).
@@ -514,6 +523,7 @@ else
         fld, screen.x_grid, screen.y_grid, ω, δt;
         w₀, run_tag = RUN_TAG, outdir = OUTDIR, source_datafile = basename(datafile),
         harmonics = HARMONICS,   # :narrow ⇒ around the ≈4γ²ω backscatter line; :full ⇒ (1,2,3,4)
+        window = APODIZATION == "none" ? nothing : hann,
         title_prefix = "Inverse Thomson scattering", fileprefix = "inverse_thomson",
         style = harmonic_field_style(cap_mult = 4.0),   # speckle maps: median-capped colorrange
         n0 = N0,                 # boosted runs label frequencies in ω_bs = N0·ω₁ units
@@ -559,6 +569,9 @@ config = Dict{String, Any}(
     "scattering" => "inverse",         # counter-propagating boosted electrons vs. rest-electron thomson_scattering.jl
     "system" => SYSTEM,                # classical | ll — written unconditionally (mixed pools crash axis detection)
     "window" => string(WINDOW),        # :full (wide, coarse) | :narrow (burst-centred, high-SPP)
+    "apodization" => APODIZATION,      # EDM_APODIZATION knob: hann | none — the reduction taper;
+    #   the deferred reducer (recover_from_manifest) reads THIS key for taper parity with the inline path
+
     "screen_hw_w0" => SCREEN_HW,       # EDM_SCREEN_HW knob (w₀ units; [setup].screen_hw is the derived a.u. value)
     "tspan_tau" => TSPAN_TAU,          # EDM_TSPAN_TAU knob (proper-time span per side, τ units; [setup].τi/τf are derived)
     "window_lead" => WINDOW_LEAD,      # EDM_WINDOW_LEAD / EDM_WINDOW_TAIL knobs (:narrow margins, λ units)


### PR DESCRIPTION
Follow-up to #82, prep for the Hot Aisle re-acquisition of the 5 clipped rungs.

- **EDM_APODIZATION** `hann` (default — unchanged behavior) | `none` (bare rfft). Recorded in `[config].apodization`; `recover_from_manifest` reads the manifest key so the deferred **REDUCE_OVERLAP** reducer applies the same taper as the inline path (the async reducer never sees the cell env). An explicit `EDM_APODIZATION` on a recovery invocation overrides the manifest — that's the re-reduce path for the clean γ ≥ 4 archived cubes.
- **campaigns/rest_departure_bridge_refix.sh** — the 5 clipped cells (γ = 1.5/2/2.5/3/3.5), as-run overrides from the original `cells.tsv` (incl. the e2e0 SPP=256 + line-anchored harmonics refinements), same BASE plus `EDM_APODIZATION=none`.

Why bare FFT: with the burst contained by the fixed window, the synthetic γ=2 check recovers 98.5% of the true line amplitude with a leakage skirt at 2×10⁻⁷ of the line and no radial taper mask; the shared-axis Hann weighted pixels 0.02–0.83 across the screen (audit §4/§6.2). Power spectra remain un-windowed by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)