### PR TITLE
ops: re-reduce-safe reduction markers + KEEP_CUBE manifest attestation

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -368,18 +368,41 @@ Invariant: every product a drain-path reducer emits must be re-renderable from a
 here. A plot rendered directly from the cube with NO cache is invisible to this marker and breaks
 publish-autonomy — add a cache instead of relying on the cube (which only exists where it was produced/archived).
 Today's drain-path reducers (harmonic_products, plot_screen_observables) cache every product.
+
+Re-reduce semantics: when no `.partial` exists but a finalized `<run_id>.reduced` does, the
+staging marker is SEEDED from the final marker (header restamped to the current pass), and an
+entry with the same `file` basename REPLACES the old one instead of duplicating it. So a
+re-reduce refreshes byte sizes for everything it touches while entries it does not touch
+survive — the VPS status collector byte-compares marker entries against the archive store, and
+a stale size would flip an actually-complete run back to "reduce-pending" (bit the
+rest_departure_bridge_refix re-reduce, 2026-08-30).
 """
 function record_reduction!(dir::AbstractString, run_id, file::AbstractString)
     path = joinpath(dir, "$(run_id).reduced.partial")
-    m = isfile(path) ? TOML.parsefile(path) : Dict{String, Any}(
-        "run_id" => string(run_id),
-        "reduced_at" => string(now()),
-        "host" => gethostname(),
-        "reduce_commit" => _script_repo_commit(),
-        "reduction" => Dict{String, Any}[],
-    )
+    final = joinpath(dir, "$(run_id).reduced")
+    m = if isfile(path)
+        TOML.parsefile(path)
+    elseif isfile(final)
+        # Re-reduce: seed from the finalized marker so untouched entries survive, but the
+        # header reflects THIS pass (a re-reduce is a new reduction event, new commit and all).
+        prev = TOML.parsefile(final)
+        prev["reduced_at"] = string(now())
+        prev["host"] = gethostname()
+        prev["reduce_commit"] = _script_repo_commit()
+        prev
+    else
+        Dict{String, Any}(
+            "run_id" => string(run_id),
+            "reduced_at" => string(now()),
+            "host" => gethostname(),
+            "reduce_commit" => _script_repo_commit(),
+            "reduction" => Dict{String, Any}[],
+        )
+    end
     full = isfile(file) ? file : joinpath(dir, file)
-    push!(m["reduction"], Dict{String, Any}("file" => basename(file), "bytes" => filesize(full)))
+    base = basename(file)
+    filter!(e -> e["file"] != base, m["reduction"])   # replace a re-reduced file, don't duplicate
+    push!(m["reduction"], Dict{String, Any}("file" => base, "bytes" => filesize(full)))
     open(io -> TOML.print(io, m; sorted = true), path, "w")
     return path
 end

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -513,3 +513,26 @@ end
     d = TOML.parsefile(joinpath(dir, only(filter(f -> startswith(f, "derived_"), readdir(dir)))))
     @test endswith(d["provenance"]["timestamp_utc"], "Z")
 end
+
+@testset "record_reduction! — re-reduce refreshes bytes, keeps untouched entries" begin
+    dir = mktempdir()
+    write(joinpath(dir, "maps.jls"), zeros(UInt8, 100))
+    write(joinpath(dir, "traces.jls"), zeros(UInt8, 50))
+
+    # first pass: two products staged, then finalized (run_cell.sh does mv .partial → .reduced)
+    partial = record_reduction!(dir, "rr", "maps.jls")
+    @test record_reduction!(dir, "rr", "traces.jls") == partial
+    final = joinpath(dir, "rr.reduced")
+    mv(partial, final)
+    @test length(TOML.parsefile(final)["reduction"]) == 2
+
+    # re-reduce: one product regrows on disk; only IT is re-recorded, then finalize again
+    write(joinpath(dir, "maps.jls"), zeros(UInt8, 300))
+    mv(record_reduction!(dir, "rr", "maps.jls"), final; force = true)
+    m = TOML.parsefile(final)
+    @test m["run_id"] == "rr"                                # header seeded from the final marker
+    @test length(m["reduction"]) == 2                        # replaced, not duplicated
+    bytes = Dict(e["file"] => e["bytes"] for e in m["reduction"])
+    @test bytes["maps.jls"] == 300                           # byte size refreshed (collector byte-compares)
+    @test bytes["traces.jls"] == 50                          # untouched entry survived the re-reduce
+end

--- a/orchestration/run_cell.sh
+++ b/orchestration/run_cell.sh
@@ -174,7 +174,7 @@ run_cell() {
     # shellcheck disable=SC2086
     ( cd "$REPO" && env ${PREENV[@]+"${PREENV[@]}"} ${BASE[@]+"${BASE[@]}"} $skip \
           ${SWEEP_NAME:+EDM_SWEEP="$SWEEP_NAME"} \
-          EDM_GPU_BACKEND="$BACKEND" EDM_CLOUD_PROVIDER="$PROVIDER" EDM_OUTDIR="$CAMP" EDM_RUN_TAG="$uuid" "$@" \
+          EDM_GPU_BACKEND="$BACKEND" EDM_CLOUD_PROVIDER="$PROVIDER" EDM_OUTDIR="$CAMP" EDM_RUN_TAG="$uuid" EDM_KEEP_CUBE="${KEEP_CUBE:-0}" "$@" \
           "${JL[@]}" --project=scripts "$SCRIPT" ) > "$log" 2>&1
     local rc=$?
     if [ "$rc" -eq 0 ]; then

--- a/scripts/inverse_thomson_scattering.jl
+++ b/scripts/inverse_thomson_scattering.jl
@@ -594,6 +594,10 @@ config = Dict{String, Any}(
 # dashboard axis representation (ε-driven pools sweep ε; γ-driven ladders never carry the key,
 # so their axis stays γ — the builder can't pick an axis a pool's runs lack).
 GAMMA_EPS === nothing || (config["gamma_eps"] = GAMMA_EPS)
+# Cube-retention policy attestation: stamped only on orchestrated runs (EDM_KEEP_CUBE from
+# run_cell), so a manual run never claims "discarded"; lets the dashboard status collector
+# tell discarded-by-policy from location-unknown.
+haskey(ENV, "EDM_KEEP_CUBE") && (config["keep_cube"] = ENV["EDM_KEEP_CUBE"] == "1")
 
 outputs = Dict{String, Any}(
     "datafile" => basename(datafile),

--- a/scripts/lpwa.jl
+++ b/scripts/lpwa.jl
@@ -265,6 +265,10 @@ config = Dict{String, Any}(
     "observable" => "field",
     "trajectory_source" => "lpwa_analytic",   # distinguishes from the ODE-solved field runs
 )
+# Cube-retention policy attestation: stamped only on orchestrated runs (EDM_KEEP_CUBE from
+# run_cell), so a manual run never claims "discarded"; lets the dashboard status collector
+# tell discarded-by-policy from location-unknown.
+haskey(ENV, "EDM_KEEP_CUBE") && (config["keep_cube"] = ENV["EDM_KEEP_CUBE"] == "1")
 
 # Beam/laser parameters → [laser]. The dashboard's PARAM_SPEC reads beam params
 # (wavelength, w0, p, m, pol, profile, …) from [laser]; emitting them here — instead of

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -312,6 +312,11 @@ resolved_spec = ThomsonScatteringSpec(;
     extra = Dict{String, Any}("Ny" => Ny, "observable" => "field"),
 )
 config = config_dict(resolved_spec)
+# Cube-retention policy attestation: stamped only on orchestrated runs (EDM_KEEP_CUBE from
+# run_cell), so a manual run never claims "discarded"; lets the dashboard status collector
+# tell discarded-by-policy from location-unknown. Not a spec field — retention is an ops
+# knob, not a replay input.
+haskey(ENV, "EDM_KEEP_CUBE") && (config["keep_cube"] = ENV["EDM_KEEP_CUBE"] == "1")
 
 outputs = Dict{String, Any}(
     "datafile" => basename(datafile),

--- a/scripts/thomson_scattering_A.jl
+++ b/scripts/thomson_scattering_A.jl
@@ -256,6 +256,10 @@ config = Dict{String, Any}(
     "sync_per_electron" => SYNC,       # replay input: run_spec_from_manifest reads this
     "observable" => "potential",       # 4-potential Aᵘ run (cf. "field" in thomson_scattering.jl)
 )
+# Cube-retention policy attestation: stamped only on orchestrated runs (EDM_KEEP_CUBE from
+# run_cell), so a manual run never claims "discarded"; lets the dashboard status collector
+# tell discarded-by-policy from location-unknown.
+haskey(ENV, "EDM_KEEP_CUBE") && (config["keep_cube"] = ENV["EDM_KEEP_CUBE"] == "1")
 
 outputs = Dict{String, Any}(
     "datafile" => basename(datafile),


### PR DESCRIPTION
Two ops/status fixes feeding the dashboard status collector.

## 1. `record_reduction!` — re-reduce refreshes the finalized marker

A re-reduce with `EDM_REDUCTION_MARKER=1` started a fresh `.reduced.partial` and blindly appended rows, so an existing finalized `<run_id>.reduced` marker was never refreshed: untouched entries were lost on finalize, and re-recorded files got duplicate rows with stale byte sizes. The VPS status collector byte-compares marker entries against the archive store, so stale sizes flipped actually-complete runs back to "reduce-pending" — this bit the rest_departure_bridge_refix campaign on 2026-08-30.

Now, when no `.partial` exists but a finalized marker does, the staging marker is **seeded from the final marker** (header restamped to the current pass), and an entry with the same `file` basename **replaces** the old one instead of duplicating it. Docstring documents the re-reduce semantics; a new testset covers the record → finalize → resize → re-record → re-finalize cycle.

## 2. KEEP_CUBE attestation in run manifests

The KEEP_CUBE knob lived only in the orchestration shell, so the dashboard couldn't tell "cube discarded by policy" from "cube location unknown". `orchestration/run_cell.sh` now passes `EDM_KEEP_CUBE="${KEEP_CUBE:-0}"` in the solver launch env, and all four solver scripts (`thomson_scattering.jl`, `thomson_scattering_A.jl`, `lpwa.jl`, `inverse_thomson_scattering.jl`) stamp `config["keep_cube"]` when the var is present. The stamp is deliberately orchestration-gated: a manual run carries no key rather than falsely claiming its cube was discarded.

## Dashboard-side counterpart

A sibling PR in EDM_results_dashboard adds the collector/frontend half: marker-stale tolerance, a "discarded" cube status, and timestamp sort.

## Notes

- Full RunManifests suite green locally (`julia --project=lib/RunManifests -e 'using Pkg; Pkg.test()'`), including the new `record_reduction!` testset.
- `scripts/inverse_thomson_scattering.jl` may trivially conflict with open PR #84 — both touch nearby config-block lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vfs1qQzKFyAcfKc2o3F9A6