### PR TITLE
Tier 0 of #86: screen geometry, observables carrier, spec fields, log-line order

### DIFF
--- a/lib/RunManifests/src/RunManifests.jl
+++ b/lib/RunManifests/src/RunManifests.jl
@@ -32,7 +32,7 @@ import Serialization
 
 export git_state, assert_committed, run_provenance, run_spec_from_manifest, expand_sweep
 export ThomsonScatteringSpec, load_spec, write_spec, spec_env, spec_from_manifest, config_dict
-export find_parent_manifest, find_parent_run, spp_from_manifest
+export find_parent_manifest, find_parent_run, spp_from_manifest, screen_halfwidth, window_start
 export write_derived, write_comparison, write_summary, write_run_manifest, write_solver_manifest, REQUIRED_CONFIG_KEYS
 export write_sweep_declaration, read_sweep_declarations
 export record_reduction!
@@ -303,6 +303,54 @@ function spp_from_manifest(manifest::AbstractDict; default = nothing)
     end
     default === nothing && error("samples_per_period not found in run manifest [config]/[setup]")
     return default
+end
+
+"""
+    screen_halfwidth(manifest) -> Float64
+
+The observer screen's half-width in the solver's raw length unit — what a deferred or
+recovery reduction must rebuild the pixel grid from. Reads `[setup].screen_hw` (recorded by
+every solver since the screen geometry moved into the manifest); older manifests resolve
+from the w₀-unit knob they do carry — `[config].screen_hw_w0` (inverse runs) or
+`[config].screen_halfw` (rest-electron runs from 2026-07-29) — times `[laser].w0`, and
+manifests that predate both knobs were all the historical ±25 w₀ full frame. Errors on a
+manifest that needs the knob fallback but records no `w0`.
+"""
+function screen_halfwidth(manifest::AbstractDict)
+    st = get(manifest, "setup", Dict{String, Any}())
+    haskey(st, "screen_hw") && return Float64(st["screen_hw"])
+    cfg = get(manifest, "config", Dict{String, Any}())
+    hw_w0 = get(cfg, "screen_hw_w0", get(cfg, "screen_halfw", 25.0))
+    w0 = get(get(manifest, "laser", Dict{String, Any}()), "w0", nothing)
+    w0 === nothing && error(
+        "screen_halfwidth: manifest records no [setup].screen_hw and no [laser].w0 to scale " *
+            "the screen_hw_w0/screen_halfw knob ($(hw_w0) w₀) by"
+    )
+    return Float64(hw_w0) * Float64(w0)
+end
+
+"""
+    window_start(manifest) -> Float64
+
+The observer-time window start x⁰_start (raw solver units) — `[setup].x0_start` when the
+run recorded it, else the corner-anchored `:full`-window formula every solver used before
+recording it: `c·τi + hypot(Z, screen_hw + Rmax)` with [`screen_halfwidth`](@ref) and the
+`[setup]` window/geometry values (`Z` may be signed; only its distance enters). A `:narrow`
+window without a recorded start cannot be reconstructed and errors.
+"""
+function window_start(manifest::AbstractDict)
+    st = get(manifest, "setup", Dict{String, Any}())
+    haskey(st, "x0_start") && return Float64(st["x0_start"])
+    win = string(get(get(manifest, "config", Dict{String, Any}()), "window", "full"))
+    win == "full" || error(
+        "window_start: a :$win observer window records its start in [setup].x0_start; " *
+            "this manifest has none and the corner-anchor reconstruction only holds for :full"
+    )
+    for k in ("τi", "Z", "Rmax")
+        haskey(st, k) || error("window_start: [setup] is missing $(repr(k))")
+    end
+    return C_HARTREE * Float64(st["τi"]) +
+        hypot(abs(Float64(st["Z"])), screen_halfwidth(manifest) + Float64(st["Rmax"]))
 end
 
 """

--- a/lib/RunManifests/src/spec.jl
+++ b/lib/RunManifests/src/spec.jl
@@ -44,6 +44,8 @@ Base.@kwdef struct ThomsonScatteringSpec
     bunch_nb::Union{Nothing, Int} = nothing
     bunch_l::Union{Nothing, Int} = nothing
     bunch_chirp::Union{Nothing, Float64} = nothing
+    screen_zsign::Union{Nothing, Int} = nothing         # 1 (+Z, backscatter side) | -1 (−Z, transmission side)
+    apodization::Union{Nothing, String} = nothing       # hann | none — the harmonic-map reduction taper
     extra::Dict{String, Any} = Dict{String, Any}()
 end
 
@@ -64,6 +66,7 @@ const _SPEC_ENV = (
     (:window_lead, "EDM_WINDOW_LEAD"), (:window_tail, "EDM_WINDOW_TAIL"),
     (:harmonics, "EDM_HARMONICS"), (:bunch_nb, "EDM_BUNCH_NB"),
     (:bunch_l, "EDM_BUNCH_L"), (:bunch_chirp, "EDM_BUNCH_CHIRP"),
+    (:screen_zsign, "EDM_SCREEN_ZSIGN"), (:apodization, "EDM_APODIZATION"),
 )
 
 const _ALG_TO_ENV = Dict("GPUKernelRK4" => "rk4", "GPUKernelNewton" => "newton")

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -289,6 +289,20 @@ end
     @test env2["EDM_GAMMA_EPS"] == "0.001" && !haskey(env2, "EDM_GAMMA")
     @test env2["EDM_SYSTEM"] == "ll" && env2["EDM_OMEGA_SCALE"] == "19.9"
     @test env2["EDM_FIELD_MODE"] == "split"                    # pre-mode default preserved
+    # screen_zsign / apodization: [config] keys the inverse script writes — typed fields, so a
+    # replay no longer silently reruns the script defaults for a −Z screen or a bare-FFT reduce.
+    cfg3 = Dict{String, Any}(k => 1 for k in REQUIRED_CONFIG_KEYS)
+    cfg3["screen_zsign"] = -1
+    cfg3["apodization"] = "none"
+    path3 = write_solver_manifest(dir; run_id = "sp3", provenance = prov, config = cfg3,
+        laser = Dict(), setup = Dict(), outputs = Dict("plots" => String[]))
+    s4 = spec_from_manifest(TOML.parsefile(path3))
+    @test s4.screen_zsign === -1 && s4.apodization == "none" && isempty(s4.extra)
+    env3 = run_spec_from_manifest(TOML.parsefile(path3)).env
+    @test env3["EDM_SCREEN_ZSIGN"] == "-1" && env3["EDM_APODIZATION"] == "none"
+    @test !haskey(env2, "EDM_SCREEN_ZSIGN") && !haskey(env2, "EDM_APODIZATION")   # absent stays absent
+    s5 = load_spec(nothing; env = Dict("EDM_SCREEN_ZSIGN" => "-1", "EDM_APODIZATION" => "none"))
+    @test s5.screen_zsign === -1 && s5.apodization == "none"
     # missing required keys fail loudly, not with a KeyError deep in emission
     @test_throws ErrorException run_spec_from_manifest(Dict{String, Any}(
         "schema_version" => 1, "config" => Dict{String, Any}("a0" => 1)))

--- a/lib/RunManifests/test/runtests.jl
+++ b/lib/RunManifests/test/runtests.jl
@@ -317,6 +317,37 @@ end
     @test_throws ErrorException expand_sweep(ThomsonScatteringSpec(), Dict("nope" => [1]))
 end
 
+@testset "screen_halfwidth / window_start — recorded, knob-derived, legacy" begin
+    c = 137.03599908330932
+    w0 = 75 * 2π * c / 0.057
+    base = Dict{String, Any}(
+        "laser" => Dict{String, Any}("w0" => w0),
+        "setup" => Dict{String, Any}("τi" => -8 * 150 / 0.057, "Z" => 2.0e5 * 2π * c / 0.057, "Rmax" => 3.25w0),
+        "config" => Dict{String, Any}(),
+    )
+    corner(hw) = c * base["setup"]["τi"] + hypot(base["setup"]["Z"], hw + base["setup"]["Rmax"])
+    # Pre-knob manifest: the historical ±25 w₀ frame and its corner-anchored window start.
+    @test screen_halfwidth(base) ≈ 25w0
+    @test window_start(base) ≈ corner(25w0)
+    # Rest-electron knob (thomson_scattering.jl, 2026-07-29…): [config].screen_halfw in w₀ units.
+    mt = deepcopy(base); mt["config"]["screen_halfw"] = 8
+    @test screen_halfwidth(mt) ≈ 8w0
+    @test window_start(mt) ≈ corner(8w0)          # the grid AND the window follow the zoom
+    # Inverse knob: [config].screen_hw_w0, and [setup].screen_hw / x0_start recorded — the
+    # recorded values win over every reconstruction, and a signed Z only enters as a distance.
+    mi = deepcopy(base); mi["config"]["screen_hw_w0"] = 5
+    @test screen_halfwidth(mi) ≈ 5w0
+    mi["setup"]["screen_hw"] = 4.5w0; mi["setup"]["x0_start"] = 123.0; mi["setup"]["Z"] = -mi["setup"]["Z"]
+    @test screen_halfwidth(mi) == 4.5w0 && window_start(mi) == 123.0
+    delete!(mi["setup"], "x0_start")
+    @test window_start(mi) ≈ corner(4.5w0)        # |Z| in the corner anchor
+    # A :narrow window without a recorded start cannot be reconstructed.
+    mn = deepcopy(base); mn["config"]["window"] = "narrow"
+    @test_throws ErrorException window_start(mn)
+    # The knob fallback needs w0 to scale by.
+    @test_throws ErrorException screen_halfwidth(Dict{String, Any}("config" => Dict{String, Any}("screen_halfw" => 8)))
+end
+
 @testset "sweep declarations — write/read + membership stamp" begin
     dir = mktempdir()
     p = write_sweep_declaration(dir; name = "ll_gamma_ladder",

--- a/orchestration/campaigns/rest_departure_linemaps_fix2.sh
+++ b/orchestration/campaigns/rest_departure_linemaps_fix2.sh
@@ -1,0 +1,33 @@
+# campaigns/rest_departure_linemaps_fix2.sh — second single-cell re-acquisition for
+# rest_departure_linemaps (the e1em1 rung); recipe header copied from the parent campaign:
+#
+# Line-anchored harmonic maps for the ε ladder.
+# The rest_departure runs mapped integer laser harmonics (the :full default 1..4 ω₁), but the
+# boosted backscatter line sits BETWEEN them — up to 32% off the nearest bin (wing maps, not
+# line maps). Reruns of the 8 off-line rungs with fractional EDM_HARMONICS at BOTH anchors:
+#   n_th  = (1+β)/(1−β)          the "4γ²" theory line
+#   n_ps  = the measured powspec peak from the original run (2026-07-30 gates; both carry the
+#           common −0.8% window systematic, ~3 rfft bins apart at Ns/SPP = 375)
+# plus h1 for continuity with the original chips. NEW campaign name: same-ε duplicates inside
+# rest_departure would break the one-axis sweep (harmonics not γ-locked across the pair).
+# KEEP_CUBE=1 + auto-drain (policy from tonight: cubes you might re-mine go to R2 — future
+# re-extraction at any frequency becomes CPU-only instead of a GPU rerun).
+CAMPAIGN=rest_departure_linemaps
+SCRIPT=scripts/inverse_thomson_scattering.jl
+KEEP_CUBE=1
+BASE=(
+  EDM_NX=601 EDM_NSAMPLES=6000 EDM_SPP=16 EDM_FIELD_MODE=total
+  EDM_N=2000 EDM_NSUBSTEPS=1 EDM_RELTOL=1e-12 EDM_ABSTOL=1.7e-9
+  EDM_A0=0.3
+  EDM_INTERP_SAVEAT=16
+  EDM_INITIAL_PHASE=-1.5707963267948966
+  EDM_TSPAN_TAU=8 EDM_WINDOW=full
+  EDM_SCREEN_HW=25
+  EDM_DIRECT_READ=1
+)
+# FIX RERUN: cell 1 of the original launch serialized into the drain backlog's disk crunch
+# (ENOSPC mid-write; the disk gate protected every later cell). Same campaign name appends
+# the rung to the same runs dir/union.
+CELLS=(
+  "e1em1_lm|EDM_GAMMA_EPS=1e-1 EDM_HARMONICS=1,2.4282,2.408"
+)

--- a/scripts/harmonic_products.jl
+++ b/scripts/harmonic_products.jl
@@ -461,9 +461,11 @@ function recover_from_manifest(toml)
         λ = las["wavelength"]
         ω = C_LIGHT * 2π / λ
         δt = 2π / ω / spp_from_manifest(m)
-        # Screen half-width from [setup] when the run recorded it (EDM_SCREEN_HW runs);
-        # legacy runs predate the knob and were all ±25w₀.
-        hw = get(get(m, "setup", Dict()), "screen_hw", 25las["w0"])
+        # Screen half-width: [setup].screen_hw when recorded, else the w₀-unit knob the run
+        # carries ([config].screen_hw_w0 / screen_halfw), else the historical ±25 w₀ frame —
+        # one resolver (RunManifests.screen_halfwidth) so a zoomed rest-electron run can no
+        # longer be re-reduced on the wrong grid.
+        hw = screen_halfwidth(m)
         x_grid = LinRange(-hw, hw, cfg["Nx"])
         y_grid = LinRange(-hw, hw, cfg["Ny"])
         println("loading $(m["outputs"]["datafile"]) …")

--- a/scripts/lpwa.jl
+++ b/scripts/lpwa.jl
@@ -24,6 +24,9 @@ const SPP = parse(Int, get(ENV, "EDM_SPP", "16"))
 const NSUBSTEPS = parse(Int, get(ENV, "EDM_NSUBSTEPS", "1"))
 const A0 = parse(Float64, get(ENV, "EDM_A0", "0.1"))
 const SYNC = parse(Bool, get(ENV, "EDM_SYNC_PER_ELECTRON", "false"))
+const SCREEN_HW = parse(Float64, get(ENV, "EDM_SCREEN_HW", "25"))   # screen half-width in w₀ — the same knob and
+#   [config].screen_hw_w0 key as inverse_thomson_scattering.jl (25 = the historical full frame); the
+#   thomson_scattering.jl spelling is EDM_SCREEN_HALFW / screen_halfw
 const FIELD_MODE = Symbol(get(ENV, "EDM_FIELD_MODE", "split"))   # :split → (E,B,E_far,B_far) | :total → (E,B) only (halves VRAM/output)
 FIELD_MODE in (:split, :total) || error("EDM_FIELD_MODE must be \"split\" or \"total\", got \"$FIELD_MODE\"")
 const SKIP_POST = get(ENV, "EDM_SKIP_POSTPROCESS", "0") == "1"   # field-only: serialize cube + manifest, defer the (CPU/IO) reduction to an async step
@@ -179,7 +182,8 @@ const Z = 2.0e5λ
 const samples_per_period = SPP
 const δt = 2π / ω / samples_per_period
 const N_samples = NSAMPLES
-const x⁰_start = c * τi + hypot(Z, 25w₀ + Rmax)
+const screen_hw = SCREEN_HW * w₀
+const x⁰_start = c * τi + hypot(Z, screen_hw + Rmax)
 
 Nx = NX
 Ny = NX
@@ -187,8 +191,8 @@ Ny = NX
 x⁰_samples = range(start = x⁰_start, step = c * δt, length = N_samples)
 
 screen = ObserverScreen(
-    LinRange(-25w₀, 25w₀, Nx),
-    LinRange(-25w₀, 25w₀, Ny),
+    LinRange(-screen_hw, screen_hw, Nx),
+    LinRange(-screen_hw, screen_hw, Ny),
     Z,
     x⁰_samples;
     c,
@@ -264,6 +268,7 @@ config = Dict{String, Any}(
     "mode" => string(FIELD_MODE),
     "observable" => "field",
     "trajectory_source" => "lpwa_analytic",   # distinguishes from the ODE-solved field runs
+    "screen_hw_w0" => SCREEN_HW,              # EDM_SCREEN_HW knob (w₀ units; [setup].screen_hw is the derived a.u. value)
 )
 # Cube-retention policy attestation: stamped only on orchestrated runs (EDM_KEEP_CUBE from
 # run_cell), so a manual run never claims "discarded"; lets the dashboard status collector
@@ -300,7 +305,11 @@ setup = Dict{String, Any}(
     "τf" => τf,
     "Rmax" => Rmax,
     "Z" => Z,
-)   # input knobs (Nx/Ny/N/N_samples/spp) live in [config]; setup is just the integration window + screen depth
+    # Screen geometry the deferred reducers rebuild the grid/window from (RunManifests.screen_halfwidth /
+    # window_start); a.u. like every other [setup] value.
+    "screen_hw" => screen_hw,
+    "x0_start" => x⁰_start,
+)   # input knobs (Nx/Ny/N/N_samples/spp) live in [config]; setup is the integration window + screen geometry
 
 outputs = Dict{String, Any}(
     "datafile" => basename(datafile),

--- a/scripts/plot_pixel_traces.jl
+++ b/scripts/plot_pixel_traces.jl
@@ -29,6 +29,7 @@ using Printf
 using CairoMakie
 using Serialization
 using TOML
+using RunManifests   # screen_halfwidth, window_start — the run's screen geometry from its manifest
 
 const c = 137.03599908330932   # speed of light, atomic units (repo convention)
 
@@ -57,15 +58,14 @@ Rmax = Float64(setup["Rmax"])
 Z = Float64(setup["Z"])
 N_samples = Int(cfg["N_samples"])
 spp = Int(cfg["samples_per_period"])
-# Mini-screen half-width = the RUN's screen. Current manifests record the zoom knob as
-# [setup].screen_hw (absolute) / [config].screen_hw_w0; the old cfg.screen_halfw key missed
-# them, so zoomed-screen runs (hw < 25 w₀) fell back to the 25 w₀ production framing and the
-# outer trace rows sampled pixels OFF the cube's screen — beyond the narrow window's corner
-# budget, so their bursts overran the window end and the chips showed a spurious end-of-pulse
-# cutoff (bridge-refix γ=2/2.5, 2026-08-30). The real screen corner is contained by
-# construction (tail margin intact), so on-screen rows never clip.
-HALFW = "screen_hw" in keys(setup) ? Float64(setup["screen_hw"]) / w₀ :
-    Float64(get(cfg, "screen_hw_w0", get(cfg, "screen_halfw", 25.0)))
+# Mini-screen half-width = the RUN's screen, resolved by RunManifests.screen_halfwidth
+# ([setup].screen_hw, else the run's w₀-unit knob, else the historical 25 w₀ frame). Reading
+# only cfg.screen_halfw once put zoomed-screen runs (hw < 25 w₀) on the 25 w₀ production
+# framing, so the outer trace rows sampled pixels OFF the cube's screen — beyond the narrow
+# window's corner budget — and the chips showed a spurious end-of-pulse cutoff (bridge-refix
+# γ=2/2.5, 2026-08-30). The real screen corner is contained by construction (tail margin
+# intact), so on-screen rows never clip.
+HALFW = screen_halfwidth(m) / w₀
 reltol = Float64(get(cfg, "reltol", 1.0e-12))
 abstol = Float64(cfg["abstol"])
 interp_saveat = string(get(cfg, "interp_saveat", "adaptive"))
@@ -151,14 +151,10 @@ traj_of = Dict(zip(solve_idx, trajs))
 
 # ── Mini-screen: the requested pixels along +x (center first), production time window ──
 xs = [f * HALFW * w₀ for f in RADII]
-# Prefer the RECORDED window start (setup.x0_start, present on current manifests): exact for
-# both :full and :narrow (burst-centred) windows — the corner-anchor formula is the pre-knob
-# reconstruction fallback and is wrong for narrow runs.
-x⁰_samples = range(
-    start = haskey(m["setup"], "x0_start") ? Float64(m["setup"]["x0_start"]) :
-        c * τi + hypot(Z, HALFW * w₀ + Rmax), step = c * (2π / ω / spp),
-    length = N_samples,
-)
+# The RECORDED window start ([setup].x0_start, present on current manifests) is exact for
+# both :full and :narrow (burst-centred) windows; RunManifests.window_start falls back to the
+# corner-anchor formula only for pre-knob :full runs (and refuses a narrow run without it).
+x⁰_samples = range(start = window_start(m), step = c * (2π / ω / spp), length = N_samples)
 screen = ObserverScreen(xs, [0.0], Z, x⁰_samples; c)   # Ny = 1: one y = 0 row of pixels
 
 # Retarded-time ODE tolerances (CPU reference path; the trajectories carry the production spline).

--- a/scripts/plot_screen_observables.jl
+++ b/scripts/plot_screen_observables.jl
@@ -18,16 +18,8 @@ using Printf
 using CairoMakie
 include(joinpath(@__DIR__, "plot_theme.jl"))   # LaTeX (Computer Modern) fonts
 
-# Thomson screen constants (identical to scripts/thomson_scattering.jl).
-const c = 137.03599908330932
-const ω = 0.057
-const λ = 2π * c / ω
-const w₀ = 75λ
-const Rmax = 3.25w₀
-const Z = 2.0e5λ
-const τ = 150 / ω
-const τi = -8τ
-const ε₀ = 1 / (4π)          # atomic units (4πε₀ = 1); map structure is ε₀-independent
+const c = 137.03599908330932   # speed of light, atomic units (repo convention)
+const ε₀ = 1 / (4π)             # atomic units (4πε₀ = 1); map structure is ε₀-independent
 
 const datafile = length(ARGS) ≥ 1 ? ARGS[1] : error("pass the field .jls as ARG 1")
 const stem = replace(datafile, r"\.jls$" => "")
@@ -35,17 +27,22 @@ const stem = replace(datafile, r"\.jls$" => "")
 include(joinpath(@__DIR__, "manifest.jl"))
 const dir = dirname(abspath(datafile))
 const parent = find_parent_manifest(dir, basename(datafile))
-parent === nothing && error("no run_*.toml in $dir binds $(basename(datafile)) — needed for samples_per_period")
-const spp = spp_from_manifest(parent[2])
-# Screen geometry from the run's [setup] when recorded (EDM_SCREEN_HW / windowed runs, e.g.
-# inverse_thomson_scattering.jl); legacy fallbacks reproduce the historical ±25w₀ full window.
-const setup_sec = get(parent[2], "setup", Dict{String, Any}())
-const screen_hw = get(setup_sec, "screen_hw", 25w₀)
-const x⁰_start_rec = get(setup_sec, "x0_start", nothing)
+parent === nothing && error("no run_*.toml in $dir binds $(basename(datafile)) — needed for the screen geometry")
+const mf = parent[2]
+const spp = spp_from_manifest(mf)
+# Carrier + screen geometry from the run's MANIFEST, never the lab-frame production constants:
+# Doppler-equivalent runs (omega_scale ≠ 1) carry a scaled wavelength in [laser] (the cube's
+# δt = T/spp is the scaled period), zoomed screens a smaller half-width, inverse runs a signed
+# Z (−Z = transmission side) and a burst-centred window start. screen_halfwidth/window_start
+# resolve [setup].screen_hw / x0_start with the pre-knob fallbacks (±25 w₀, corner anchor).
+const ω = 2π * c / Float64(mf["laser"]["wavelength"])
+const w₀ = Float64(mf["laser"]["w0"])
+const Z = Float64(mf["setup"]["Z"])
+const screen_hw = screen_halfwidth(mf)
+const x⁰_start = window_start(mf)
 
 function thomson_screen(Nx, N_samples)
     δt = 2π / ω / spp
-    x⁰_start = x⁰_start_rec === nothing ? c * τi + hypot(Z, screen_hw + Rmax) : x⁰_start_rec
     x⁰ = range(start = x⁰_start, step = c * δt, length = N_samples)
     return ObserverScreen(LinRange(-screen_hw, screen_hw, Nx), LinRange(-screen_hw, screen_hw, Nx), Z, x⁰; c)
 end
@@ -57,9 +54,25 @@ end
 # skip BOTH the 86 GB .jls reload and the (minutes-long) screen_observables recompute
 # when re-plotting. Bump OBS_CACHE_VERSION whenever the reduced schema/math changes,
 # so an older cache is detected as stale and recomputed.
-const OBS_CACHE_VERSION = 3   # v3: screen geometry (screen_hw / x0_start) now read from the manifest
+const OBS_CACHE_VERSION = 4   # v4: carrier + screen geometry from the manifest for EVERY run family, and
+#   recorded in the cache. v3 read [setup].screen_hw / x0_start but kept the lab-frame ω=0.057 and
+#   the ±25 w₀ corner anchor as fallbacks — right for inverse runs and pre-knob rest-electron runs,
+#   wrong for zoomed (screen_halfw ≠ 25) or ω-scaled rest-electron runs.
 const cachefile = stem * "_obscache.jls"
 const recompute = ("--recompute" in ARGS) || get(ENV, "EDM_OBS_RECOMPUTE", "0") == "1"
+
+# Is an existing cache exact for THIS run's geometry? v4 caches carry the geometry they were
+# reduced with; a v3 cache is kept when v3's assumptions held for the run (lab carrier, and
+# either a recorded [setup].screen_hw or the ±25 w₀ frame), so only caches built under the
+# wrong assumptions pay the cube reload.
+function cache_valid(cc)
+    haskey(cc, :version) || return false
+    cc.version == OBS_CACHE_VERSION &&
+        return isapprox(cc.omega, ω) && isapprox(cc.screen_hw, screen_hw) && isapprox(cc.x0_start, x⁰_start)
+    cc.version == 3 || return false
+    st = get(mf, "setup", Dict{String, Any}())
+    return isapprox(ω, 0.057) && (haskey(st, "screen_hw") || isapprox(screen_hw, 25w₀))
+end
 
 # Collapse one screen_observables result to the plot-ready quantities (per field).
 reduce_field(o, kp, dt, dA) = (;
@@ -100,6 +113,7 @@ function build_cache()
         total = reduce_field(ot, kp, dt, dA),
         far = has_far ? reduce_field(ofar, kp, dt, dA) : nothing,
         k_peak = kp, slot_energy = se, Nx = nx, Ny = ny, N_samples = Ns,
+        omega = ω, screen_hw = screen_hw, x0_start = x⁰_start,   # the geometry these reductions used
     )
 end
 
@@ -116,9 +130,10 @@ function load_or_build()
         cc = build_and_save()
     else
         cc = deserialize(cachefile)
-        if haskey(cc, :version) && cc.version == OBS_CACHE_VERSION
+        if cache_valid(cc)
             return cc
         else
+            println("obscache $(basename(cachefile)) predates the manifest-driven geometry — rebuilding from the cube")
             cc = build_and_save()
         end
     end

--- a/scripts/thomson_scattering.jl
+++ b/scripts/thomson_scattering.jl
@@ -7,7 +7,7 @@
 # ENV knobs (defaults = full production): EDM_GPU_BACKEND (rocm|cuda), EDM_A0,
 # EDM_INITIAL_PHASE, EDM_NX, EDM_N, EDM_NSAMPLES, EDM_SPP, EDM_NSUBSTEPS,
 # EDM_OMEGA_SCALE (Doppler-equivalent ω upshift) + EDM_SCREEN_HALFW (screen half-extent, w₀ units),
-# EDM_GPU_SOLVER (rk4|newton) + EDM_NEWTON_ITERS,
+# EDM_ACCUM_ALG (rk4|newton) + EDM_NEWTON_ITERS,
 # EDM_POL (linear|circular[_plus]|circular_minus),
 # EDM_SYNC_PER_ELECTRON, EDM_OUTDIR. Writes the field .jls + per-harmonic PNGs +
 # run_<uuid>.toml manifest.
@@ -83,16 +83,24 @@ const FIELD_MODE = Symbol(something(SPEC.mode, "split"))   # :split → (E,B,E_f
 FIELD_MODE in (:split, :total) || error("spec mode must be \"split\" or \"total\", got \"$FIELD_MODE\"")
 const SKIP_POST = get(ENV, "EDM_SKIP_POSTPROCESS", "0") == "1"   # field-only: serialize cube + manifest, defer the (CPU/IO) reduction to an async step
 const RUN_TAG = get(ENV, "EDM_RUN_TAG", string(uuid4()))   # launcher may pin via EDM_RUN_TAG so .jls/log/manifest share one id
-mkpath(OUTDIR)
-@info "Thomson (field) run config" RUN_TAG GPU_BACKEND GPU_SOLVER ϕ₀ A0 SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS NEWTON_ITERS OMEGA_SCALE HALFW
-const T_START = time()   # wall-clock start → [timing].total in the manifest
-
-# Laser parameters
 # EDM_OMEGA_SCALE: Doppler-equivalent runs — upshift ω by γ(1+β) = γ+√(γ²−1), the frequency a
 # counter-propagating electron of that γ sees. The pulse keeps its cycle count (τ·ω = 150, phase
 # is boost-invariant) while the transverse/detector geometry stays pinned to the lab λ₀ = 2πc/0.057
 # layout (transverse lengths are boost-invariant). 1.0 ⇒ byte-identical to the production setup.
 const OMEGA_SCALE = something(SPEC.omega_scale, 1.0)
+# EDM_SCREEN_HALFW: screen half-extent in w₀ units (default 25 = production). Do NOT zoom
+# scaled-ω cells ∝ 1/OMEGA_SCALE: with the geometry pinned, the source Fraunhofer distance
+# a²/λ′ grows with the scale (≳Z beyond γ≈2), the screen enters the Fresnel zone, and the
+# pattern shrinks slower than 1/scale. Zoom only when the sampling window demands it — the
+# corner-anchored x⁰_start sits ~11λ_lab after the center-pixel arrival, so once that spread
+# (in scaled periods, ∝scale) exceeds the 8τ pulse half-span (γ≳10 at full frame) the window
+# would open after the peak passed the central pixels; ±8 w₀ suffices at γ=10 (gamma_equiv).
+const HALFW = something(SPEC.screen_halfw, 25.0)
+mkpath(OUTDIR)
+@info "Thomson (field) run config" RUN_TAG GPU_BACKEND GPU_SOLVER ϕ₀ A0 SYNC FIELD_MODE OUTDIR NX NELEC NSAMPLES SPP NSUBSTEPS NEWTON_ITERS OMEGA_SCALE HALFW
+const T_START = time()   # wall-clock start → [timing].total in the manifest
+
+# Laser parameters
 const ω₀_lab = 0.057
 ω = ω₀_lab * OMEGA_SCALE
 τ = 150 / ω
@@ -201,15 +209,7 @@ t_trajectories = @elapsed solution = solve(
 # Radiation computation
 trajs = trajectory_interpolants(solution)
 
-# Screen parameters
-# EDM_SCREEN_HALFW: screen half-extent in w₀ units (default 25 = production). Do NOT zoom
-# scaled-ω cells ∝ 1/OMEGA_SCALE: with the geometry pinned, the source Fraunhofer distance
-# a²/λ′ grows with the scale (≳Z beyond γ≈2), the screen enters the Fresnel zone, and the
-# pattern shrinks slower than 1/scale. Zoom only when the sampling window demands it — the
-# corner-anchored x⁰_start sits ~11λ_lab after the center-pixel arrival, so once that spread
-# (in scaled periods, ∝scale) exceeds the 8τ pulse half-span (γ≳10 at full frame) the window
-# would open after the peak passed the central pixels; ±8 w₀ suffices at γ=10 (gamma_equiv).
-const HALFW = something(SPEC.screen_halfw, 25.0)
+# Screen parameters (HALFW = the EDM_SCREEN_HALFW knob, resolved with the spec above)
 const Z = 2.0e5λ_lab
 const samples_per_period = SPP
 const δt = 2π / ω / samples_per_period
@@ -345,7 +345,12 @@ setup = Dict{String, Any}(
     "τf" => τf,
     "Rmax" => Rmax,
     "Z" => Z,
-)   # input knobs (Nx/Ny/N/N_samples/spp) live in [config]; setup is just the integration window + screen depth
+    # Screen geometry the deferred reducers rebuild the grid/window from (harmonic_products.jl,
+    # plot_screen_observables.jl read [setup].screen_hw / x0_start via RunManifests.screen_halfwidth /
+    # window_start). Recorded in a.u. like every other [setup] value; [config].screen_halfw is the knob.
+    "screen_hw" => HALFW * w₀,
+    "x0_start" => x⁰_start,
+)   # input knobs (Nx/Ny/N/N_samples/spp) live in [config]; setup is the integration window + screen geometry
 
 # Wall-clock phase timings → [timing] (dashboard renders total/trajectories/field, in seconds).
 timing = Dict{String, Any}(


### PR DESCRIPTION
Tier 0 of #86: the bugs the post-RunSpec audit found, each its own commit.

- **spec: typed `screen_zsign` + `apodization` fields.** The inverse script records both in `[config]` but the spec had no field, so `run_spec_from_manifest` replay silently reran the script defaults for a −Z screen or a bare-FFT reduce — the silent context loss #76 was meant to close.
- **Record the screen geometry in every solver manifest and resolve it in one place.** `thomson_scattering.jl` / `lpwa.jl` never wrote `[setup].screen_hw` / `x0_start`; the deferred reducers fell back to ±25 w₀, so an overlapped or archive re-reduce of a zoomed rest-electron run rebuilt the wrong grid and window. New `RunManifests.screen_halfwidth` / `window_start` (recorded → the run's w₀-unit knob → legacy frame) used by `harmonic_products.jl` and `plot_pixel_traces.jl`; existing manifests with `screen_halfw` resolve correctly with no data migration. `lpwa.jl` now honours `EDM_SCREEN_HW` (a sanity recipe sets it; it was ignored) and records `screen_hw_w0`. Also fixes the thomson config `@info` line that referenced `OMEGA_SCALE`/`HALFW` before their definition (every run logged an `UndefVarError` instead of its config).
- **campaigns: track `rest_departure_linemaps_fix2.sh`** — the only record of the e1em1 re-acquisition.
- **`plot_screen_observables.jl`: carrier + geometry from the manifest.** It hard-coded ω = 0.057, λ, w₀, Rmax, Z, τ — wrong for `omega_scale ≠ 1` runs. Obscache v4 records the geometry it used; v3 caches are kept where v3's assumptions held.

## Verification
- RunManifests suite: 147 asserts pass (9 new resolver tests, extended spec round-trip).
- Resolver on real manifests: zoomed rest-electron run → 8 w₀ (was 25 on the recovery path), inverse run → recorded values, pre-knob run → 25 w₀.
- Reducer change run old-vs-new on the same lab-frame cube (N=400, Nx=200, Ns=6000): every cached reduction, the three sidecars and the three PNGs bit-identical. The new script accepts an existing v3 cache without reloading the cube.

Not in this PR (tracked in #86): the default-kernel and screen-width-knob decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115QTEmc4AvGx24eTrHFB4i
