### PR TITLE
Quantile colorrange cap + EDM_HARMONICS re-extraction override

### DIFF
--- a/ext/EDMMakieExt.jl
+++ b/ext/EDMMakieExt.jl
@@ -94,7 +94,8 @@ function ElectronDynamicsModels.plot_power_spectrum(
     # became wallpaper once spans reached 4γ² ~ 10⁶ ω₁: the aligned dash segments of ~10⁶
     # overlapping dashed vlines rendered as solid gray bars).
     xh = collect(freqs) ./ (ω / 2π) ./ n0
-    xlab = n0 == 1 ? "frequency / ω₁" : "frequency / ω_bs   (ω_bs = $(n0) ω₁)"
+    xlab = n0 == 1 ? "frequency / ω₁" :
+        "frequency / ω_bs   (ω_bs = $(round(n0, sigdigits = 6)) ω₁)"
     yfloor = maximum(power_spec) * 1.0e-30     # log axis needs a positive floor
     fig = with_theme(theme_latexfonts()) do
         f = Figure(size = (1150, 560))

--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -732,7 +732,7 @@ Raw values in [config]/[laser]/[setup] are NEVER converted. Read back (with the 
 fallback) via [`units_from_manifest`](@ref).
 """
 function units_section(ω::Real, λ::Real, w₀::Real; system = "hartree_atomic",
-        n0::Integer = 1, omega_scale::Real = 1.0, transverse_length = "w0", extra_defs...)
+        n0::Real = 1, omega_scale::Real = 1.0, transverse_length = "w0", extra_defs...)
     def(value, tex) = Dict{String, Any}("value" => Float64(value), "tex" => String(tex))
     defs = Dict{String, Any}(
         "omega_laser" => def(ω, "ω₁"),
@@ -767,9 +767,15 @@ end
 
 Read a manifest's `[units]` section; for manifests that predate it, synthesize the same
 structure from what they do record (`[laser] wavelength/w0`, `[config] backscatter_n0/
-omega_scale`) so consumers have ONE code path. `n0` is the derived integer ratio
-preferred-frequency-scale / ω₁ (1 when frequencies are ω₁-preferred) — exactly the legacy
-`backscatter_n0` contract the powspec axis and harmonic-map labels consume.
+omega_scale`) so consumers have ONE code path. `n0` is the EXACT ratio
+preferred-frequency-scale / ω₁ (`1.0` when frequencies are ω₁-preferred) — the legacy
+`backscatter_n0` contract the powspec axis and harmonic-map labels consume. Exact, not
+rounded: near-rest rungs have fractional ω_bs/ω₁ where an integer round is a visible
+axis/label offset (+2.1% at γ=1.5, shrinking ∝1/4γ² up the ladder — invisible at γ=10,
+where the old integer convention came from). Manifests written before this fix stored
+`omega_bs = round(n_th)·ω₁` in [units], so when ω_bs is the preferred scale the exact
+`[config].backscatter_n0` (always recorded at full precision) takes precedence over the
+stored-defs ratio.
 """
 function units_from_manifest(m::AbstractDict)
     u = get(m, "units", nothing)
@@ -779,13 +785,18 @@ function units_from_manifest(m::AbstractDict)
         λ = Float64(get(las, "wavelength", NaN))
         u = units_section(
             2π * C_HARTREE / λ, λ, Float64(get(las, "w0", NaN));
-            n0 = round(Int, get(cfg, "backscatter_n0", 1)),
+            n0 = Float64(get(cfg, "backscatter_n0", 1)),
             omega_scale = Float64(get(cfg, "omega_scale", 1.0)),
         )
     end
     defs, pref = u["defs"], u["preferred"]
     fscale = get(defs, get(pref, "frequency", "omega_laser"), defs["omega_laser"])
-    n0 = round(Int, Float64(fscale["value"]) / Float64(defs["omega_laser"]["value"]))
+    # sigdigits guards FP noise in the stored-defs ratio ((n0·ω)/ω ≠ n0 exactly), NOT a
+    # display round; the ω_bs branch below replaces it with the full-precision config value.
+    n0 = round(Float64(fscale["value"]) / Float64(defs["omega_laser"]["value"]); sigdigits = 12)
+    if get(pref, "frequency", "omega_laser") == "omega_bs"
+        n0 = Float64(get(get(m, "config", Dict{String, Any}()), "backscatter_n0", n0))
+    end
     return (; system = u["system"], defs, preferred = pref, n0)
 end
 

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -179,6 +179,20 @@ end
     @test ub["defs"]["omega_bs"]["value"] ≈ 398ω
     @test units_from_manifest(Dict{String, Any}("units" => ub)).n0 == 398
 
+    # near-rest backscatter: n0 is the EXACT fractional line, never rounded (the integer
+    # round is a +2.1% axis/label offset at γ=1.5)
+    n_th = 6.854101966249684
+    uf = units_section(ω, λ, w₀; n0 = n_th)
+    @test uf["defs"]["omega_bs"]["value"] ≈ n_th * ω
+    @test units_from_manifest(Dict{String, Any}("units" => uf)).n0 ≈ n_th
+    # pre-fix manifests stored omega_bs = round(n_th)·ω₁ in [units] while [config] always
+    # carried the exact line — the config value must win when ω_bs is preferred
+    ur = units_section(ω, λ, w₀; n0 = 7)
+    mfix = Dict{String, Any}(
+        "units" => ur, "config" => Dict{String, Any}("backscatter_n0" => n_th),
+    )
+    @test units_from_manifest(mfix).n0 ≈ n_th
+
     # Doppler-equivalent run: scaled carrier + unscaled lab reference
     s = 19.949874371066196
     us = units_section(s * ω, λ / s, w₀; omega_scale = s)

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -87,7 +87,7 @@ function write_field_products(
             title = n0 == 1 ?
                 @sprintf("%s (%s field) — %gω₁ (%.3f× fundamental)",
                 title_prefix, ftype, n, ffund[k]) :
-                @sprintf("%s (%s field) — %gω₁ = %.4g ω_bs (ω_bs = %dω₁)",
+                @sprintf("%s (%s field) — %gω₁ = %.4f ω_bs (ω_bs = %.4gω₁)",
                 title_prefix, ftype, n, ffund[k] / n0, n0),
             outfile = out,
         )
@@ -100,8 +100,8 @@ function write_field_products(
             plot = basename(out), source = source_datafile,
             setup = Dict("field" => ftype), plot_params = Dict("apodization" => window),
             description = "Field harmonic maps at $(n)ω₁" *
-                (n0 == 1 ? "" : " = $(round(n / n0, sigdigits = 4)) ω_bs (ω_bs = $(n0)ω₁, " *
-                    "the on-axis backscattered fundamental)") *
+                (n0 == 1 ? "" : " = $(round(n / n0, sigdigits = 4)) ω_bs (ω_bs = " *
+                    "$(round(n0, sigdigits = 6))ω₁, the on-axis backscattered fundamental)") *
                 " — each panel a component (Eˣ…Bᶻ). " *
                 "Toggle total (far 1/R + near 1/R²) vs far (radiation 1/R only); the far field is " *
                 "what the LPWA analytic formula is compared against in the lpwa-vs-numeric view. " *
@@ -561,7 +561,9 @@ function recover_from_manifest(toml)
         plot_power_spectrum(
             pc.freqs, pc.ps;
             ω = C_LIGHT * 2π / λ, labels = COMPLABELS,
-            marks = collect(Float64, pc.harmonics), n0 = pc.n0,
+            # n0 from the MANIFEST, not the cache: caches serialized before the exact-n0 fix
+            # froze the rounded integer (7 vs 6.8541 at γ=1.5 — the 2.1% axis offset).
+            marks = collect(Float64, pc.harmonics), n0,
             title = "$title_prefix — field power spectra (un-windowed)",
             outfile = joinpath(dir, "powspec_$(run_tag).png"),
         )

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -29,7 +29,7 @@ _read_cube(path) = get(ENV, "EDM_DIRECT_READ", "0") == "1" ?
     open(deserialize, `dd if=$path bs=64M iflag=direct status=none`) : deserialize(path)
 
 """
-    harmonic_field_style(; cap_mult = nothing) -> (; colormap, colorrange[, highclip, lowclip])
+    harmonic_field_style(; cap_quantile = nothing) -> (; colormap, colorrange[, highclip, lowclip])
 
 Panel style for the field-harmonic heat-maps, splatted into [`plot_harmonic_grid`]. Those panels
 show the **real part** of each component (signed, oscillatory data), so the choice here sets how
@@ -38,15 +38,18 @@ the sign structure reads. Returns a `NamedTuple` with:
   * `colorrange` — a `data -> (lo, hi)` function applied **per panel** (`symmetric_colorrange` and
     `harmonic_colorrange` are both in scope from ElectronDynamicsModels).
 
-`cap_mult` caps the colorrange at ±`cap_mult`×median(|data|) with over-limit pixels rendered in
-the clip colors: speckle-dominated maps (inverse scattering) are otherwise normalized to their
-brightest grain (~6× median), which buries everything below ~2× median in the flat bottom of the
-colormap. The panel title still reports the true peak.
+`cap_quantile` caps the colorrange at ±quantile(|data|, cap_quantile) with over-limit pixels
+rendered in the clip colors: speckle-dominated maps (inverse scattering) are otherwise normalized
+to their brightest grain, which buries everything below ~2× median in the flat bottom of the
+colormap. A quantile clips a FIXED pixel fraction whatever the tail shape — the previous
+±4×median(|data|) cap assumed the ~6×median tail of fully-developed speckle and saturated 36% of
+the central quarter on the heavy-tailed low-γ bridge maps, where the bright beaming core sits on
+a large dark screen (q99.5 ≈ 20×median there). The panel title still reports the true peak.
 """
-function harmonic_field_style(; cap_mult = nothing)
-    cap_mult === nothing && return (; colormap = :jet, colorrange = symmetric_colorrange)
+function harmonic_field_style(; cap_quantile = nothing)
+    cap_quantile === nothing && return (; colormap = :jet, colorrange = symmetric_colorrange)
     capped = data -> begin
-        hi = min(maximum(abs, data), cap_mult * median(abs.(data)))
+        hi = quantile(abs.(vec(data)), cap_quantile)
         hi = hi > 0 ? hi : one(hi)
         (-hi, hi)
     end
@@ -394,6 +397,34 @@ function _retire_stale_phase(dir, run_tag)
     return
 end
 
+# Delete the per-bin chip artifacts (field/envelope/phase sidecars + PNGs) of harmonic bins
+# DROPPED by an EDM_HARMONICS re-extraction, so the campaign dir doesn't keep publishing chips
+# for bins the manifest no longer declares. Bin `n` appears in filenames via plain string
+# interpolation of the solver's parse (integer-valued bins are Int — "h6", never "h6.0"), so
+# string(n) reproduces the on-disk names exactly.
+function _retire_dropped_bins(dir, run_tag, fileprefix, old_harmonics, new_harmonics)
+    id8 = first(run_tag, 8)
+    keep = Set(string.(collect(new_harmonics)))
+    for n in old_harmonics
+        s = string(n)
+        s in keep && continue
+        for f in (
+                "derived_h$(s)_total_$(id8).toml", "derived_h$(s)_far_$(id8).toml",
+                "derived_envelope_$(s)_$(id8).toml",
+                "derived_phaseE_$(s)_$(id8).toml", "derived_phaseB_$(s)_$(id8).toml",
+                "$(fileprefix)_field_h$(s)_$(run_tag).png",
+                "$(fileprefix)_fieldfar_h$(s)_$(run_tag).png",
+                "$(fileprefix)_envelope_h$(s)_$(run_tag).png",
+                "$(fileprefix)_phaseE_h$(s)_$(run_tag).png",
+                "$(fileprefix)_phaseB_h$(s)_$(run_tag).png",
+            )
+            p = joinpath(dir, f)
+            isfile(p) && (rm(p); println("retired dropped-bin → $f"))
+        end
+    end
+    return
+end
+
 # ── Standalone recovery: rebuild reduced maps + plots from a serialized cube via its manifest ──
 function recover_from_manifest(toml)
     m = TOML.parsefile(toml)
@@ -405,9 +436,9 @@ function recover_from_manifest(toml)
     inverse = get(cfg, "scattering", "") == "inverse"
     title_prefix, fileprefix = lpwa ? ("LPWA", "lpwa") :
         inverse ? ("Inverse Thomson scattering", "inverse_thomson") : ("Thomson scattering", "thomson")
-    # Speckle-dominated inverse maps get the median-capped colorrange (grains saturate in the
-    # clip colors); rest-electron/LPWA maps keep the plain symmetric range.
-    style = harmonic_field_style(cap_mult = inverse ? 4.0 : nothing)
+    # Speckle-dominated inverse maps get the quantile-capped colorrange (brightest 0.5% saturate
+    # in the clip colors); rest-electron/LPWA maps keep the plain symmetric range.
+    style = harmonic_field_style(cap_quantile = inverse ? 0.995 : nothing)
     run_tag = m["provenance"]["run_id"]
     cube = joinpath(dir, m["outputs"]["datafile"])
     # Envelope view geometry (inverse runs only): the blur grain needs the screen distance +
@@ -446,37 +477,55 @@ function recover_from_manifest(toml)
         apod = lowercase(get(ENV, "EDM_APODIZATION", get(cfg, "apodization", "hann")))
         apod in ("hann", "none") ||
             error("apodization must be \"hann\" or \"none\", got \"$apod\"")
+        # The run's own bins (≈4γ²ω for inverse :narrow) — a deferred reduction must produce
+        # exactly what the inline (non-SKIP_POST) path would have; legacy default (1,2,3,4).
+        # An explicit EDM_HARMONICS on a recovery invocation overrides the manifest — the
+        # re-extraction path for archived cubes (e.g. adding measured-powspec-peak line anchors).
+        # Same parse as the solver: integer-valued entries stay Int so filenames read "h6", not "h6.0".
+        harms = if haskey(ENV, "EDM_HARMONICS")
+            Tuple(
+                isinteger(n) ? Int(n) : Float64(n)
+                    for n in parse.(Float64, split(ENV["EDM_HARMONICS"], ","))
+            )
+        else
+            Tuple(get(cfg, "harmonics", (1, 2, 3, 4)))
+        end
         hprod = write_harmonic_products(
             fld, x_grid, y_grid, ω, δt;
             w₀ = las["w0"], run_tag, outdir = dir,
             source_datafile = m["outputs"]["datafile"], title_prefix, fileprefix, style, n0,
-            # The run's own bins (≈4γ²ω for inverse :narrow) — a deferred reduction must produce
-            # exactly what the inline (non-SKIP_POST) path would have; legacy default (1,2,3,4).
-            harmonics = Tuple(get(cfg, "harmonics", (1, 2, 3, 4))),
+            harmonics = harms,
             window = apod == "none" ? nothing : hann,
         )
         isfile(joinpath(dir, ".reduce_only")) || get(ENV, "EDM_REDUCE_ONLY", "0") == "1" ||
-            envelope!(hprod.fields_h, Tuple(get(cfg, "harmonics", (1, 2, 3, 4))), x_grid, y_grid, las["w0"])
+            envelope!(hprod.fields_h, harms, x_grid, y_grid, las["w0"])
         # Close the loop the inline (non-SKIP_POST) path already does: a deferred/async reduction
         # must ALSO declare what it produced, so [outputs] is complete for resolve_hmaps + the
         # dashboard hmaps download. `sorted` keeps [timing] last (the ops timing-append relies on it).
         outs = m["outputs"]
         declare = get(outs, "harmonic_maps", nothing) === nothing
-        # Stamp the APPLIED taper: an env-override re-reduce (e.g. hann→none on an archived cube)
-        # must leave the manifest describing the products actually on disk — otherwise the next
-        # recovery without the env var silently reverts them to hann, and nothing records that
-        # the published maps changed convention.
+        # Stamp what was APPLIED: an env-override re-reduce (hann→none, or an EDM_HARMONICS
+        # re-extraction) must leave the manifest describing the products actually on disk —
+        # otherwise the next recovery without the env var silently reverts them, and nothing
+        # records that the published maps changed convention/bins.
         restamp = get(cfg, "apodization", nothing) != apod
-        if declare || restamp
+        old_harms = collect(get(cfg, "harmonics", (1, 2, 3, 4)))
+        restamp_h = collect(Float64, old_harms) != collect(Float64, harms)
+        # Bins dropped by the re-extraction leave chips behind that the manifest no longer
+        # declares — retire them so the dir (and the next publish staging) stays consistent.
+        restamp_h && _retire_dropped_bins(dir, run_tag, fileprefix, old_harms, harms)
+        if declare || restamp || restamp_h
             if declare
                 outs["harmonic_maps"] = basename(hprod.hmapsfile)
                 outs["plots"] = basename.(hprod.plots)
             end
             restamp && (cfg["apodization"] = apod)
+            restamp_h && (cfg["harmonics"] = collect(harms))
             open(io -> TOML.print(io, m; sorted = true), toml, "w")
             println(
                 "updated $(basename(toml)):" * (declare ? " declared harmonic_maps + plots" : "") *
-                    (restamp ? " stamped apodization = $apod" : "")
+                    (restamp ? " stamped apodization = $apod" : "") *
+                    (restamp_h ? " stamped harmonics = $(collect(harms))" : "")
             )
         end
         return hprod

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -199,6 +199,11 @@ const DTMAX = τ / (2 * GAMMA)
 # harmonic the :narrow window targets. EDM_HARMONICS overrides (comma-separated n); default is the
 # fundamental ±1 + its 2nd (narrow) or the legacy (1,2,3,4) (full — the ω-harmonics of the drive laser).
 const N0 = round(Int, (1 + β) / (1 - β))
+# Display/units twin of N0: the EXACT line ratio. N0 stays integer where integers belong
+# (:narrow default bins, Nyquist guard, burst sizing — acquisition parity); every ω_bs
+# LABEL and axis uses the exact value, else near-rest rungs show the line at 0.98 ω_bs
+# (the round is +2.1% at γ=1.5 — larger than the physical a0² redshift it obscures).
+const N0_EXACT = (1 + β) / (1 - β)
 const HARMONICS = let h = get(ENV, "EDM_HARMONICS", "")
     # Fractional n is allowed: near-rest boosted lines sit BETWEEN laser harmonics
     # ((1+β)/(1−β) = 1.33 at ε = 1e-2) — extraction is nearest-rfft-bin of n·ω₁ either way
@@ -526,12 +531,12 @@ else
         window = APODIZATION == "none" ? nothing : hann,
         title_prefix = "Inverse Thomson scattering", fileprefix = "inverse_thomson",
         style = harmonic_field_style(cap_quantile = 0.995),   # speckle maps: quantile-capped colorrange
-        n0 = N0,                 # boosted runs label frequencies in ω_bs = N0·ω₁ units
+        n0 = N0_EXACT,           # boosted runs label frequencies in the exact ω_bs unit
     )
     # Speckle-envelope chips (per-bin maps are envelope × speckle; see the report).
     write_envelope_products(
         hprod.fields_h, HARMONICS, screen.x_grid, screen.y_grid;
-        w₀, Z, Rmax, λ, n0 = N0, run_tag = RUN_TAG, outdir = OUTDIR,
+        w₀, Z, Rmax, λ, n0 = N0_EXACT, run_tag = RUN_TAG, outdir = OUTDIR,
         source_datafile = basename(datafile),
         title_prefix = "Inverse Thomson scattering", fileprefix = "inverse_thomson",
     )
@@ -583,7 +588,7 @@ config = Dict{String, Any}(
     # EXACT ratio, not the rounded N0: near-rest ladders have ω_s/ω ∈ (1, 3.5) where the
     # integer round collapses distinct rungs onto "1" (γ≫1 rounding was harmless: 397.99→398).
     # N0 stays integer for the :narrow defaults; this key is the dashboard/display value.
-    "backscatter_n0" => (1 + β) / (1 - β),   # on-axis backscatter fundamental ω_s/ω ≈ 4γ²
+    "backscatter_n0" => N0_EXACT,      # on-axis backscatter fundamental ω_s/ω ≈ 4γ²
     "screen_zsign" => SCREEN_ZSIGN,    # screen side: +1 backscatter (+Z), −1 transmission (−Z)
     "accumulation_alg" => (ACCUM_ALG == "newton" ? "GPUKernelNewton" : "GPUKernelRK4"),   # dashboard canonical name
     "newton_iters" => NEWTON_ITERS,    # recorded UNCONDITIONALLY (rk4 runs too): a mixed rk4/newton
@@ -641,9 +646,9 @@ sharding = Dict{String, Any}("electrons" => ndev)
 gpu = gpu_manifest_section(gpu_backend, GPU_BACKEND, Nx * Ny, ndev, gpu_telem)
 extra = Dict{String, Any}(
     "timing" => timing, "sharding" => sharding,
-    # [units]: n0 = N0 declares ω_bs = N0·ω₁ as the preferred frequency scale — the
-    # declaration-layer generalization of [config].backscatter_n0 (kept for legacy readers).
-    "units" => units_section(ω, λ, w₀; n0 = N0),
+    # [units]: declares the EXACT ω_bs = (1+β)/(1−β)·ω₁ as the preferred frequency scale —
+    # the declaration-layer generalization of [config].backscatter_n0 (kept for legacy readers).
+    "units" => units_section(ω, λ, w₀; n0 = N0_EXACT),
 )
 gpu === nothing || (extra["gpu"] = gpu)
 manifestfile = write_solver_manifest(

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -525,7 +525,7 @@ else
         harmonics = HARMONICS,   # :narrow ⇒ around the ≈4γ²ω backscatter line; :full ⇒ (1,2,3,4)
         window = APODIZATION == "none" ? nothing : hann,
         title_prefix = "Inverse Thomson scattering", fileprefix = "inverse_thomson",
-        style = harmonic_field_style(cap_mult = 4.0),   # speckle maps: median-capped colorrange
+        style = harmonic_field_style(cap_quantile = 0.995),   # speckle maps: quantile-capped colorrange
         n0 = N0,                 # boosted runs label frequencies in ω_bs = N0·ω₁ units
     )
     # Speckle-envelope chips (per-bin maps are envelope × speckle; see the report).

--- a/scripts/ll_system_chips.jl
+++ b/scripts/ll_system_chips.jl
@@ -46,7 +46,7 @@ function main(dir)
     for c in cells
         push!(get!(groups, (c.gamma, c.a0, c.iters), []), c)
     end
-    style = harmonic_field_style(cap_mult = 4.0)
+    style = harmonic_field_style(cap_quantile = 0.995)
     pairs = []
     for ((γ, a0, it), g) in groups
         cl = findfirst(c -> c.system == "classical", g)

--- a/scripts/ll_system_chips.jl
+++ b/scripts/ll_system_chips.jl
@@ -35,7 +35,7 @@ function load_cells(dir)
         c = m["config"]
         push!(cells, (; id, system = get(c, "system", "classical"), gamma = get(c, "gamma", 0),
             a0 = c["a0"], iters = get(c, "newton_iters", 2),
-            n0 = round(Int, get(c, "backscatter_n0", 1)), h = deserialize(hm)))
+            n0 = Float64(get(c, "backscatter_n0", 1)), h = deserialize(hm)))
     end
     return cells
 end

--- a/scripts/plot_pixel_traces.jl
+++ b/scripts/plot_pixel_traces.jl
@@ -57,7 +57,15 @@ Rmax = Float64(setup["Rmax"])
 Z = Float64(setup["Z"])
 N_samples = Int(cfg["N_samples"])
 spp = Int(cfg["samples_per_period"])
-HALFW = Float64(get(cfg, "screen_halfw", 25.0))   # pre-knob manifests: production framing
+# Mini-screen half-width = the RUN's screen. Current manifests record the zoom knob as
+# [setup].screen_hw (absolute) / [config].screen_hw_w0; the old cfg.screen_halfw key missed
+# them, so zoomed-screen runs (hw < 25 w₀) fell back to the 25 w₀ production framing and the
+# outer trace rows sampled pixels OFF the cube's screen — beyond the narrow window's corner
+# budget, so their bursts overran the window end and the chips showed a spurious end-of-pulse
+# cutoff (bridge-refix γ=2/2.5, 2026-08-30). The real screen corner is contained by
+# construction (tail margin intact), so on-screen rows never clip.
+HALFW = "screen_hw" in keys(setup) ? Float64(setup["screen_hw"]) / w₀ :
+    Float64(get(cfg, "screen_hw_w0", get(cfg, "screen_halfw", 25.0)))
 reltol = Float64(get(cfg, "reltol", 1.0e-12))
 abstol = Float64(cfg["abstol"])
 interp_saveat = string(get(cfg, "interp_saveat", "adaptive"))


### PR DESCRIPTION
Two reduce-path improvements motivated by reviewing the `rest_departure_bridge_refix` line maps:

**q99.5 quantile colorrange cap** (replaces `cap_mult = 4×median`). The median-multiple cap assumed the ~6×median tail of fully-developed speckle; the low-γ bridge line maps are much heavier-tailed (bright beaming core on a mostly-dark screen — q99.5 ≈ 20×median at γ=1.5), and the 4×median cap saturated 36% of the central quarter there, hiding exactly the structure the maps exist to show. A quantile cap clips a fixed 0.5% pixel fraction regardless of tail shape. Same clip-color rendering; panel titles still report the true peak.

**`EDM_HARMONICS` override in the recovery path.** `recover_from_manifest` previously reduced only the manifest's as-run bins, so re-extracting an archived cube at different frequencies required editing the manifest by hand. The override mirrors the `EDM_APODIZATION` pattern: same int-preserving parse as the solver, applied bins stamped back into `[config].harmonics`, and chips of bins the re-extraction dropped are retired from the campaign dir (so the next publish prunes them).

First use: re-extracting the 5 local refix rungs at `{n_ps, n_th, 2n_ps, 2n_th}` — the measured powspec peak alongside the theory anchor at both harmonics, replacing the integer wing bins. Measured on the refix powspec caches, the theory anchors sit +0.8–1.1% above the actual (chirp-redshifted) line peak and hold only 44–73% of its bin power (~10% at 2n_th), so the measured-peak maps are the fair "at the line" view; keeping n_th preserves cross-rung continuity (`coherence_curve.jl` selects nearest-to-n_th and is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vfs1qQzKFyAcfKc2o3F9A6